### PR TITLE
fix(docker): expose api port 8080 and ui port 3000 for Traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       dockerfile: apps/api/Dockerfile
     env_file:
       - .env
+    expose:
+      - "8080"
     depends_on:
       db:
         condition: service_healthy
@@ -71,6 +73,8 @@ services:
         NEXT_PUBLIC_API_BASE: ${NEXT_PUBLIC_API_BASE}
     env_file:
       - .env
+    expose:
+      - "3000"
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
This pull request makes a small update to the `docker-compose.yml` file, adding explicit port exposure for the `api` and `web` services. This change helps clarify which internal ports are available for inter-service communication within the Docker network.

- Docker Compose configuration:
  * Added the `expose` directive for the `api` service to expose port `8080`.
  * Added the `expose` directive for the `web` service to expose port `3000`.