### PR TITLE
fix(infra): remove host port bindings from api and ui to avoid Traefi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
 name: clevis
 
-# Production: docker compose up --build
-# Local dev (selective): docker compose up db api   or   docker compose up db
-# All services have no profiles so Coolify (and plain docker compose up) starts them all.
+# No host port bindings — Traefik (Coolify proxy) routes traffic to containers
+# via the internal Docker network. Exposing ports to the host would conflict
+# with Traefik on 8080 and is a security risk.
+#
+# Local dev: docker compose up db            → DB only (run api/ui/worker locally)
+#            docker compose up --build       → full stack
 
 services:
   db:
@@ -33,8 +36,6 @@ services:
       - .env
     volumes:
       - ./packages/checks:/app/packages/checks
-    ports:
-      - "${API_PORT:-8080}:8080"
     depends_on:
       db:
         condition: service_healthy
@@ -73,8 +74,6 @@ services:
         NEXT_PUBLIC_DEFAULT_ROLE: ${NEXT_PUBLIC_DEFAULT_ROLE:-viewer}
     env_file:
       - .env
-    ports:
-      - "${UI_PORT:-3000}:3000"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` configuration to improve security and clarify usage instructions. The main change is the removal of host port bindings for the `api` and `ui` services, relying instead on Traefik (Coolify proxy) for routing traffic. This prevents port conflicts and reduces security risks. The documentation in the file has also been updated to reflect these changes and provide clearer guidance for local development.

Configuration and security improvements:

* Removed host port bindings from the `api` and `ui` services to prevent conflicts with Traefik and reduce security risks. Traffic is now routed internally via Docker's network. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L36-L37) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L76-L77)

Documentation updates:

* Updated comments at the top of `docker-compose.yml` to clarify that ports are no longer exposed to the host, and provided new instructions for local development workflows.