### PR TITLE
fix(infra): remove compose profiles so all services start on plain do…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,8 @@
 name: clevis
 
-# Profiles:
-#   docker compose --profile backend up           → db + api + worker
-#   docker compose --profile frontend up          → db + ui (point NEXT_PUBLIC_API_BASE at a running api)
-#   docker compose --profile backend --profile frontend up  → full stack
-#   docker compose up db                          → db only (for running services locally)
+# Production: docker compose up --build
+# Local dev (selective): docker compose up db api   or   docker compose up db
+# All services have no profiles so Coolify (and plain docker compose up) starts them all.
 
 services:
   db:
@@ -28,7 +26,6 @@ services:
 
   api:
     container_name: api
-    profiles: ["backend"]
     build:
       context: .
       dockerfile: apps/api/Dockerfile
@@ -53,7 +50,6 @@ services:
 
   worker:
     container_name: worker
-    profiles: ["backend"]
     build:
       context: apps/worker
     env_file:
@@ -69,7 +65,6 @@ services:
 
   ui:
     container_name: ui
-    profiles: ["frontend"]
     build:
       context: apps/ui
       args:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to simplify service management and improve compatibility with deployment platforms like Coolify. The main change is the removal of service profiles, ensuring that all services start by default when running `docker compose up`, making the setup more straightforward for both production and local development.

**Docker Compose configuration simplification:**

* Updated the documentation at the top of `docker-compose.yml` to clarify usage instructions for both production and local development, removing references to profiles and providing simpler example commands.
* Removed the `profiles` field from the `api`, `worker`, and `ui` service definitions so that all services are included by default when running `docker compose up`, improving compatibility with platforms like Coolify and simplifying local development. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L31) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L56) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L72)…cker compose up