### PR TITLE
refactor: update tests and routers, tests, src for API and worker

### DIFF
--- a/apps/api/src/routers/config.py
+++ b/apps/api/src/routers/config.py
@@ -45,9 +45,18 @@ def update_config(
     # Type validation
     if key in _INT_KEYS:
         try:
-            int(body.value)
+            parsed_int = int(body.value)
         except ValueError:
             raise HTTPException(status_code=422, detail=f"{key} must be an integer")
+        if parsed_int < 1:
+            raise HTTPException(status_code=422, detail=f"{key} must be at least 1")
+    elif key == "github_api_base":
+        candidate = body.value.strip()
+        if not candidate.startswith(("http://", "https://")):
+            raise HTTPException(
+                status_code=422,
+                detail=f"{key} must be an http(s) URL",
+            )
     elif key in _JSON_KEYS:
         try:
             parsed = json.loads(body.value)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -200,6 +200,30 @@ def test_update_config_invalid_int(config_client_owner):
     assert resp.status_code == 422
 
 
+@pytest.mark.parametrize("value", ["0", "-5"])
+def test_update_config_int_below_minimum(config_client_owner, value):
+    resp = config_client_owner.put("/config/worker_poll_seconds", json={"value": value})
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("value", ["", "  ", "api.github.com", "ftp://x"])
+def test_update_config_invalid_github_api_base(config_client_owner, value):
+    resp = config_client_owner.put("/config/github_api_base", json={"value": value})
+    assert resp.status_code == 422
+
+
+def test_update_config_valid_github_api_base(config_client_owner):
+    with (
+        patch("src.routers.config.set_config") as mock_set,
+        patch("src.routers.config.read_all", return_value=_MOCK_CONFIG),
+    ):
+        resp = config_client_owner.put(
+            "/config/github_api_base", json={"value": "https://ghe.example.com/api/v3"}
+        )
+    assert resp.status_code == 200
+    mock_set.assert_called_once_with("github_api_base", "https://ghe.example.com/api/v3")
+
+
 def test_update_config_invalid_json_array(config_client_owner):
     resp = config_client_owner.put("/config/cors_origins", json={"value": "not-json"})
     assert resp.status_code == 422

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -31,6 +31,17 @@ def _read_app_config(key: str, default: str) -> str:
         return default
 
 
+def _read_poll_seconds() -> int:
+    """Read worker_poll_seconds, clamped to a minimum of 1. Falls back to 5 on a
+    malformed value so a bad config row can never crash or busy-loop the worker."""
+    raw = _read_app_config("worker_poll_seconds", "5")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        log.warning("worker_poll_seconds %r is not an integer; using 5", raw)
+        return 5
+
+
 def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None:
     base = _read_app_config("github_api_base", "https://api.github.com")
     try:
@@ -69,11 +80,11 @@ def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None
 
 
 def run() -> None:
-    poll_seconds = int(_read_app_config("worker_poll_seconds", "5"))
+    poll_seconds = _read_poll_seconds()
     log.info("worker started, polling every %ds", poll_seconds)
     while True:
         # Re-read poll interval each cycle so changes in settings take effect without restart
-        poll_seconds = int(_read_app_config("worker_poll_seconds", "5"))
+        poll_seconds = _read_poll_seconds()
         try:
             with psycopg.connect(_DB_URL) as conn:
                 with conn.cursor() as cur:


### PR DESCRIPTION
This pull request introduces improved validation for configuration updates and enhances the robustness of the worker's polling interval handling. The main changes include stricter validation for integer and URL config values in the API, new tests to cover these cases, and a safer way for the worker to read its polling interval, ensuring it always uses a sane value.

**API validation improvements:**

* Added a check ensuring integer config values (such as `worker_poll_seconds`) must be at least 1, and that `github_api_base` must be a valid HTTP(S) URL.

**Testing enhancements:**

* Added tests to verify that invalid integer values (zero or negative) and invalid `github_api_base` values are rejected, and that valid URLs are accepted.

**Worker robustness improvements:**

* Introduced the `_read_poll_seconds` helper to clamp the polling interval to a minimum of 1 and default to 5 on errors, preventing crashes or busy loops due to bad config.
* Updated the worker's main loop to use `_read_poll_seconds` for safer and more robust polling interval handling.