### PR TITLE
feat(auth): optimistically restore user session from JWT payload

### DIFF
--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -30,11 +30,12 @@ class UserOut(BaseModel):
     is_owner: bool
 
 
-def create_access_token(user_id: int, email: str, is_owner: bool) -> str:
+def create_access_token(user_id: int, email: str, is_owner: bool, name: str | None = None) -> str:
     payload = {
         "sub": str(user_id),
         "email": email,
         "is_owner": is_owner,
+        "name": name,
         "exp": datetime.now(timezone.utc) + timedelta(days=_TOKEN_EXPIRE_DAYS),
     }
     return jwt.encode(payload, settings.auth_secret.get_secret_value(), algorithm=_ALGORITHM)

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -99,7 +99,7 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token(user.id, user.email, user.is_owner)
+    token = create_access_token(user.id, user.email, user.is_owner, user.name)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_owner=user.is_owner)}
 
 
@@ -109,7 +109,7 @@ def login(body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == body.email).first()
     if not user or not _verify_password(body.password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token(user.id, user.email, user.is_owner)
+    token = create_access_token(user.id, user.email, user.is_owner, user.name)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_owner=user.is_owner)}
 
 

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -24,6 +24,21 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 const _TOKEN_KEY = "clevis:token"
 const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
 
+function parseJwtPayload(token: string): AuthUser | null {
+  try {
+    // JWT uses base64url — normalize to standard base64 before atob()
+    const segment = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")
+    const padded = segment.padEnd(Math.ceil(segment.length / 4) * 4, "=")
+    const payload = JSON.parse(atob(padded))
+    const id = Number(payload.sub)
+    if (!id || !payload.email) return null
+    if (payload.exp && payload.exp * 1000 < Date.now()) return null
+    return { id, email: payload.email, name: payload.name ?? null, is_owner: Boolean(payload.is_owner) }
+  } catch {
+    return null
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [token, setToken] = useState<string | null>(null)
@@ -35,13 +50,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser(null)
   }, [])
 
-  // On mount: restore token from localStorage and validate it
+  // On mount: restore session from JWT immediately, then validate silently in background
   useEffect(() => {
     const stored = localStorage.getItem(_TOKEN_KEY)
     if (!stored) {
       setIsLoading(false)
       return
     }
+
+    // Optimistic restore — unblock the UI without a network round-trip
+    const optimistic = parseJwtPayload(stored)
+    if (optimistic) {
+      setToken(stored)
+      setUser(optimistic)
+      setIsLoading(false)
+    }
+
+    // Background validation — evict stale tokens, refresh user fields
     fetch(`${BASE}/auth/me`, {
       headers: { Authorization: `Bearer ${stored}` },
     })
@@ -50,16 +75,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           logout()
           return
         }
-        if (!res.ok) {
-          // Non-401 error (e.g. 500, network blip) — keep token, try again next load
-          return
-        }
+        if (!res.ok) return
         const data = await res.json()
         setToken(stored)
         setUser(data as AuthUser)
       })
       .catch(() => {
-        // Network unreachable — keep token, don't log out; user can retry
+        // Network unreachable — keep optimistic session
       })
       .finally(() => setIsLoading(false))
   }, [logout])


### PR DESCRIPTION
This pull request enhances authentication by including the user's name in JWT access tokens and improves the client-side authentication flow for a more responsive user experience. The main changes involve updating token creation and parsing logic, and optimizing how the UI restores user sessions.

**Backend changes:**

* The `create_access_token` function now includes the user's `name` in the JWT payload, and all token creation points (`setup` and `login` endpoints) pass the `name` value when generating tokens. [[1]](diffhunk://#diff-b4c19bfa294c3a26304fc0e2a0f347717af3c482e85460d56035fddba1bdc02aL33-R38) [[2]](diffhunk://#diff-dfe9cdbc498c6bb9069ec2a50ea944053f1836fef6185eccad4b564e25b68e61L102-R102) [[3]](diffhunk://#diff-dfe9cdbc498c6bb9069ec2a50ea944053f1836fef6185eccad4b564e25b68e61L112-R112)

**Frontend (UI) improvements:**

* Added a `parseJwtPayload` function in `auth-context.tsx` to extract user information (including `name`) directly from the JWT, enabling immediate session restoration without waiting for a network request.
* Modified the authentication provider to optimistically restore the user session from the JWT on page load, then validate it in the background. This provides a faster, smoother user experience.
* Adjusted error handling during background validation to be less aggressive: if the network is unreachable or there's a non-authentication error, the optimistic session is kept instead of logging the user out.