### PR TITLE
Feat/settings

### DIFF
--- a/apps/ui/app/globals.css
+++ b/apps/ui/app/globals.css
@@ -70,10 +70,10 @@
   --border:       #1c1c1c;
   --border-muted: #141414;
 
-  /* Brand accent — amber, not purple */
-  --primary:            #f59e0b;
-  --primary-foreground: #0a0a0a;
-  --ring:               #f59e0b;
+  /* Brand accent — clean blue */
+  --primary:            #60a5fa;
+  --primary-foreground: #030712;
+  --ring:               #60a5fa;
 
   /* Semantic */
   --accent:             #22c55e;
@@ -84,12 +84,12 @@
   /* Sidebar */
   --sidebar:                    #060606;
   --sidebar-foreground:         #f5f5f5;
-  --sidebar-primary:            #f59e0b;
-  --sidebar-primary-foreground: #0a0a0a;
+  --sidebar-primary:            #60a5fa;
+  --sidebar-primary-foreground: #030712;
   --sidebar-accent:             #141414;
   --sidebar-accent-foreground:  #f5f5f5;
   --sidebar-border:             #1a1a1a;
-  --sidebar-ring:               #f59e0b;
+  --sidebar-ring:               #60a5fa;
 
   /* Popover / card foreground */
   --card-foreground:      #f5f5f5;
@@ -101,7 +101,7 @@
   --input:                #111111;
 
   /* Charts */
