### PR TITLE
fix(ui): revert standalone COPY path — server.js is always at standal…

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -19,10 +19,10 @@ FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
-# outputFileTracingRoot resolves to "/" in Docker, so Next.js nests the
-# standalone output under /app/.next/standalone/app/ (mirroring the /app path).
-COPY --from=builder /app/.next/standalone/app ./
-COPY --from=builder /app/.next/static         ./.next/static
+# server.js is always at the root of .next/standalone/ regardless of
+# outputFileTracingRoot. Copy the whole standalone dir so server.js lands at ./
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static     ./.next/static
 
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
This pull request updates the Docker build process for the UI application to ensure that the Next.js `server.js` file is correctly copied to the container's root directory. Instead of copying only the nested application directory, the change copies the entire `.next/standalone` directory, which ensures proper server startup regardless of the `outputFileTracingRoot` configuration.

**Docker build process update:**

* Changed the `COPY` command in `apps/ui/Dockerfile` to copy the entire `.next/standalone` directory from the builder stage, ensuring `server.js` is placed at the expected root location for Next.js standalone deployments.…one root