### PR TITLE
fix(api): install checks package via pip instead of PYTHONPATH

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,6 +7,6 @@ COPY apps/api/alembic ./alembic
 COPY apps/api/alembic.ini .
 COPY apps/api/entrypoint.sh .
 COPY packages/checks /app/packages/checks
-ENV PYTHONPATH=/app:/app/packages/checks/src
+RUN pip install --no-cache-dir /app/packages/checks
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       dockerfile: apps/api/Dockerfile
     env_file:
       - .env
-    volumes:
-      - ./packages/checks:/app/packages/checks
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This pull request updates how the `packages/checks` Python package is included and installed in the API service. Instead of mounting the package as a volume at runtime, the package is now installed during the Docker build process, simplifying deployment and ensuring consistent dependencies.

**Docker build and dependency management:**

* The `packages/checks` package is now installed using `pip install` during the Docker image build in `apps/api/Dockerfile`, replacing the previous method of setting `PYTHONPATH`.
* The runtime volume mount for `packages/checks` in the API service has been removed from `docker-compose.yml`, as the package is now included in the built image.