### PR TITLE
fix(ui): bind standalone server to 0.0.0.0 for Docker networking

### DIFF
--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -18,6 +18,10 @@ RUN npm run build
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# Bind to all interfaces so Traefik can reach the server via the Docker network.
+# Without this Next.js standalone defaults to localhost (127.0.0.1), which is
+# unreachable from other containers.
+ENV HOSTNAME=0.0.0.0
 
 # outputFileTracingRoot resolves to "/" in Docker, so Next.js mirrors the full
 # path and nests standalone output under app/ (i.e. server.js is at


### PR DESCRIPTION
This pull request makes a small but important change to the Docker configuration for the UI application. It sets the `HOSTNAME` environment variable to `0.0.0.0` to ensure that the Next.js server binds to all network interfaces, allowing it to be accessible from other containers such as Traefik.

* Docker networking:
  * Set `HOSTNAME=0.0.0.0` in `apps/ui/Dockerfile` so the Next.js server is reachable from other containers, not just localhost.