-  --chart-1: #f59e0b;   /* amber  — primary data */
+  --chart-1: #60a5fa;   /* blue   — primary data */
   --chart-2: #22c55e;   /* green  — positive */
   --chart-3: #38bdf8;   /* sky    — secondary */
   --chart-4: #ef4444;   /* red    — negative */

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -13,20 +13,22 @@ import type { SavedTokenMeta } from "@/lib/api/types"
 
 function ProfileSection() {
   const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
   const [org, setOrg] = useState("")
   const [saved, setSaved] = useState(false)
 
   useEffect(() => {
     setName(localStorage.getItem("profile_name") || "")
+    setEmail(localStorage.getItem("profile_email") || "")
     setOrg(localStorage.getItem("default_org") || "")
   }, [])
 
   function save() {
     localStorage.setItem("profile_name", name.trim() || "Guest")
+    localStorage.setItem("profile_email", email.trim())
     localStorage.setItem("default_org", org.trim())
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
-    // Refresh sidebar without full page reload
     window.dispatchEvent(new Event("profile-updated"))
   }
 
@@ -42,6 +44,15 @@ function ProfileSection() {
             placeholder="Your name"
             value={name}
             onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+          <Input
+            placeholder="you@example.com"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
           />
         </div>
         <div>

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
 import Link from "next/link"
-import { Settings, Check, LogOut } from "lucide-react"
+import { Settings, Check, LogOut, UserPlus } from "lucide-react"
 import {
   Sidebar,
   SidebarContent,
@@ -96,7 +96,7 @@ function ProfileDropdown({
         </div>
       </div>
 
-      {/* Settings button */}
+      {/* Settings + Invite members buttons */}
       <div className="px-1.5 pb-1.5 flex gap-1.5">
         <Link
           href="/settings"
@@ -106,6 +106,14 @@ function ProfileDropdown({
           <Settings className="size-3" />
           Settings
         </Link>
+        <button
+          disabled
+          className="flex items-center gap-1.5 px-2.5 py-1.5 text-[0.75rem] font-medium text-sidebar-foreground/70 hover:text-sidebar-foreground bg-sidebar-accent/60 hover:bg-sidebar-accent border border-sidebar-border/60 transition-colors flex-1 justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Coming soon"
+        >
+          <UserPlus className="size-3" />
+          Invite members
+        </button>
       </div>
 
       {/* Sign out */}

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { usePathname } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import Link from "next/link"
-import { Settings } from "lucide-react"
+import { Settings, Check, LogOut } from "lucide-react"
 import {
   Sidebar,
   SidebarContent,
@@ -16,7 +16,7 @@ import {
   SidebarSeparator,
 } from "@/components/ui/sidebar"
 
-// Each group is an array of nav items. Groups are separated by a thin line — no labels.
+// Settings is no longer in the sidebar nav — it lives inside the profile dropdown.
 const groups = [
   [
     { title: "Overview",         href: "/",             shortcut: "g o" },
@@ -33,7 +33,6 @@ const groups = [
     { title: "Automation",       href: "/automation",    shortcut: undefined },
     { title: "Audit Log",        href: "/audit",         shortcut: undefined },
     { title: "Job Queue",        href: "/jobs",          shortcut: undefined },
-    { title: "Settings",         href: "/settings",      shortcut: undefined },
   ],
   [
     { title: "My PRs",     href: "/my/prs",     shortcut: undefined },
@@ -42,15 +41,123 @@ const groups = [
   ],
 ]
 
+interface Profile {
+  name: string
+  org: string
+  email: string
+}
+
+function ProfileDropdown({
+  profile,
+  onClose,
+}: {
+  profile: Profile
+  onClose: () => void
+}) {
+  const initials = profile.name.charAt(0).toUpperCase()
+
+  function signOut() {
+    localStorage.removeItem("profile_name")
+    localStorage.removeItem("profile_email")
+    localStorage.removeItem("default_org")
+    window.location.reload()
+  }
+
+  return (
+    <div
+      className="absolute top-full left-0 right-0 z-50 border-b border-sidebar-border bg-sidebar shadow-2xl"
+      // prevent clicks inside from bubbling to the click-away handler
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Email */}
+      <div className="px-3.5 py-2.5 border-b border-sidebar-border/60">
+        <p className="text-[0.75rem] text-sidebar-foreground/50 truncate">
+          {profile.email || "no email set"}
+        </p>
+      </div>
+
+      {/* Workspace row */}
+      <div className="p-1.5">
+        <div className="flex items-center gap-2.5 px-2 py-2 rounded-sm">
+          <div className="size-7 rounded-sm bg-primary/15 border border-primary/20 flex items-center justify-center shrink-0">
+            <span className="text-[0.6875rem] font-semibold text-primary leading-none">
+              {initials}
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[0.8125rem] font-medium text-sidebar-foreground leading-none truncate">
+              {profile.name}
+            </p>
+            <p className="text-[0.6875rem] text-sidebar-foreground/40 mt-0.5 leading-none">
+              {profile.org || "Members"}
+            </p>
+          </div>
+          <Check className="size-3.5 text-primary shrink-0" />
+        </div>
+      </div>
+
+      {/* Settings button */}
+      <div className="px-1.5 pb-1.5 flex gap-1.5">
+        <Link
+          href="/settings"
+          onClick={onClose}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 text-[0.75rem] font-medium text-sidebar-foreground/70 hover:text-sidebar-foreground bg-sidebar-accent/60 hover:bg-sidebar-accent border border-sidebar-border/60 transition-colors flex-1 justify-center"
+        >
+          <Settings className="size-3" />
+          Settings
+        </Link>
+      </div>
+
+      {/* Sign out */}
+      <div className="border-t border-sidebar-border/60 p-1.5">
+        <button
+          onClick={signOut}
+          className="flex w-full items-center gap-2 px-2.5 py-1.5 text-[0.8125rem] text-destructive/70 hover:text-destructive hover:bg-sidebar-accent/60 transition-colors"
+        >
+          <LogOut className="size-3.5" />
+          Sign out
+        </button>
+      </div>
+    </div>
+  )
+}
+
 export function AppSidebar() {
   const pathname = usePathname()
-  const [profile, setProfile] = useState({ name: "Guest", org: "no org connected" })
+  const [profile, setProfile] = useState<Profile>({ name: "Guest", org: "no org connected", email: "" })
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const name = localStorage.getItem("profile_name") || "Guest"
-    const org  = localStorage.getItem("default_org")  || "no org connected"
-    setProfile({ name, org })
+    const name  = localStorage.getItem("profile_name")  || "Guest"
+    const org   = localStorage.getItem("default_org")   || "no org connected"
+    const email = localStorage.getItem("profile_email") || ""
+    setProfile({ name, org, email })
   }, [])
+
+  // Listen for profile updates from settings page
+  useEffect(() => {
+    function handleUpdate() {
+      const name  = localStorage.getItem("profile_name")  || "Guest"
+      const org   = localStorage.getItem("default_org")   || "no org connected"
+      const email = localStorage.getItem("profile_email") || ""
+      setProfile({ name, org, email })
+    }
+    window.addEventListener("profile-updated", handleUpdate)
+    return () => window.removeEventListener("profile-updated", handleUpdate)
+  }, [])
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [open])
 
   const initials = profile.name.charAt(0).toUpperCase()
 
@@ -61,11 +168,11 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
-      {/* Profile widget — links to /settings */}
-      <SidebarHeader className="border-b border-sidebar-border p-0">
-        <Link
-          href="/settings"
-          className="flex items-center gap-2.5 px-3.5 py-3 hover:bg-sidebar-accent/60 transition-colors group"
+      {/* Profile widget — opens dropdown */}
+      <SidebarHeader className="border-b border-sidebar-border p-0 relative" ref={containerRef}>
+        <button
+          onClick={() => setOpen((v) => !v)}
+          className="flex w-full items-center gap-2.5 px-3.5 py-3 hover:bg-sidebar-accent/60 transition-colors group text-left"
         >
           <div className="size-7 rounded-full bg-primary/15 border border-primary/25 flex items-center justify-center shrink-0">
             <span className="text-[0.6875rem] font-semibold text-primary leading-none">{initials}</span>
@@ -79,7 +186,11 @@ export function AppSidebar() {
             </p>
           </div>
           <Settings className="size-3 text-sidebar-foreground/20 group-hover:text-sidebar-foreground/50 transition-colors shrink-0" />
-        </Link>
+        </button>
+
+        {open && (
+          <ProfileDropdown profile={profile} onClose={() => setOpen(false)} />
+        )}
       </SidebarHeader>
 
       <SidebarContent>
@@ -119,7 +230,6 @@ export function AppSidebar() {
           </div>
         ))}
       </SidebarContent>
-
     </Sidebar>
   )
 }


### PR DESCRIPTION
This pull request updates the user profile experience in the sidebar and settings, and refreshes the brand color palette to use a blue accent instead of amber. The sidebar profile widget is now a dropdown with profile details, settings access, and a sign-out option. The Settings link is removed from the main sidebar navigation and moved into the profile dropdown. Additionally, the profile email is now stored and editable in the settings page, and the UI color theme is updated.

**Sidebar profile and navigation changes:**

* Replaces the sidebar profile widget with a dropdown menu that displays the user's name, organization, and email, and provides quick access to settings, a (disabled) "invite members" button, and a sign-out option. The dropdown closes when clicking outside of it. (`apps/ui/components/app-sidebar.tsx`) [[1]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eR44-R169) [[2]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eL64-R183) [[3]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eL82-R201)
* Removes the Settings link from the main sidebar navigation and moves it into the profile dropdown. (`apps/ui/components/app-sidebar.tsx`) [[1]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eL19-R19) [[2]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eL36)

**Profile data management:**

* Adds support for storing and editing the user's email address in local storage via the settings page, and ensures the sidebar profile updates in real time when profile data changes. (`apps/ui/app/settings/page.tsx`, `apps/ui/components/app-sidebar.tsx`) [[1]](diffhunk://#diff-460b93f5b7002a078612f62b47f0e0e5a0d439fe5b9e633aa118b11dbf10e180R16-L29) [[2]](diffhunk://#diff-460b93f5b7002a078612f62b47f0e0e5a0d439fe5b9e633aa118b11dbf10e180R49-R57) [[3]](diffhunk://#diff-99f3a2fbed69470a1928617ee5699e6b14a3fe91eb41a6e92c1fb7363bfcd02eR44-R169)

**Branding and theme updates:**

* Updates the brand accent color and related UI variables from amber to a clean blue across the application, including sidebar, buttons, and charts. (`apps/ui/app/globals.css`) [[1]](diffhunk://#diff-1436c35c218a60426eb1bcc41690a3a545729c41d2a27bbd45f3c114af63603dL73-R76) [[2]](diffhunk://#diff-1436c35c218a60426eb1bcc41690a3a545729c41d2a27bbd45f3c114af63603dL87-R92) [[3]](diffhunk://#diff-1436c35c218a60426eb1bcc41690a3a545729c41d2a27bbd45f3c114af63603dL104-R104)