### PR TITLE
Feat/saved tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
           context: apps/ui
           file: apps/ui/Dockerfile
           push: true
+          # NEXT_PUBLIC_API_BASE is baked at build time — set via repo secret
+          build-args: |
+            NEXT_PUBLIC_API_BASE=${{ secrets.NEXT_PUBLIC_API_BASE }}
+            NEXT_PUBLIC_DEFAULT_ROLE=${{ secrets.NEXT_PUBLIC_DEFAULT_ROLE || 'viewer' }}
           tags: |
             ghcr.io/${{ github.repository }}-ui:latest
             ghcr.io/${{ github.repository }}-ui:${{ github.ref_name }}

--- a/apps/api/alembic/versions/0003_add_saved_tokens.py
+++ b/apps/api/alembic/versions/0003_add_saved_tokens.py
@@ -1,0 +1,42 @@
+"""add saved_tokens table
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-25
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "saved_tokens",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("org", sa.String, nullable=False, unique=True),
+        sa.Column("label", sa.String, nullable=True),
+        sa.Column("encrypted_token", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_saved_tokens_org", "saved_tokens", ["org"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_saved_tokens_org", table_name="saved_tokens")
+    op.drop_table("saved_tokens")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -47,6 +47,19 @@ class Job(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
 
+class SavedToken(Base):
+    __tablename__ = "saved_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    label: Mapped[str | None] = mapped_column(String, nullable=True)
+    encrypted_token: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 engine = create_engine(settings.database_url.get_secret_value())
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.core.config import settings
 from src.core.logging import setup_logging
 from src.core.middleware import RequestIdMiddleware
-from src.routers import actions_cache, analytics, audit, auth, health, jobs
+from src.routers import actions_cache, analytics, audit, auth, health, jobs, tokens
 
 
 @asynccontextmanager
@@ -37,3 +37,4 @@ app.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
 app.include_router(actions_cache.router, prefix="/repos", tags=["actions-cache"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
+app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from src.core._crypto import decrypt_job_token, encrypt_job_token
 from src.core.config import settings
 from src.core.db import SavedToken, get_db
+from src.services.rbac import require_role
 
 router = APIRouter()
 
@@ -45,8 +46,11 @@ class VerifyTokenResponse(BaseModel):
 # ── routes ─────────────────────────────────────────────────────────────────
 
 @router.get("", response_model=list[TokenMeta])
-def list_tokens(db: Session = Depends(get_db)) -> list[TokenMeta]:
-    """Return metadata for all saved tokens (never the raw token)."""
+def list_tokens(
+    db: Session = Depends(get_db),
+    _role: str = Depends(require_role("analyst")),
+) -> list[TokenMeta]:
+    """Return metadata for all saved tokens (never the raw token). Requires analyst+."""
     rows = db.query(SavedToken).order_by(SavedToken.org).all()
     return [TokenMeta.model_validate(r) for r in rows]
 
@@ -56,8 +60,9 @@ def upsert_token(
     org: str,
     body: UpsertTokenRequest,
     db: Session = Depends(get_db),
+    _role: str = Depends(require_role("admin")),
 ) -> TokenMeta:
-    """Save or update the token for an org (encrypted at rest)."""
+    """Save or update the token for an org (encrypted at rest). Requires admin."""
     encrypted = encrypt_job_token(
         body.token.get_secret_value(),
         settings.job_secret_key.get_secret_value(),
@@ -78,8 +83,9 @@ def upsert_token(
 def resolve_token(
     body: VerifyTokenRequest,
     db: Session = Depends(get_db),
+    _role: str = Depends(require_role("admin")),
 ) -> VerifyTokenResponse:
-    """Decrypt and return the saved token for an org so the UI can pre-fill fields."""
+    """Decrypt and return the saved token for an org. Admin-only — returns raw secret."""
     row = db.query(SavedToken).filter_by(org=body.org).first()
     if not row:
         raise HTTPException(status_code=404, detail="No saved token for this org")
@@ -91,8 +97,12 @@ def resolve_token(
 
 
 @router.delete("/{org}", status_code=204)
-def delete_token(org: str, db: Session = Depends(get_db)) -> None:
-    """Remove a saved token."""
+def delete_token(
+    org: str,
+    db: Session = Depends(get_db),
+    _role: str = Depends(require_role("admin")),
+) -> None:
+    """Remove a saved token. Requires admin."""
     row = db.query(SavedToken).filter_by(org=org).first()
     if not row:
         raise HTTPException(status_code=404, detail="No saved token for this org")

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -1,0 +1,100 @@
+"""
+Saved-token CRUD.
+
+Tokens are Fernet-encrypted at rest using JOB_SECRET_KEY (same key as jobs).
+The GET /tokens endpoint intentionally never returns raw tokens — only metadata
+(org name, label, created_at). The UI uses PUT to upsert and DELETE to remove.
+"""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, SecretStr
+from sqlalchemy.orm import Session
+
+from src.core._crypto import decrypt_job_token, encrypt_job_token
+from src.core.config import settings
+from src.core.db import SavedToken, get_db
+
+router = APIRouter()
+
+
+# ── schemas ────────────────────────────────────────────────────────────────
+
+class TokenMeta(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    org: str
+    label: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class UpsertTokenRequest(BaseModel):
+    token: SecretStr
+    label: str | None = None
+
+
+class VerifyTokenRequest(BaseModel):
+    org: str
+
+
+class VerifyTokenResponse(BaseModel):
+    token: str
+
+
+# ── routes ─────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=list[TokenMeta])
+def list_tokens(db: Session = Depends(get_db)) -> list[TokenMeta]:
+    """Return metadata for all saved tokens (never the raw token)."""
+    rows = db.query(SavedToken).order_by(SavedToken.org).all()
+    return [TokenMeta.model_validate(r) for r in rows]
+
+
+@router.put("/{org}", response_model=TokenMeta)
+def upsert_token(
+    org: str,
+    body: UpsertTokenRequest,
+    db: Session = Depends(get_db),
+) -> TokenMeta:
+    """Save or update the token for an org (encrypted at rest)."""
+    encrypted = encrypt_job_token(
+        body.token.get_secret_value(),
+        settings.job_secret_key.get_secret_value(),
+    )
+    row = db.query(SavedToken).filter_by(org=org).first()
+    if row:
+        row.encrypted_token = encrypted
+        row.label = body.label
+    else:
+        row = SavedToken(org=org, label=body.label, encrypted_token=encrypted)
+        db.add(row)
+    db.commit()
+    db.refresh(row)
+    return TokenMeta.model_validate(row)
+
+
+@router.post("/resolve", response_model=VerifyTokenResponse)
+def resolve_token(
+    body: VerifyTokenRequest,
+    db: Session = Depends(get_db),
+) -> VerifyTokenResponse:
+    """Decrypt and return the saved token for an org so the UI can pre-fill fields."""
+    row = db.query(SavedToken).filter_by(org=body.org).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="No saved token for this org")
+    raw = decrypt_job_token(
+        row.encrypted_token,
+        settings.job_secret_key.get_secret_value(),
+    )
+    return VerifyTokenResponse(token=raw)
+
+
+@router.delete("/{org}", status_code=204)
+def delete_token(org: str, db: Session = Depends(get_db)) -> None:
+    """Remove a saved token."""
+    row = db.query(SavedToken).filter_by(org=org).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="No saved token for this org")
+    db.delete(row)
+    db.commit()

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -1,13 +1,27 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
+
 COPY package.json package-lock.json ./
 RUN npm ci
+
 COPY . .
+
+# NEXT_PUBLIC_* vars are baked at build time — must be passed as build args
+ARG NEXT_PUBLIC_API_BASE
+ARG NEXT_PUBLIC_DEFAULT_ROLE=viewer
+ENV NEXT_PUBLIC_API_BASE=$NEXT_PUBLIC_API_BASE
+ENV NEXT_PUBLIC_DEFAULT_ROLE=$NEXT_PUBLIC_DEFAULT_ROLE
+
 RUN npm run build
 
+# ── runner ────────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
-COPY --from=builder /app/.next/standalone/app ./
-COPY --from=builder /app/.next/static ./.next/static
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static     ./.next/static
+COPY --from=builder /app/public           ./public
+
+EXPOSE 3000
 CMD ["node", "server.js"]

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -19,9 +19,10 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static     ./.next/static
-COPY --from=builder /app/public           ./public
+# outputFileTracingRoot resolves to "/" in Docker, so Next.js nests the
+# standalone output under /app/.next/standalone/app/ (mirroring the /app path).
+COPY --from=builder /app/.next/standalone/app ./
+COPY --from=builder /app/.next/static         ./.next/static
 
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/apps/ui/app/repos/[repo]/cache/page.tsx
+++ b/apps/ui/app/repos/[repo]/cache/page.tsx
@@ -4,21 +4,39 @@
 // syntax (not a literal path); param holds owner and repo joined with "~" (see repos/page.tsx).
 
 import { useParams } from "next/navigation"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Eye, Loader2, Trash2 } from "lucide-react"
+import { Eye, KeyRound, Loader2, Trash2 } from "lucide-react"
 import { api } from "@/lib/api/client"
 import type { CacheEntry } from "@/lib/api/types"
 
 export default function CachePage() {
   const params = useParams<{ repo: string }>()
   const [token, setToken] = useState("")
+  const [tokenSaved, setTokenSaved] = useState(false)
   const [actor, setActor] = useState("")
 
   const [owner, repo] = (params.repo || "").split("~")
+
+  // Auto-resolve saved token for this owner
+  const resolveMutation = useMutation({
+    mutationFn: (org: string) => api.tokens.resolve(org),
+    onSuccess: (data) => { setToken(data.token); setTokenSaved(true) },
+    onError: () => setTokenSaved(false),
+  })
+
+  useEffect(() => {
+    if (owner) resolveMutation.mutate(owner)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [owner])
+
+  const saveTokenMutation = useMutation({
+    mutationFn: () => api.tokens.upsert(owner, token.trim()),
+    onSuccess: () => setTokenSaved(true),
+  })
 
   function formatBytes(bytes: number) {
     if (bytes < 1024) return `${bytes} B`
@@ -57,17 +75,33 @@ export default function CachePage() {
           </div>
           <div className="p-4 flex flex-col gap-3">
             <div>
-              <label className="text-xs font-medium text-foreground block mb-1.5">
+              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
+                {tokenSaved && (
+                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                    <KeyRound className="size-3" />saved
+                  </span>
+                )}
               </label>
               <Input
                 placeholder="ghp_..."
                 type="password"
                 value={token}
-                onChange={(e) => setToken(e.target.value)}
+                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
                 className="font-mono"
               />
             </div>
+            {!tokenSaved && token && (
+              <Button
+                variant="outline"
+                onClick={() => saveTokenMutation.mutate()}
+                disabled={saveTokenMutation.isPending}
+                className="w-full"
+              >
+                <KeyRound className="size-3.5" />
+                {saveTokenMutation.isPending ? "Saving…" : "Save token for this org"}
+              </Button>
+            )}
             <div>
               <label className="text-xs font-medium text-foreground block mb-1.5">Actor</label>
               <Input

--- a/apps/ui/app/repos/[repo]/cache/page.tsx
+++ b/apps/ui/app/repos/[repo]/cache/page.tsx
@@ -29,7 +29,13 @@ export default function CachePage() {
   })
 
   useEffect(() => {
-    if (owner) resolveMutation.mutate(owner)
+    if (owner) {
+      // Clear immediately so a stale token from a previous owner never lingers
+      // while the resolve request is in-flight or when it 404s.
+      setToken("")
+      setTokenSaved(false)
+      resolveMutation.mutate(owner)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner])
 

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -72,10 +72,12 @@ export default function SecurityPage() {
   })
 
   useEffect(() => {
+    // Clear immediately on every owner change so a stale token from a previous
+    // org never lingers while resolve is in-flight or when it 404s.
+    setToken("")
+    setTokenSaved(false)
     if (owner.trim().length > 2) {
       resolveMutation.mutate(owner.trim())
-    } else {
-      setTokenSaved(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner])

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 import { PageHeader } from "@/components/page-header"
 import { CheckCard } from "@/components/check-card"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { AlertTriangle } from "lucide-react"
+import { AlertTriangle, KeyRound } from "lucide-react"
 import { api } from "@/lib/api/client"
 import type { CheckResult } from "@/lib/api/types"
 
@@ -50,6 +50,41 @@ function ScoreGauge({ score, failed, total }: { score: number; failed: number; t
 export default function SecurityPage() {
   const [owner, setOwner] = useState("")
   const [token, setToken] = useState("")
+  const [tokenSaved, setTokenSaved] = useState(false)
+
+  // Pre-fill org from profile settings
+  useEffect(() => {
+    const defaultOrg = localStorage.getItem("default_org") || ""
+    if (defaultOrg) setOwner(defaultOrg)
+  }, [])
+
+  // Auto-resolve saved token when org changes
+  const resolveMutation = useMutation({
+    mutationFn: (org: string) => api.tokens.resolve(org),
+    onSuccess: (data) => {
+      setToken(data.token)
+      setTokenSaved(true)
+    },
+    onError: () => {
+      // No saved token — user enters manually
+      setTokenSaved(false)
+    },
+  })
+
+  useEffect(() => {
+    if (owner.trim().length > 2) {
+      resolveMutation.mutate(owner.trim())
+    } else {
+      setTokenSaved(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [owner])
+
+  // Save token after successful scan
+  const saveTokenMutation = useMutation({
+    mutationFn: () => api.tokens.upsert(owner.trim(), token.trim()),
+    onSuccess: () => setTokenSaved(true),
+  })
 
   const scan = useMutation({
     mutationFn: () => api.analytics.overview(owner, token),
@@ -79,14 +114,19 @@ export default function SecurityPage() {
               />
             </div>
             <div>
-              <label className="text-xs font-medium text-foreground block mb-1.5">
+              <label className="text-xs font-medium text-foreground block mb-1.5 flex items-center gap-1.5">
                 GitHub Token
+                {tokenSaved && (
+                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                    <KeyRound className="size-3" />saved
+                  </span>
+                )}
               </label>
               <Input
                 placeholder="ghp_..."
                 type="password"
                 value={token}
-                onChange={(e) => setToken(e.target.value)}
+                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
                 className="font-mono"
               />
             </div>
@@ -97,6 +137,16 @@ export default function SecurityPage() {
             >
               {scan.isPending ? "Scanning…" : "Run scan"}
             </Button>
+            {!tokenSaved && token && owner && (
+              <Button
+                variant="outline"
+                onClick={() => saveTokenMutation.mutate()}
+                disabled={saveTokenMutation.isPending}
+              >
+                <KeyRound className="size-3.5" />
+                {saveTokenMutation.isPending ? "Saving…" : "Save token for this org"}
+              </Button>
+            )}
             {scan.isError && (
               <div className="flex items-start gap-2 text-xs text-destructive">
                 <AlertTriangle className="size-3.5 mt-0.5 shrink-0" />

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -1,13 +1,205 @@
-import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+"use client"
 
-export const metadata = { title: "Settings · clevis" }
+import { useEffect, useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Trash2, Plus, Loader2, Check } from "lucide-react"
+import { PageHeader } from "@/components/page-header"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { api } from "@/lib/api/client"
+import type { SavedTokenMeta } from "@/lib/api/types"
+
+// ── Profile section ──────────────────────────────────────────────────────────
+
+function ProfileSection() {
+  const [name, setName] = useState("")
+  const [org, setOrg] = useState("")
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    setName(localStorage.getItem("profile_name") || "")
+    setOrg(localStorage.getItem("default_org") || "")
+  }, [])
+
+  function save() {
+    localStorage.setItem("profile_name", name.trim() || "Guest")
+    localStorage.setItem("default_org", org.trim())
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2000)
+    // Refresh sidebar without full page reload
+    window.dispatchEvent(new Event("profile-updated"))
+  }
+
+  return (
+    <div className="bg-card border border-border">
+      <div className="px-4 py-3 border-b border-border">
+        <span className="section-label">Profile</span>
+      </div>
+      <div className="p-4 flex flex-col gap-3 max-w-sm">
+        <div>
+          <label className="text-xs font-medium text-foreground block mb-1.5">Display name</label>
+          <Input
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-foreground block mb-1.5">Default organization</label>
+          <Input
+            placeholder="e.g. octocat"
+            value={org}
+            onChange={(e) => setOrg(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Pre-fills the org field on Health &amp; Security and other pages.
+          </p>
+        </div>
+        <Button onClick={save} className="mt-1 w-fit">
+          {saved ? <><Check className="size-3.5" />Saved</> : "Save profile"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ── Saved tokens section ─────────────────────────────────────────────────────
+
+function SavedTokensSection() {
+  const qc = useQueryClient()
+  const [addOrg, setAddOrg] = useState("")
+  const [addToken, setAddToken] = useState("")
+  const [addLabel, setAddLabel] = useState("")
+
+  const { data: tokens = [], isLoading } = useQuery<SavedTokenMeta[]>({
+    queryKey: ["tokens"],
+    queryFn: () => api.tokens.list(),
+  })
+
+  const upsert = useMutation({
+    mutationFn: () => api.tokens.upsert(addOrg.trim(), addToken.trim(), addLabel.trim() || undefined),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["tokens"] })
+      setAddOrg("")
+      setAddToken("")
+      setAddLabel("")
+    },
+  })
+
+  const remove = useMutation({
+    mutationFn: (org: string) => api.tokens.delete(org),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["tokens"] }),
+  })
+
+  const canAdd = addOrg.trim().length > 0 && addToken.trim().length > 0
+
+  return (
+    <div className="bg-card border border-border">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <span className="section-label">Saved tokens</span>
+        {tokens.length > 0 && (
+          <span className="stat-chip">{tokens.length} saved</span>
+        )}
+      </div>
+
+      {/* Token list */}
+      {isLoading ? (
+        <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" /> Loading…
+        </div>
+      ) : tokens.length === 0 ? (
+        <div className="px-4 py-6">
+          <p className="text-sm text-muted-foreground">No saved tokens yet. Add one below.</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Org</th>
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Label</th>
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Saved</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {tokens.map((t: SavedTokenMeta) => (
+                <tr key={t.org} className="hover:bg-elevated transition-colors">
+                  <td className="px-4 py-2.5 font-mono text-foreground/80">{t.org}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground">{t.label ?? "—"}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground whitespace-nowrap">
+                    {new Date(t.created_at).toLocaleDateString(undefined, {
+                      month: "short", day: "numeric", year: "numeric",
+                    })}
+                  </td>
+                  <td className="px-4 py-2.5 text-right">
+                    <button
+                      onClick={() => remove.mutate(t.org)}
+                      disabled={remove.isPending}
+                      className="text-muted-foreground hover:text-destructive transition-colors"
+                      aria-label={`Delete token for ${t.org}`}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add new token */}
+      <div className="border-t border-border p-4">
+        <p className="text-xs font-medium text-foreground mb-3">Add token</p>
+        <div className="grid gap-2 sm:grid-cols-3">
+          <Input
+            placeholder="Org or owner"
+            value={addOrg}
+            onChange={(e) => setAddOrg(e.target.value)}
+          />
+          <Input
+            placeholder="ghp_… token"
+            type="password"
+            value={addToken}
+            onChange={(e) => setAddToken(e.target.value)}
+            className="font-mono"
+          />
+          <Input
+            placeholder="Label (optional)"
+            value={addLabel}
+            onChange={(e) => setAddLabel(e.target.value)}
+          />
+        </div>
+        <Button
+          onClick={() => upsert.mutate()}
+          disabled={!canAdd || upsert.isPending}
+          className="mt-2"
+        >
+          {upsert.isPending ? (
+            <><Loader2 className="size-3.5 animate-spin" />Saving…</>
+          ) : (
+            <><Plus className="size-3.5" />Save token</>
+          )}
+        </Button>
+        {upsert.isError && (
+          <p className="text-xs text-destructive mt-2">{upsert.error.message}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function SettingsPage() {
   return (
     <>
-      <PageHeader title="Settings" description="Configure your clevis workspace." />
-      <EmptyStatePage message="— settings coming in a future phase" />
+      <PageHeader title="Settings" description="Configure your workspace." />
+      <div className="flex flex-col gap-4">
+        <ProfileSection />
+        <SavedTokensSection />
+      </div>
     </>
   )
 }

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -1,4 +1,4 @@
-import type { AnalyticsOverviewResponse, AuditLogOut, CacheListResponse, CacheClearResponse, JobOut } from "./types"
+import type { AnalyticsOverviewResponse, AuditLogOut, CacheListResponse, CacheClearResponse, JobOut, SavedTokenMeta } from "./types"
 
 const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
 // Role sent in X-Role header for privileged operations (e.g. cache clear).
@@ -25,6 +25,25 @@ async function get<T>(path: string): Promise<T> {
   return json as T
 }
 
+async function put<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const json = await res.json()
+  if (!res.ok) throw new Error((json as { detail?: string }).detail ?? `Request failed: ${res.status}`)
+  return json as T
+}
+
+async function del(path: string): Promise<void> {
+  const res = await fetch(`${BASE}${path}`, { method: "DELETE" })
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}))
+    throw new Error((json as { detail?: string }).detail ?? `Request failed: ${res.status}`)
+  }
+}
+
 export const api = {
   analytics: {
     overview: (owner: string, token: string) =>
@@ -48,5 +67,13 @@ export const api = {
   audit: {
     list: (action?: string) =>
       get<AuditLogOut[]>(`/audit${action ? `?action=${encodeURIComponent(action)}` : ""}`),
+  },
+  tokens: {
+    list: () => get<SavedTokenMeta[]>("/tokens"),
+    upsert: (org: string, token: string, label?: string) =>
+      put<SavedTokenMeta>(`/tokens/${encodeURIComponent(org)}`, { token, label }),
+    resolve: (org: string) =>
+      post<{ token: string }>("/tokens/resolve", { org }),
+    delete: (org: string) => del(`/tokens/${encodeURIComponent(org)}`),
   },
 }

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -55,3 +55,10 @@ export interface AuditLogOut {
   payload: string
   created_at: string
 }
+
+export interface SavedTokenMeta {
+  org: string
+  label: string | null
+  created_at: string
+  updated_at: string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_NAME}
-    ports:
-      - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,10 @@ services:
     profiles: ["frontend"]
     build:
       context: apps/ui
+      args:
+        # NEXT_PUBLIC_* vars must be available at build time
+        NEXT_PUBLIC_API_BASE: ${NEXT_PUBLIC_API_BASE}
+        NEXT_PUBLIC_DEFAULT_ROLE: ${NEXT_PUBLIC_DEFAULT_ROLE:-viewer}
     env_file:
       - .env
     ports:


### PR DESCRIPTION
This pull request introduces a secure, encrypted "Saved Tokens" feature to both the backend API and the frontend UI. It enables users to save, update, and delete GitHub tokens associated with organizations, with tokens encrypted at rest. The UI now automatically resolves and pre-fills tokens for organizations where a token is saved, and provides a new settings page for managing saved tokens and profile preferences.

**Backend: Saved Tokens API and Database**

* Added a new `saved_tokens` table via Alembic migration to store encrypted tokens per organization, with metadata such as label and timestamps.
* Introduced the `SavedToken` SQLAlchemy model and integrated it into the database layer.
* Implemented a new `tokens` API router with CRUD endpoints for listing, upserting, resolving (decrypting), and deleting tokens, ensuring tokens are encrypted at rest and never exposed via GET endpoints.
* Registered the new tokens router in the FastAPI application. [[1]](diffhunk://#diff-c307805a5ad6386cefa925eab157796199096e8d428a9ceb766817286e82b04bL9-R9) [[2]](diffhunk://#diff-c307805a5ad6386cefa925eab157796199096e8d428a9ceb766817286e82b04bR40)

**Frontend: Token Management and Autofill**

* Updated the cache and security pages to automatically resolve and pre-fill saved tokens for the selected organization, indicate when a token is saved, and allow users to save or update tokens directly from those pages. ([apps/ui/app/repos/[repo]/cache/page.tsxL7-R40](diffhunk://#diff-e7cb91deaef489e2f3fa6b05762920ff2573c63495a727c482f9a33ea3baf514L7-R40), [apps/ui/app/repos/[repo]/cache/page.tsxL60-R104](diffhunk://#diff-e7cb91deaef489e2f3fa6b05762920ff2573c63495a727c482f9a33ea3baf514L60-R104), [[1]](diffhunk://#diff-0c8d1c00a0919be3d3cf0b0b731fad756864ad98c66fc2e0ec8be4d3934c0146L3-R9) [[2]](diffhunk://#diff-0c8d1c00a0919be3d3cf0b0b731fad756864ad98c66fc2e0ec8be4d3934c0146R53-R87) [[3]](diffhunk://#diff-0c8d1c00a0919be3d3cf0b0b731fad756864ad98c66fc2e0ec8be4d3934c0146L82-R129) [[4]](diffhunk://#diff-0c8d1c00a0919be3d3cf0b0b731fad756864ad98c66fc2e0ec8be4d3934c0146R140-R149)
* Added a comprehensive settings page with sections for editing profile information (display name, default org) and managing saved tokens (list, add, delete, and label tokens).

**API Client Enhancements**

* Extended the frontend API client to support the new token endpoints with `put` and `delete` helpers, and updated types for saved token metadata. [[1]](diffhunk://#diff-39c22ad3575413abc0dbc654c5cb4d048b5763e9354b057b37e70f6f5962462dL1-R1) [[2]](diffhunk://#diff-39c22ad3575413abc0dbc654c5cb4d048b5763e9354b057b37e70f6f5962462dR28-R46)