### PR TITLE
Feat/org rbac

### DIFF
--- a/apps/api/alembic/versions/0009_add_org_rbac.py
+++ b/apps/api/alembic/versions/0009_add_org_rbac.py
@@ -97,6 +97,23 @@ def upgrade() -> None:
             "ON CONFLICT (org_id, user_id) DO NOTHING"
         )
     )
+
+    # Fail loudly rather than silently deploying orgs nobody can administer: this only
+    # happens if no user has is_workspace_admin = true at migration time (e.g. the owner
+    # account was deleted, or /auth/setup never ran despite installations existing).
+    orphaned = op.get_bind().execute(
+        sa.text(
+            "SELECT COUNT(*) FROM orgs o "
+            "WHERE NOT EXISTS (SELECT 1 FROM org_memberships m WHERE m.org_id = o.id)"
+        )
+    ).scalar()
+    if orphaned:
+        raise RuntimeError(
+            f"{orphaned} org(s) were backfilled with no admin membership because no user has "
+            "is_workspace_admin = true. Ensure a workspace admin exists before running this "
+            "migration, then re-run it, or manually insert org_memberships rows afterward."
+        )
+
     op.execute(
         sa.text(
             "UPDATE github_installations gi SET org_id = o.id "

--- a/apps/api/alembic/versions/0009_add_org_rbac.py
+++ b/apps/api/alembic/versions/0009_add_org_rbac.py
@@ -1,0 +1,128 @@
+"""add multi-tenant org RBAC: orgs, org_memberships, invitations
+
+Introduces the org/member/individual model. `users.is_owner` becomes
+`users.is_workspace_admin` (same semantics: the instance host). `github_installations`
+gains `org_id` / `owner_user_id` (exactly one set per row) to scope each installation to
+either a connected GitHub org or an individual's personal account.
+
+Existing `github_installations` rows are backfilled best-effort: organization installs
+each get a new `Org` row (github_org_id left NULL — GitHub's numeric org id was never
+recorded historically; it fills in lazily the next time an org member authenticates and
+the GitHub membership check runs) plus an admin `OrgMembership` for the current workspace
+admin, since there's no historical record of who actually connected each installation.
+User installs get `owner_user_id` set to the workspace admin for the same reason.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-07-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("users", "is_owner", new_column_name="is_workspace_admin")
+
+    op.create_table(
+        "orgs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("github_org_id", sa.Integer, nullable=True, unique=True),
+        sa.Column("github_login", sa.Text, nullable=False, unique=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "org_memberships",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Integer, sa.ForeignKey("orgs.id"), nullable=False),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role", sa.String, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("org_id", "user_id", name="uq_org_memberships_org_user"),
+    )
+
+    op.create_table(
+        "invitations",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("org_id", sa.Integer, sa.ForeignKey("orgs.id"), nullable=False),
+        sa.Column("email", sa.Text, nullable=False),
+        sa.Column("token", sa.String, nullable=False, unique=True),
+        sa.Column("status", sa.String, nullable=False, server_default="pending"),
+        sa.Column("invited_by_user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.add_column("github_installations", sa.Column("org_id", sa.Integer(), sa.ForeignKey("orgs.id"), nullable=True))
+    op.add_column(
+        "github_installations", sa.Column("owner_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True)
+    )
+
+    # Backfill: attribute every existing installation to the current workspace admin,
+    # since there's no historical record of who actually connected each one.
+    op.execute(
+        sa.text(
+            "INSERT INTO orgs (github_login) "
+            "SELECT DISTINCT account_login FROM github_installations "
+            "WHERE account_type = 'Organization' "
+            "ON CONFLICT (github_login) DO NOTHING"
+        )
+    )
+    op.execute(
+        sa.text(
+            "INSERT INTO org_memberships (org_id, user_id, role) "
+            "SELECT o.id, u.id, 'admin' "
+            "FROM orgs o, (SELECT id FROM users WHERE is_workspace_admin = true ORDER BY id LIMIT 1) u "
+            "ON CONFLICT (org_id, user_id) DO NOTHING"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE github_installations gi SET org_id = o.id "
+            "FROM orgs o WHERE gi.account_type = 'Organization' AND gi.account_login = o.github_login"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE github_installations SET owner_user_id = "
+            "(SELECT id FROM users WHERE is_workspace_admin = true ORDER BY id LIMIT 1) "
+            "WHERE account_type = 'User'"
+        )
+    )
+
+    op.create_check_constraint(
+        "ck_github_installations_org_xor_owner",
+        "github_installations",
+        "(org_id IS NOT NULL AND owner_user_id IS NULL) OR (org_id IS NULL AND owner_user_id IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_github_installations_org_xor_owner", "github_installations", type_="check")
+    op.drop_column("github_installations", "owner_user_id")
+    op.drop_column("github_installations", "org_id")
+    op.drop_table("invitations")
+    op.drop_table("org_memberships")
+    op.drop_table("orgs")
+    op.alter_column("users", "is_workspace_admin", new_column_name="is_owner")

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -2,8 +2,11 @@
 JWT helpers and FastAPI auth dependencies.
 
 Two access levels:
-  - require_auth  — any authenticated user (valid JWT)
-  - require_owner — authenticated user with is_owner=True (instance config only)
+  - require_auth           — any authenticated user (valid JWT)
+  - require_workspace_admin — authenticated user with is_workspace_admin=True (instance config only)
+
+Org-scoped access levels (member/admin per org) live in src/core/rbac.py, since they
+require a DB lookup rather than just the JWT claims.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -53,14 +56,14 @@ class UserOut(BaseModel):
     id: int
     email: str
     name: str | None
-    is_owner: bool
+    is_workspace_admin: bool
 
 
-def create_access_token(user_id: int, email: str, is_owner: bool, name: str | None = None) -> str:
+def create_access_token(user_id: int, email: str, is_workspace_admin: bool, name: str | None = None) -> str:
     payload = {
         "sub": str(user_id),
         "email": email,
-        "is_owner": is_owner,
+        "is_workspace_admin": is_workspace_admin,
         "name": name,
         "exp": datetime.now(timezone.utc) + timedelta(days=_TOKEN_EXPIRE_DAYS),
     }
@@ -105,12 +108,12 @@ def require_auth(
         id=user_id,
         email=email,
         name=payload.get("name"),
-        is_owner=bool(payload.get("is_owner", False)),
+        is_workspace_admin=bool(payload.get("is_workspace_admin", False)),
     )
 
 
-def require_owner(user: UserOut = Depends(require_auth)) -> UserOut:
-    """Dependency: raises 403 if the authenticated user is not the instance owner."""
-    if not user.is_owner:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Owner access required")
+def require_workspace_admin(user: UserOut = Depends(require_auth)) -> UserOut:
+    """Dependency: raises 403 if the authenticated user is not the workspace admin."""
+    if not user.is_workspace_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Workspace admin access required")
     return user

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -1,7 +1,19 @@
 from collections.abc import Generator
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Index, Integer, String, Text, create_engine, func
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    func,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from src.core.config import settings
@@ -13,6 +25,13 @@ class Base(DeclarativeBase):
 
 class GitHubInstallation(Base):
     __tablename__ = "github_installations"
+    __table_args__ = (
+        CheckConstraint(
+            "(org_id IS NOT NULL AND owner_user_id IS NULL) "
+            "OR (org_id IS NULL AND owner_user_id IS NOT NULL)",
+            name="ck_github_installations_org_xor_owner",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     account_login: Mapped[str] = mapped_column(String, nullable=False)
@@ -20,6 +39,9 @@ class GitHubInstallation(Base):
     installation_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     auth_mode: Mapped[str] = mapped_column(String, nullable=False)
     token_ref: Mapped[str] = mapped_column(String, nullable=False)
+    # Exactly one of org_id / owner_user_id is set: org-connected installs vs. personal installs.
+    org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
+    owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -68,12 +90,48 @@ class User(Base):
     name: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Null for users who only sign in with GitHub (no email/password credential).
     password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
-    is_owner: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_workspace_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     # GitHub identity (set when the user links / signs in via GitHub OAuth).
     github_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
     github_login: Mapped[str | None] = mapped_column(Text, nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Org(Base):
+    __tablename__ = "orgs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Nullable: not known for orgs backfilled from pre-existing installations; filled in
+    # lazily the next time a member of the org authenticates and the GitHub membership
+    # check runs.
+    github_org_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
+    github_login: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class OrgMembership(Base):
+    __tablename__ = "org_memberships"
+    __table_args__ = (UniqueConstraint("org_id", "user_id", name="uq_org_memberships_org_user"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(ForeignKey("orgs.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    role: Mapped[str] = mapped_column(String, nullable=False)  # "admin" | "member"
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Invitation(Base):
+    __tablename__ = "invitations"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    org_id: Mapped[int] = mapped_column(ForeignKey("orgs.id"), nullable=False)
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    token: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="pending")  # pending|accepted|revoked
+    invited_by_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class AppConfig(Base):

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import GitHubInstallation, Org, OrgMembership, get_db
+from src.repositories import org_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -33,7 +34,7 @@ def require_org_role(min_role: Literal["member", "admin"]):
         db: Session = Depends(get_db),
         user: UserOut = Depends(require_auth),
     ) -> OrgContext:
-        org = db.query(Org).filter(Org.github_login == org_login).first()
+        org = org_repo.get_by_login(db, org_login)
         if org is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
         membership = (
@@ -41,7 +42,7 @@ def require_org_role(min_role: Literal["member", "admin"]):
             .filter(OrgMembership.org_id == org.id, OrgMembership.user_id == user.id)
             .first()
         )
-        if membership is None or _ROLE_RANK[membership.role] < _ROLE_RANK[min_role]:
+        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         return OrgContext(org=org, membership=membership)
 

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -13,8 +13,8 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import GitHubInstallation, Org, OrgMembership, get_db
-from src.repositories import org_repo
+from src.core.db import Org, OrgMembership, get_db
+from src.repositories import org_membership_repo, org_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -37,11 +37,7 @@ def require_org_role(min_role: Literal["member", "admin"]):
         org = org_repo.get_by_login(db, org_login)
         if org is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
-        membership = (
-            db.query(OrgMembership)
-            .filter(OrgMembership.org_id == org.id, OrgMembership.user_id == user.id)
-            .first()
-        )
+        membership = org_membership_repo.get(db, org.id, user.id)
         if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         return OrgContext(org=org, membership=membership)
@@ -49,21 +45,9 @@ def require_org_role(min_role: Literal["member", "admin"]):
     return dependency
 
 
-def require_personal_installation(
-    installation_login: str,
-    db: Session = Depends(get_db),
-    user: UserOut = Depends(require_auth),
-) -> GitHubInstallation:
-    """Dependency: 404 if no personal installation matching installation_login exists
-    for the current user."""
-    installation = (
-        db.query(GitHubInstallation)
-        .filter(
-            GitHubInstallation.owner_user_id == user.id,
-            GitHubInstallation.account_login == installation_login,
-        )
-        .first()
-    )
-    if installation is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installation not found")
-    return installation
+def assert_owner_matches_org(owner: str, ctx: OrgContext) -> None:
+    """Raises 403 if a repo-level `owner` path/body value doesn't match the org context
+    require_org_role already resolved — keeps an org-scoped route from acting on a
+    GitHub owner outside the org the caller was authorized for."""
+    if owner != ctx.org.github_login:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="owner must match the org in the URL")

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -1,0 +1,68 @@
+"""
+Org-scoped RBAC dependencies.
+
+Unlike require_auth/require_workspace_admin (JWT-only, no DB hit), these dependencies
+resolve role fresh from the DB on every request, because org membership and invite
+status can change while a 30-day JWT is still valid.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import GitHubInstallation, Org, OrgMembership, get_db
+
+_ROLE_RANK = {"member": 0, "admin": 1}
+
+
+@dataclass
+class OrgContext:
+    org: Org
+    membership: OrgMembership
+
+
+def require_org_role(min_role: Literal["member", "admin"]):
+    """Dependency factory: 404 if org_login (path param) doesn't exist, 403 if the
+    current user isn't a member of it or is below min_role."""
+
+    def dependency(
+        org_login: str,
+        db: Session = Depends(get_db),
+        user: UserOut = Depends(require_auth),
+    ) -> OrgContext:
+        org = db.query(Org).filter(Org.github_login == org_login).first()
+        if org is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
+        membership = (
+            db.query(OrgMembership)
+            .filter(OrgMembership.org_id == org.id, OrgMembership.user_id == user.id)
+            .first()
+        )
+        if membership is None or _ROLE_RANK[membership.role] < _ROLE_RANK[min_role]:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
+        return OrgContext(org=org, membership=membership)
+
+    return dependency
+
+
+def require_personal_installation(
+    installation_login: str,
+    db: Session = Depends(get_db),
+    user: UserOut = Depends(require_auth),
+) -> GitHubInstallation:
+    """Dependency: 404 if no personal installation matching installation_login exists
+    for the current user."""
+    installation = (
+        db.query(GitHubInstallation)
+        .filter(
+            GitHubInstallation.owner_user_id == user.id,
+            GitHubInstallation.account_login == installation_login,
+        )
+        .first()
+    )
+    if installation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installation not found")
+    return installation

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -6,7 +6,19 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.core.config import settings
 from src.core.logging import setup_logging
 from src.core.middleware import RequestIdMiddleware
-from src.routers import actions_cache, analytics, audit, auth, config, github_auth, health, installations, jobs, tokens
+from src.routers import (
+    actions_cache,
+    analytics,
+    audit,
+    auth,
+    config,
+    github_auth,
+    health,
+    installations,
+    invitations,
+    jobs,
+    tokens,
+)
 
 # CORS allowed origins are a deploy-time security boundary, set via the CORS_ORIGINS env var.
 _cors_origins = settings.cors_origins
@@ -44,6 +56,7 @@ app.include_router(health.router)
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(github_auth.router, prefix="/auth/github", tags=["github-auth"])
 app.include_router(installations.router, tags=["installations"])
+app.include_router(invitations.router, tags=["invitations"])
 app.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
 app.include_router(actions_cache.router, prefix="/repos", tags=["actions-cache"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -17,6 +17,7 @@ from src.routers import (
     installations,
     invitations,
     jobs,
+    orgs,
     tokens,
 )
 
@@ -56,9 +57,10 @@ app.include_router(health.router)
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(github_auth.router, prefix="/auth/github", tags=["github-auth"])
 app.include_router(installations.router, tags=["installations"])
+app.include_router(orgs.router, tags=["orgs"])
 app.include_router(invitations.router, tags=["invitations"])
-app.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
-app.include_router(actions_cache.router, prefix="/repos", tags=["actions-cache"])
+app.include_router(analytics.router, tags=["analytics"])
+app.include_router(actions_cache.router, tags=["actions-cache"])
 app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -12,6 +12,8 @@ def create(
     org_id: int | None = None,
     owner_user_id: int | None = None,
 ) -> GitHubInstallation:
+    if (org_id is None) == (owner_user_id is None):
+        raise ValueError("Exactly one of org_id or owner_user_id must be set")
     token_ref = f"tok_{account_login}"
     row = GitHubInstallation(
         account_login=account_login,

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -9,6 +9,8 @@ def create(
     account_type: str,
     auth_mode: str,
     installation_id: int | None = None,
+    org_id: int | None = None,
+    owner_user_id: int | None = None,
 ) -> GitHubInstallation:
     token_ref = f"tok_{account_login}"
     row = GitHubInstallation(
@@ -17,6 +19,8 @@ def create(
         installation_id=installation_id,
         auth_mode=auth_mode,
         token_ref=token_ref,
+        org_id=org_id,
+        owner_user_id=owner_user_id,
     )
     db.add(row)
     db.commit()
@@ -24,5 +28,19 @@ def create(
     return row
 
 
-def list_all(db: Session) -> list[GitHubInstallation]:
-    return db.query(GitHubInstallation).order_by(GitHubInstallation.created_at.desc()).all()
+def list_for_org(db: Session, org_id: int) -> list[GitHubInstallation]:
+    return (
+        db.query(GitHubInstallation)
+        .filter(GitHubInstallation.org_id == org_id)
+        .order_by(GitHubInstallation.created_at.desc())
+        .all()
+    )
+
+
+def list_for_user(db: Session, owner_user_id: int) -> list[GitHubInstallation]:
+    return (
+        db.query(GitHubInstallation)
+        .filter(GitHubInstallation.owner_user_id == owner_user_id)
+        .order_by(GitHubInstallation.created_at.desc())
+        .all()
+    )

--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -1,0 +1,43 @@
+import secrets
+
+from sqlalchemy.orm import Session
+
+from src.core.db import Invitation
+
+
+def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Invitation:
+    invitation = Invitation(
+        org_id=org_id,
+        email=email,
+        token=secrets.token_urlsafe(32),
+        status="pending",
+        invited_by_user_id=invited_by_user_id,
+    )
+    db.add(invitation)
+    db.commit()
+    db.refresh(invitation)
+    return invitation
+
+
+def get_by_token(db: Session, token: str) -> Invitation | None:
+    return db.query(Invitation).filter(Invitation.token == token).first()
+
+
+def get_by_id_and_org(db: Session, invitation_id: int, org_id: int) -> Invitation | None:
+    return (
+        db.query(Invitation)
+        .filter(Invitation.id == invitation_id, Invitation.org_id == org_id)
+        .first()
+    )
+
+
+def list_for_org(db: Session, org_id: int) -> list[Invitation]:
+    return db.query(Invitation).filter(Invitation.org_id == org_id).order_by(Invitation.created_at.desc()).all()
+
+
+def list_pending_for_email(db: Session, email: str) -> list[Invitation]:
+    return (
+        db.query(Invitation)
+        .filter(Invitation.email.ilike(email), Invitation.status == "pending")
+        .all()
+    )

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+
+from src.core.db import OrgMembership
+
+
+def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
+    return (
+        db.query(OrgMembership)
+        .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+        .first()
+    )
+
+
+def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
+    membership = get(db, org_id, user_id)
+    if membership is not None:
+        return membership
+    membership = OrgMembership(org_id=org_id, user_id=user_id, role=role)
+    db.add(membership)
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def list_for_user(db: Session, user_id: int) -> list[OrgMembership]:
+    return db.query(OrgMembership).filter(OrgMembership.user_id == user_id).all()
+
+
+def list_for_org(db: Session, org_id: int) -> list[OrgMembership]:
+    return db.query(OrgMembership).filter(OrgMembership.org_id == org_id).all()

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import OrgMembership
@@ -17,7 +18,15 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
         return membership
     membership = OrgMembership(org_id=org_id, user_id=user_id, role=role)
     db.add(membership)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same (org_id, user_id) pair.
+        db.rollback()
+        membership = get(db, org_id, user_id)
+        if membership is None:
+            raise
+        return membership
     db.refresh(membership)
     return membership
 

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import Org
@@ -17,6 +18,14 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
         return org
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same github_login (unique constraint).
+        db.rollback()
+        org = get_by_login(db, github_login)
+        if org is None:
+            raise
+        return org
     db.refresh(org)
     return org

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+
+from src.core.db import Org
+
+
+def get_by_login(db: Session, github_login: str) -> Org | None:
+    return db.query(Org).filter(Org.github_login == github_login).first()
+
+
+def get_or_create(db: Session, github_login: str, github_org_id: int | None = None) -> Org:
+    org = get_by_login(db, github_login)
+    if org is not None:
+        if github_org_id is not None and org.github_org_id is None:
+            org.github_org_id = github_org_id
+            db.commit()
+            db.refresh(org)
+        return org
+    org = Org(github_login=github_login, github_org_id=github_org_id)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org

--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_workspace_admin
+from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
+from src.core.rbac import OrgContext, require_org_role
 from src.schemas.cache import CacheClearInput, CacheClearResponse, CacheListInput, CacheListResponse
 from src.services.cache_service import clear
 from src.services.github_client import GitHubClient
@@ -10,19 +11,55 @@ from src.services.github_client import GitHubClient
 router = APIRouter()
 
 
-@router.post("/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
-def list_caches(owner: str, repo: str, payload: CacheListInput, _user: UserOut = Depends(require_workspace_admin)):
+def _list_caches(owner: str, repo: str, payload: CacheListInput) -> CacheListResponse:
     client = GitHubClient(payload.token.get_secret_value())
     data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
     return {"repository": f"{owner}/{repo}", "total": data.get("total_count", 0), "actions_caches": data.get("actions_caches", [])}
 
 
-@router.post("/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
-def clear_caches(
+@router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
+def org_list_caches(
+    org_login: str,
+    owner: str,
+    repo: str,
+    payload: CacheListInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+):
+    if owner != ctx.org.github_login:
+        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    return _list_caches(owner, repo, payload)
+
+
+@router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
+def org_clear_caches(
+    org_login: str,
+    owner: str,
+    repo: str,
+    payload: CacheClearInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    db: Session = Depends(get_db),
+):
+    if owner != ctx.org.github_login:
+        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    return clear(db, owner, repo, payload)
+
+
+@router.post("/me/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
+def personal_list_caches(
+    owner: str,
+    repo: str,
+    payload: CacheListInput,
+    _user: UserOut = Depends(require_auth),
+):
+    return _list_caches(owner, repo, payload)
+
+
+@router.post("/me/repos/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
+def personal_clear_caches(
     owner: str,
     repo: str,
     payload: CacheClearInput,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_workspace_admin),
+    _user: UserOut = Depends(require_auth),
 ):
     return clear(db, owner, repo, payload)

--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.core.db import get_db
 from src.schemas.cache import CacheClearInput, CacheClearResponse, CacheListInput, CacheListResponse
 from src.services.cache_service import clear
@@ -11,7 +11,7 @@ router = APIRouter()
 
 
 @router.post("/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
-def list_caches(owner: str, repo: str, payload: CacheListInput, _user: UserOut = Depends(require_owner)):
+def list_caches(owner: str, repo: str, payload: CacheListInput, _user: UserOut = Depends(require_workspace_admin)):
     client = GitHubClient(payload.token.get_secret_value())
     data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
     return {"repository": f"{owner}/{repo}", "total": data.get("total_count", 0), "actions_caches": data.get("actions_caches", [])}
@@ -23,6 +23,6 @@ def clear_caches(
     repo: str,
     payload: CacheClearInput,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ):
     return clear(db, owner, repo, payload)

--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
-from src.core.rbac import OrgContext, require_org_role
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.schemas.cache import CacheClearInput, CacheClearResponse, CacheListInput, CacheListResponse
 from src.services.cache_service import clear
 from src.services.github_client import GitHubClient
@@ -25,8 +25,7 @@ def org_list_caches(
     payload: CacheListInput,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
 ):
-    if owner != ctx.org.github_login:
-        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    assert_owner_matches_org(owner, ctx)
     return _list_caches(owner, repo, payload)
 
 
@@ -39,8 +38,7 @@ def org_clear_caches(
     ctx: OrgContext = Depends(require_org_role(min_role="admin")),
     db: Session = Depends(get_db),
 ):
-    if owner != ctx.org.github_login:
-        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    assert_owner_matches_org(owner, ctx)
     return clear(db, owner, repo, payload)
 
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -4,7 +4,8 @@ import anyio
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
-from src.core.auth import UserOut, require_workspace_admin
+from src.core.auth import UserOut, require_auth
+from src.core.rbac import OrgContext, require_org_role
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
 from src.services.analytics_service import get_overview
 
@@ -13,13 +14,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/overview", response_model=AnalyticsResponse)
-async def analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(require_workspace_admin)):
+async def _run_overview(payload: AnalyticsInput) -> AnalyticsResponse:
     try:
-        result = await anyio.to_thread.run_sync(
+        return await anyio.to_thread.run_sync(
             lambda: get_overview(owner=payload.owner, token=payload.token.get_secret_value())
         )
-        return result
     except httpx.HTTPStatusError as exc:
         raise HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
     except httpx.RequestError:
@@ -27,3 +26,18 @@ async def analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(r
     except Exception:
         logger.exception("analytics_overview failed")
         raise HTTPException(status_code=500, detail="Internal error")
+
+
+@router.post("/orgs/{org_login}/analytics/overview", response_model=AnalyticsResponse)
+async def org_analytics_overview(
+    payload: AnalyticsInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
+):
+    if payload.owner != ctx.org.github_login:
+        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    return await _run_overview(payload)
+
+
+@router.post("/me/analytics/overview", response_model=AnalyticsResponse)
+async def personal_analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(require_auth)):
+    return await _run_overview(payload)

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -4,7 +4,7 @@ import anyio
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
 from src.services.analytics_service import get_overview
 
@@ -14,7 +14,7 @@ router = APIRouter()
 
 
 @router.post("/overview", response_model=AnalyticsResponse)
-async def analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(require_owner)):
+async def analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(require_workspace_admin)):
     try:
         result = await anyio.to_thread.run_sync(
             lambda: get_overview(owner=payload.owner, token=payload.token.get_secret_value())

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -5,7 +5,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException
 
 from src.core.auth import UserOut, require_auth
-from src.core.rbac import OrgContext, require_org_role
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
 from src.services.analytics_service import get_overview
 
@@ -33,8 +33,7 @@ async def org_analytics_overview(
     payload: AnalyticsInput,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
 ):
-    if payload.owner != ctx.org.github_login:
-        raise HTTPException(status_code=403, detail="owner must match the org in the URL")
+    assert_owner_matches_org(payload.owner, ctx)
     return await _run_overview(payload)
 
 

--- a/apps/api/src/routers/audit.py
+++ b/apps/api/src/routers/audit.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.core.db import AuditLog, get_db
 
 router = APIRouter()
@@ -26,7 +26,7 @@ def list_audit_logs(
     action: str | None = Query(default=None, description="Filter by action type"),
     limit: int = Query(default=100, le=500),
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ):
     q = db.query(AuditLog).order_by(AuditLog.id.desc())
     if action:

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -67,7 +67,7 @@ class MeResponse(BaseModel):
     id: int
     email: str
     name: str | None
-    is_owner: bool
+    is_workspace_admin: bool
     created_at: datetime
 
 
@@ -102,13 +102,13 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
         email=body.email,
         name=body.name,
         password_hash=_hash_password(body.password),
-        is_owner=True,
+        is_workspace_admin=True,
     )
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token(user.id, user.email, user.is_owner, user.name)
-    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_owner=user.is_owner)}
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
@@ -127,13 +127,13 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         email=body.email,
         name=body.name,
         password_hash=_hash_password(body.password),
-        is_owner=False,
+        is_workspace_admin=False,
     )
     db.add(user)
     db.commit()
     db.refresh(user)
-    token = create_access_token(user.id, user.email, user.is_owner, user.name)
-    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_owner=user.is_owner)}
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
 @router.post("/logout")
@@ -149,8 +149,8 @@ def login(body: LoginRequest, db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == body.email).first()
     if not user or not _verify_password(body.password, user.password_hash):
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    token = create_access_token(user.id, user.email, user.is_owner, user.name)
-    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_owner=user.is_owner)}
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
+    return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
 
 @router.get("/me", response_model=MeResponse)

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -113,7 +113,9 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 def register(body: RegisterRequest, db: Session = Depends(get_db)):
-    """Creates a non-owner account. 403 if registration has been disabled by the owner."""
+    """Creates a non-admin account. 409 if setup hasn't run yet; 403 if registration is disabled."""
+    if db.query(User).count() == 0:
+        raise HTTPException(status_code=409, detail="Setup must be completed before registration")
     if get_config("registration_enabled", "true") != "true":
         raise HTTPException(status_code=403, detail="Registration is disabled")
     if len(body.password) < _MIN_PASSWORD_LEN:

--- a/apps/api/src/routers/config.py
+++ b/apps/api/src/routers/config.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from src.core.app_config import _ACCEPTED_KEYS, read_all, set_config
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -25,7 +25,7 @@ class ConfigValue(BaseModel):
 
 
 @router.get("", response_model=dict[str, str])
-def get_all_config(_user: UserOut = Depends(require_owner)) -> dict[str, str]:
+def get_all_config(_user: UserOut = Depends(require_workspace_admin)) -> dict[str, str]:
     """Return all instance config values. Owner only."""
     return read_all()
 
@@ -34,7 +34,7 @@ def get_all_config(_user: UserOut = Depends(require_owner)) -> dict[str, str]:
 def update_config(
     key: str,
     body: ConfigValue,
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ) -> dict[str, str]:
     """Update a single config value. Owner only."""
     if key not in _ACCEPTED_KEYS:

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -92,7 +92,7 @@ def github_callback(
         logger.warning("GitHub OAuth callback failed: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc))
     user = find_or_create_user(db, identity)
-    org_provisioning.sync_org_admin_memberships(db, user, user_token, identity.login)
+    org_provisioning.sync_org_admin_memberships(db, user, user_token)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
     response = RedirectResponse(_ui_redirect_target(), status_code=303)
     set_session_cookie(response, token)

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -46,12 +46,12 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
         db.commit()
         db.refresh(user)
         return user
-    is_owner = db.query(User).count() == 0
+    is_workspace_admin = db.query(User).count() == 0
     user = User(
         email=identity.email,
         name=identity.name,
         password_hash=None,
-        is_owner=is_owner,
+        is_workspace_admin=is_workspace_admin,
         github_user_id=identity.github_user_id,
         github_login=identity.login,
         avatar_url=identity.avatar_url,
@@ -90,7 +90,7 @@ def github_callback(
         logger.warning("GitHub OAuth callback failed: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc))
     user = find_or_create_user(db, identity)
-    token = create_access_token(user.id, user.email, user.is_owner, user.name)
+    token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
     response = RedirectResponse(_ui_redirect_target(), status_code=303)
     set_session_cookie(response, token)
     return response

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -2,11 +2,13 @@
 
   GET /auth/github/login     -> 307 redirect to GitHub's authorize page (with a signed CSRF state)
   GET /auth/github/callback  -> verify state, exchange code, fetch identity, find-or-create the
-                                local user, set the httpOnly session cookie, redirect to the UI
+                                local user, sync verified GitHub org-admin memberships, set the
+                                httpOnly session cookie, redirect to the UI
 
-Find-or-create policy (S1, pre-multi-tenancy): link to an existing user by GitHub id, else by
-verified email (preserving that user's role); otherwise create a new user — the first-ever user
-becomes the owner, mirroring the email/password setup flow.
+Find-or-create policy: link to an existing user by GitHub id, else by verified email (preserving
+that user's role); otherwise create a new user — the first-ever user becomes the workspace admin,
+mirroring the email/password setup flow. See src.services.org_provisioning for how org-admin
+membership is auto-granted based on verified GitHub org-admin status.
 """
 
 import logging
@@ -18,7 +20,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import create_access_token, set_session_cookie
 from src.core.config import settings
 from src.core.db import User, get_db
-from src.services import github_oauth
+from src.services import github_oauth, org_provisioning
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -90,6 +92,7 @@ def github_callback(
         logger.warning("GitHub OAuth callback failed: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc))
     user = find_or_create_user(db, identity)
+    org_provisioning.sync_org_admin_memberships(db, user, user_token, identity.login)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name)
     response = RedirectResponse(_ui_redirect_target(), status_code=303)
     set_session_cookie(response, token)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -12,12 +12,12 @@
   POST /me/installations/sync                connect a personal (User-type) GitHub installation
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
-from src.core.rbac import OrgContext, require_org_role
+from src.core.db import User, get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.repositories import installation_repo
 from src.schemas.installation import (
     InstallationOut,
@@ -42,6 +42,7 @@ def sync_org_installation(
     ctx: OrgContext = Depends(require_org_role(min_role="admin")),
     db: Session = Depends(get_db),
 ):
+    assert_owner_matches_org(payload.account_login, ctx)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,
@@ -67,6 +68,13 @@ def sync_personal_installation(
     user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
+    if payload.account_type == "User":
+        db_user = db.query(User).filter(User.id == user.id).first()
+        if db_user and db_user.github_login and payload.account_login != db_user.github_login:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="account_login must match your own GitHub account",
+            )
     row = installation_repo.create(
         db,
         account_login=payload.account_login,

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -1,8 +1,23 @@
+"""GitHub App installation router.
+
+  GET  /orgs/{org_login}/installations       member: list installations connected to this org
+  POST /orgs/{org_login}/installations/sync  admin: re-sync installation metadata for an
+                                              *existing* org. A brand-new org's first
+                                              installation is only created via the
+                                              auto-provisioning flow (src.services.org_provisioning,
+                                              run at OAuth login) — this endpoint can't bootstrap a
+                                              brand-new Org row since it has no way to verify the
+                                              caller is a real GitHub org admin.
+  GET  /me/installations                     list the current user's personal installations
+  POST /me/installations/sync                connect a personal (User-type) GitHub installation
+"""
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_workspace_admin
+from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
+from src.core.rbac import OrgContext, require_org_role
 from src.repositories import installation_repo
 from src.schemas.installation import (
     InstallationOut,
@@ -13,20 +28,19 @@ from src.schemas.installation import (
 router = APIRouter()
 
 
-@router.get("/github/app/installations", response_model=list[InstallationOut])
-def list_installations(
+@router.get("/orgs/{org_login}/installations", response_model=list[InstallationOut])
+def list_org_installations(
+    ctx: OrgContext = Depends(require_org_role(min_role="member")),
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_workspace_admin),
 ):
-    """Organizations that have installed the Clevis GitHub App (the 'Connected Orgs' list)."""
-    return installation_repo.list_all(db)
+    return installation_repo.list_for_org(db, org_id=ctx.org.id)
 
 
-@router.post("/github/app/installations/sync", response_model=SyncInstallationsResponse)
-def sync_installation(
+@router.post("/orgs/{org_login}/installations/sync", response_model=SyncInstallationsResponse)
+def sync_org_installation(
     payload: SyncInstallationsInput,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_workspace_admin),
 ):
     row = installation_repo.create(
         db,
@@ -34,5 +48,31 @@ def sync_installation(
         account_type=payload.account_type,
         auth_mode=payload.auth_mode,
         installation_id=payload.installation_id,
+        org_id=ctx.org.id,
+    )
+    return {"synced": True, "token_ref": row.token_ref}
+
+
+@router.get("/me/installations", response_model=list[InstallationOut])
+def list_personal_installations(
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    return installation_repo.list_for_user(db, owner_user_id=user.id)
+
+
+@router.post("/me/installations/sync", response_model=SyncInstallationsResponse)
+def sync_personal_installation(
+    payload: SyncInstallationsInput,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    row = installation_repo.create(
+        db,
+        account_login=payload.account_login,
+        account_type=payload.account_type,
+        auth_mode=payload.auth_mode,
+        installation_id=payload.installation_id,
+        owner_user_id=user.id,
     )
     return {"synced": True, "token_ref": row.token_ref}

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.core.db import get_db
 from src.repositories import installation_repo
 from src.schemas.installation import (
@@ -16,7 +16,7 @@ router = APIRouter()
 @router.get("/github/app/installations", response_model=list[InstallationOut])
 def list_installations(
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ):
     """Organizations that have installed the Clevis GitHub App (the 'Connected Orgs' list)."""
     return installation_repo.list_all(db)
@@ -26,7 +26,7 @@ def list_installations(
 def sync_installation(
     payload: SyncInstallationsInput,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ):
     row = installation_repo.create(
         db,

--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -1,0 +1,105 @@
+"""Org invitation router.
+
+  POST   /orgs/{org_login}/invitations             admin: create a pending invite, returns a
+                                                     shareable link (no email is sent)
+  GET    /orgs/{org_login}/invitations             admin: list pending/accepted/revoked invites
+  POST   /orgs/{org_login}/invitations/{id}/revoke admin: revoke a pending invite
+  GET    /invitations/{token}                      unauthenticated: preview an invite by token
+  POST   /invitations/{token}/accept               any authenticated user whose account email
+                                                     case-insensitively matches the invite
+"""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from src.core.auth import UserOut, require_auth
+from src.core.config import settings
+from src.core.db import Org, get_db
+from src.core.rbac import OrgContext, require_org_role
+from src.repositories import invitation_repo, org_membership_repo
+from src.schemas.invitation import (
+    InvitationAcceptResponse,
+    InvitationCreate,
+    InvitationCreateResponse,
+    InvitationOut,
+    InvitationPreview,
+)
+
+router = APIRouter()
+
+
+def _ui_base() -> str:
+    return settings.cors_origins[0] if settings.cors_origins else ""
+
+
+@router.post("/orgs/{org_login}/invitations", response_model=InvitationCreateResponse)
+def create_invitation(
+    body: InvitationCreate,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    invitation = invitation_repo.create(db, org_id=ctx.org.id, email=body.email, invited_by_user_id=user.id)
+    return {
+        "invitation": invitation,
+        "invite_link": f"{_ui_base()}/invite/{invitation.token}",
+    }
+
+
+@router.get("/orgs/{org_login}/invitations", response_model=list[InvitationOut])
+def list_invitations(
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    db: Session = Depends(get_db),
+):
+    return invitation_repo.list_for_org(db, org_id=ctx.org.id)
+
+
+@router.post("/orgs/{org_login}/invitations/{invitation_id}/revoke", response_model=InvitationOut)
+def revoke_invitation(
+    invitation_id: int,
+    ctx: OrgContext = Depends(require_org_role(min_role="admin")),
+    db: Session = Depends(get_db),
+):
+    invitation = invitation_repo.get_by_id_and_org(db, invitation_id=invitation_id, org_id=ctx.org.id)
+    if invitation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    if invitation.status != "pending":
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Invitation is not pending")
+    invitation.status = "revoked"
+    db.commit()
+    db.refresh(invitation)
+    return invitation
+
+
+@router.get("/invitations/{token}", response_model=InvitationPreview)
+def preview_invitation(token: str, db: Session = Depends(get_db)):
+    invitation = invitation_repo.get_by_token(db, token)
+    if invitation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    org = db.query(Org).filter(Org.id == invitation.org_id).first()
+    return {"org_login": org.github_login, "email": invitation.email, "status": invitation.status}
+
+
+@router.post("/invitations/{token}/accept", response_model=InvitationAcceptResponse)
+def accept_invitation(
+    token: str,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    invitation = invitation_repo.get_by_token(db, token)
+    if invitation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    if invitation.status != "pending":
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Invitation is no longer pending")
+    if invitation.email.lower() != user.email.lower():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invitation email does not match account")
+
+    membership = org_membership_repo.get_or_create(db, org_id=invitation.org_id, user_id=user.id, role="member")
+    invitation.status = "accepted"
+    invitation.accepted_at = datetime.now(timezone.utc)
+    db.commit()
+
+    org = db.query(Org).filter(Org.id == invitation.org_id).first()
+    return {"org_login": org.github_login, "role": membership.role}

--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -79,7 +79,7 @@ def preview_invitation(token: str, db: Session = Depends(get_db)):
     if invitation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
     org = db.query(Org).filter(Org.id == invitation.org_id).first()
-    return {"org_login": org.github_login, "email": invitation.email, "status": invitation.status}
+    return {"org_login": org.github_login, "status": invitation.status}
 
 
 @router.post("/invitations/{token}/accept", response_model=InvitationAcceptResponse)

--- a/apps/api/src/routers/jobs.py
+++ b/apps/api/src/routers/jobs.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.core.db import get_db
 from src.repositories import job_repo
 from src.schemas.job import JobOut
@@ -10,5 +10,5 @@ router = APIRouter()
 
 
 @router.get("", response_model=list[JobOut])
-def jobs(db: Session = Depends(get_db), _user: UserOut = Depends(require_owner)):
+def jobs(db: Session = Depends(get_db), _user: UserOut = Depends(require_workspace_admin)):
     return job_repo.list_jobs(db)

--- a/apps/api/src/routers/orgs.py
+++ b/apps/api/src/routers/orgs.py
@@ -1,0 +1,22 @@
+"""GET /me/orgs — the current user's org memberships, for the UI's org/personal context switcher."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import Org, get_db
+from src.repositories import org_membership_repo
+from src.schemas.org import MyOrgMembershipOut
+
+router = APIRouter()
+
+
+@router.get("/me/orgs", response_model=list[MyOrgMembershipOut])
+def list_my_orgs(user: UserOut = Depends(require_auth), db: Session = Depends(get_db)):
+    memberships = org_membership_repo.list_for_user(db, user_id=user.id)
+    org_by_id = {org.id: org for org in db.query(Org).filter(Org.id.in_([m.org_id for m in memberships])).all()}
+    return [
+        {"org_login": org_by_id[m.org_id].github_login, "role": m.role}
+        for m in memberships
+        if m.org_id in org_by_id
+    ]

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -50,7 +50,7 @@ def list_tokens(
     db: Session = Depends(get_db),
     _user: UserOut = Depends(require_workspace_admin),
 ) -> list[TokenMeta]:
-    """Return metadata for all saved tokens (never the raw token). Owner only."""
+    """Return metadata for all saved tokens (never the raw token). Workspace admin only."""
     rows = db.query(SavedToken).order_by(SavedToken.org).all()
     return [TokenMeta.model_validate(r) for r in rows]
 
@@ -62,7 +62,7 @@ def upsert_token(
     db: Session = Depends(get_db),
     _user: UserOut = Depends(require_workspace_admin),
 ) -> TokenMeta:
-    """Save or update the token for an org (encrypted at rest). Owner only."""
+    """Save or update the token for an org (encrypted at rest). Workspace admin only."""
     encrypted = encrypt_job_token(
         body.token.get_secret_value(),
         settings.job_secret_key.get_secret_value(),
@@ -85,7 +85,7 @@ def resolve_token(
     db: Session = Depends(get_db),
     _user: UserOut = Depends(require_workspace_admin),
 ) -> VerifyTokenResponse:
-    """Decrypt and return the saved token for an org. Returns raw secret — owner only."""
+    """Decrypt and return the saved token for an org. Returns raw secret — workspace admin only."""
     row = db.query(SavedToken).filter_by(org=body.org).first()
     if not row:
         raise HTTPException(status_code=404, detail="No saved token for this org")
@@ -102,7 +102,7 @@ def delete_token(
     db: Session = Depends(get_db),
     _user: UserOut = Depends(require_workspace_admin),
 ) -> None:
-    """Remove a saved token. Owner only."""
+    """Remove a saved token. Workspace admin only."""
     row = db.query(SavedToken).filter_by(org=org).first()
     if not row:
         raise HTTPException(status_code=404, detail="No saved token for this org")

--- a/apps/api/src/routers/tokens.py
+++ b/apps/api/src/routers/tokens.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, SecretStr
 from sqlalchemy.orm import Session
 
 from src.core._crypto import decrypt_job_token, encrypt_job_token
-from src.core.auth import UserOut, require_owner
+from src.core.auth import UserOut, require_workspace_admin
 from src.core.config import settings
 from src.core.db import SavedToken, get_db
 
@@ -48,7 +48,7 @@ class VerifyTokenResponse(BaseModel):
 @router.get("", response_model=list[TokenMeta])
 def list_tokens(
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ) -> list[TokenMeta]:
     """Return metadata for all saved tokens (never the raw token). Owner only."""
     rows = db.query(SavedToken).order_by(SavedToken.org).all()
@@ -60,7 +60,7 @@ def upsert_token(
     org: str,
     body: UpsertTokenRequest,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ) -> TokenMeta:
     """Save or update the token for an org (encrypted at rest). Owner only."""
     encrypted = encrypt_job_token(
@@ -83,7 +83,7 @@ def upsert_token(
 def resolve_token(
     body: VerifyTokenRequest,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ) -> VerifyTokenResponse:
     """Decrypt and return the saved token for an org. Returns raw secret — owner only."""
     row = db.query(SavedToken).filter_by(org=body.org).first()
@@ -100,7 +100,7 @@ def resolve_token(
 def delete_token(
     org: str,
     db: Session = Depends(get_db),
-    _user: UserOut = Depends(require_owner),
+    _user: UserOut = Depends(require_workspace_admin),
 ) -> None:
     """Remove a saved token. Owner only."""
     row = db.query(SavedToken).filter_by(org=org).first()

--- a/apps/api/src/schemas/invitation.py
+++ b/apps/api/src/schemas/invitation.py
@@ -1,6 +1,9 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr
+
+InvitationStatus = Literal["pending", "accepted", "revoked"]
 
 
 class InvitationCreate(BaseModel):
@@ -13,7 +16,7 @@ class InvitationOut(BaseModel):
     id: int
     org_id: int
     email: str
-    status: str
+    status: InvitationStatus
     created_at: datetime
     accepted_at: datetime | None
 
@@ -24,9 +27,10 @@ class InvitationCreateResponse(BaseModel):
 
 
 class InvitationPreview(BaseModel):
+    # Deliberately excludes the invitee's email — this endpoint is unauthenticated
+    # and invite links are shareable, so the email shouldn't be disclosed pre-auth.
     org_login: str
-    email: str
-    status: str
+    status: InvitationStatus
 
 
 class InvitationAcceptResponse(BaseModel):

--- a/apps/api/src/schemas/invitation.py
+++ b/apps/api/src/schemas/invitation.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, EmailStr
+
+
+class InvitationCreate(BaseModel):
+    email: EmailStr
+
+
+class InvitationOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    org_id: int
+    email: str
+    status: str
+    created_at: datetime
+    accepted_at: datetime | None
+
+
+class InvitationCreateResponse(BaseModel):
+    invitation: InvitationOut
+    invite_link: str
+
+
+class InvitationPreview(BaseModel):
+    org_login: str
+    email: str
+    status: str
+
+
+class InvitationAcceptResponse(BaseModel):
+    org_login: str
+    role: str

--- a/apps/api/src/schemas/org.py
+++ b/apps/api/src/schemas/org.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class MyOrgMembershipOut(BaseModel):
+    org_login: str
+    role: str

--- a/apps/api/src/services/github_oauth.py
+++ b/apps/api/src/services/github_oauth.py
@@ -149,11 +149,11 @@ class GitHubOrgMembership:
     role: str  # "admin" | "member"
 
 
-def list_user_orgs(user_token: str) -> list[GitHubOrgMembership]:
-    """List the organizations the authenticated user belongs to (needs read:org scope).
-
-    Does not include per-org role — GitHub's /user/orgs response omits it. Callers should
-    follow up with get_org_membership_role for orgs they actually care about.
+def list_user_org_memberships(user_token: str) -> list[GitHubOrgMembership]:
+    """List the authenticated user's active org memberships, role included (needs read:org
+    scope). One endpoint replaces the old list-orgs-then-check-each-role N+1 pattern —
+    GET /user/memberships/orgs returns the caller's role per org in a single (paginated)
+    call. Follows the Link header so callers in >100 orgs still get the full list.
     """
     api = settings.github_api_base.rstrip("/")
     headers = {
@@ -161,26 +161,17 @@ def list_user_orgs(user_token: str) -> list[GitHubOrgMembership]:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
+    memberships: list[GitHubOrgMembership] = []
+    url = f"{api}/user/memberships/orgs?state=active&per_page=100"
     with httpx.Client(timeout=20) as client:
-        resp = client.get(f"{api}/user/orgs", headers=headers)
-        resp.raise_for_status()
-    return [GitHubOrgMembership(github_org_id=o["id"], login=o["login"], role="") for o in resp.json()]
-
-
-def get_org_membership_role(user_token: str, org_login: str, username: str) -> str | None:
-    """Returns the caller's role ("admin" | "member") in org_login, or None if not a member."""
-    api = settings.github_api_base.rstrip("/")
-    headers = {
-        "Authorization": f"Bearer {user_token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    with httpx.Client(timeout=20) as client:
-        resp = client.get(f"{api}/orgs/{org_login}/memberships/{username}", headers=headers)
-    if resp.status_code == 404:
-        return None
-    resp.raise_for_status()
-    return resp.json().get("role")
+        while url:
+            resp = client.get(url, headers=headers)
+            resp.raise_for_status()
+            for m in resp.json():
+                org = m["organization"]
+                memberships.append(GitHubOrgMembership(github_org_id=org["id"], login=org["login"], role=m["role"]))
+            url = resp.links.get("next", {}).get("url")
+    return memberships
 
 
 def _primary_verified_email(emails: list[dict]) -> str | None:

--- a/apps/api/src/services/github_oauth.py
+++ b/apps/api/src/services/github_oauth.py
@@ -22,7 +22,7 @@ import jwt
 
 from src.core.config import settings
 
-_OAUTH_SCOPE = "read:user user:email"
+_OAUTH_SCOPE = "read:user user:email read:org"
 _STATE_TTL_SECONDS = 600  # 10 minutes between /login and /callback
 _STATE_ALG = "HS256"
 _STATE_PURPOSE = "github_oauth"
@@ -140,6 +140,47 @@ def fetch_identity(user_token: str) -> GitHubIdentity:
         email=email,
         avatar_url=user.get("avatar_url"),
     )
+
+
+@dataclass
+class GitHubOrgMembership:
+    github_org_id: int
+    login: str
+    role: str  # "admin" | "member"
+
+
+def list_user_orgs(user_token: str) -> list[GitHubOrgMembership]:
+    """List the organizations the authenticated user belongs to (needs read:org scope).
+
+    Does not include per-org role — GitHub's /user/orgs response omits it. Callers should
+    follow up with get_org_membership_role for orgs they actually care about.
+    """
+    api = settings.github_api_base.rstrip("/")
+    headers = {
+        "Authorization": f"Bearer {user_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.get(f"{api}/user/orgs", headers=headers)
+        resp.raise_for_status()
+    return [GitHubOrgMembership(github_org_id=o["id"], login=o["login"], role="") for o in resp.json()]
+
+
+def get_org_membership_role(user_token: str, org_login: str, username: str) -> str | None:
+    """Returns the caller's role ("admin" | "member") in org_login, or None if not a member."""
+    api = settings.github_api_base.rstrip("/")
+    headers = {
+        "Authorization": f"Bearer {user_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.get(f"{api}/orgs/{org_login}/memberships/{username}", headers=headers)
+    if resp.status_code == 404:
+        return None
+    resp.raise_for_status()
+    return resp.json().get("role")
 
 
 def _primary_verified_email(emails: list[dict]) -> str | None:

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -2,12 +2,12 @@
 Auto-provisions Clevis orgs/admin-memberships from verified GitHub org-admin status.
 
 Runs at OAuth login time, where a live user token is transiently available (see
-src/routers/github_auth.py). For every GitHub org the user belongs to, checks whether
-they're an org admin there; if so, get-or-creates the Clevis Org and an admin
-OrgMembership for them. This covers both "first person to connect this org" and "another
-verified GitHub admin signing in later" — GitHub already vouches for admins, so no invite
-is required. Non-admin GitHub members are never touched here; they only gain access
-through the explicit invite-accept flow.
+src/routers/github_auth.py). Fetches the user's org memberships (role included) from
+GitHub in a single call; for every org where they're an admin, get-or-creates the Clevis
+Org and an admin OrgMembership for them. This covers both "first person to connect this
+org" and "another verified GitHub admin signing in later" — GitHub already vouches for
+admins, so no invite is required. Non-admin GitHub members are never touched here; they
+only gain access through the explicit invite-accept flow.
 
 Best-effort: any GitHub API failure is logged and swallowed so it never blocks login.
 """
@@ -25,23 +25,17 @@ from src.services import github_oauth
 logger = logging.getLogger(__name__)
 
 
-def sync_org_admin_memberships(db: Session, user: User, user_token: str, github_username: str) -> None:
+def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None:
     try:
-        github_orgs = github_oauth.list_user_orgs(user_token)
+        memberships = github_oauth.list_user_org_memberships(user_token)
     except httpx.HTTPError:
-        logger.warning("Failed to list GitHub orgs for user %s during org provisioning", user.id, exc_info=True)
+        logger.warning(
+            "Failed to list GitHub org memberships for user %s during org provisioning", user.id, exc_info=True
+        )
         return
 
-    for gh_org in github_orgs:
-        try:
-            role = github_oauth.get_org_membership_role(user_token, gh_org.login, github_username)
-        except httpx.HTTPError:
-            logger.warning(
-                "Failed to check GitHub org membership role for %s in %s", github_username, gh_org.login,
-                exc_info=True,
-            )
+    for gh_membership in memberships:
+        if gh_membership.role != "admin":
             continue
-        if role != "admin":
-            continue
-        org = org_repo.get_or_create(db, github_login=gh_org.login, github_org_id=gh_org.github_org_id)
+        org = org_repo.get_or_create(db, github_login=gh_membership.login, github_org_id=gh_membership.github_org_id)
         org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -1,0 +1,47 @@
+"""
+Auto-provisions Clevis orgs/admin-memberships from verified GitHub org-admin status.
+
+Runs at OAuth login time, where a live user token is transiently available (see
+src/routers/github_auth.py). For every GitHub org the user belongs to, checks whether
+they're an org admin there; if so, get-or-creates the Clevis Org and an admin
+OrgMembership for them. This covers both "first person to connect this org" and "another
+verified GitHub admin signing in later" — GitHub already vouches for admins, so no invite
+is required. Non-admin GitHub members are never touched here; they only gain access
+through the explicit invite-accept flow.
+
+Best-effort: any GitHub API failure is logged and swallowed so it never blocks login.
+"""
+
+import logging
+
+import httpx
+
+from sqlalchemy.orm import Session
+
+from src.core.db import User
+from src.repositories import org_membership_repo, org_repo
+from src.services import github_oauth
+
+logger = logging.getLogger(__name__)
+
+
+def sync_org_admin_memberships(db: Session, user: User, user_token: str, github_username: str) -> None:
+    try:
+        github_orgs = github_oauth.list_user_orgs(user_token)
+    except httpx.HTTPError:
+        logger.warning("Failed to list GitHub orgs for user %s during org provisioning", user.id, exc_info=True)
+        return
+
+    for gh_org in github_orgs:
+        try:
+            role = github_oauth.get_org_membership_role(user_token, gh_org.login, github_username)
+        except httpx.HTTPError:
+            logger.warning(
+                "Failed to check GitHub org membership role for %s in %s", github_username, gh_org.login,
+                exc_info=True,
+            )
+            continue
+        if role != "admin":
+            continue
+        org = org_repo.get_or_create(db, github_login=gh_org.login, github_org_id=gh_org.github_org_id)
+        org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -6,10 +6,17 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
 from src.routers.analytics import router
 
-_MOCK_USER = UserOut(id=1, email="test@example.com", name=None, is_workspace_admin=True)
-_MOCK_NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_workspace_admin=False)
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
 MOCK_OVERVIEW = {
     "owner": "acme",
@@ -30,10 +37,16 @@ MOCK_OVERVIEW = {
 
 
 @pytest.fixture()
-def app():
+def mock_user(db):
+    return _make_user(db, "test@example.com")
+
+
+@pytest.fixture()
+def app(db, mock_user):
     a = FastAPI()
-    a.dependency_overrides[require_auth] = lambda: _MOCK_USER
-    a.include_router(router, prefix="/analytics")
+    a.dependency_overrides[require_auth] = lambda: mock_user
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
     return a
 
 
@@ -42,27 +55,19 @@ def http(app):
     return TestClient(app)
 
 
-@pytest.fixture()
-def non_owner_http():
+def test_personal_overview_requires_auth(db):
     a = FastAPI()
-    a.dependency_overrides[require_auth] = lambda: _MOCK_NON_OWNER
-    a.include_router(router, prefix="/analytics")
-    return TestClient(a)
-
-
-def test_overview_non_owner_forbidden(non_owner_http):
-    resp = non_owner_http.post(
-        "/analytics/overview",
-        json={"owner": "acme", "token": "ghp_test"},
-    )
-    assert resp.status_code == 403
+    a.dependency_overrides[get_db] = lambda: db
+    a.include_router(router)
+    resp = TestClient(a).post("/me/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 401
 
 
 def test_overview_returns_expected_shape(http):
     # Mock get_overview directly; anyio.to_thread.run_sync runs the lambda for real
     with patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW):
         resp = http.post(
-            "/analytics/overview",
+            "/me/analytics/overview",
             json={"owner": "acme", "token": "ghp_test"},
         )
     assert resp.status_code == 200
@@ -83,7 +88,7 @@ def test_overview_github_http_error_returns_400(http):
         ),
     ):
         resp = http.post(
-            "/analytics/overview",
+            "/me/analytics/overview",
             json={"owner": "acme", "token": "ghp_test"},
         )
     assert resp.status_code == 400
@@ -98,7 +103,7 @@ def test_overview_request_error_returns_503(http):
         side_effect=httpx.RequestError("timeout"),
     ):
         resp = http.post(
-            "/analytics/overview",
+            "/me/analytics/overview",
             json={"owner": "acme", "token": "ghp_test"},
         )
     assert resp.status_code == 503
@@ -113,9 +118,32 @@ def test_overview_unexpected_exception_logs_and_returns_500(http):
         patch("src.routers.analytics.logger") as mock_logger,
     ):
         resp = http.post(
-            "/analytics/overview",
+            "/me/analytics/overview",
             json={"owner": "acme", "token": "ghp_test"},
         )
     assert resp.status_code == 500
     # B-10: exception must be logged, not silently swallowed
     mock_logger.exception.assert_called_once_with("analytics_overview failed")
+
+
+# ── org-scoped ────────────────────────────────────────────────────────────────
+
+def test_org_overview_outsider_forbidden(http, db):
+    org_repo.get_or_create(db, github_login="acme")
+    resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 403
+
+
+def test_org_overview_member_ok(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    with patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW):
+        resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme", "token": "ghp_test"})
+    assert resp.status_code == 200
+
+
+def test_org_overview_owner_mismatch_forbidden(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    resp = http.post("/orgs/acme/analytics/overview", json={"owner": "someone-else", "token": "ghp_test"})
+    assert resp.status_code == 403

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -8,8 +8,8 @@ from fastapi.testclient import TestClient
 from src.core.auth import UserOut, require_auth
 from src.routers.analytics import router
 
-_MOCK_USER = UserOut(id=1, email="test@example.com", name=None, is_owner=True)
-_MOCK_NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_owner=False)
+_MOCK_USER = UserOut(id=1, email="test@example.com", name=None, is_workspace_admin=True)
+_MOCK_NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_workspace_admin=False)
 
 MOCK_OVERVIEW = {
     "owner": "acme",

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -84,17 +84,17 @@ def test_register_creates_non_owner(auth_client):
     assert body["user"]["email"] == "member@example.com"
 
 
-def test_register_before_setup_still_creates_non_owner(auth_client):
-    """Registration doesn't require setup to have run first; the first-ever user via /setup
-    becomes owner, but a /register call before that just makes a regular account."""
+def test_register_before_setup_rejected(auth_client):
+    """/auth/setup must run first to create the workspace admin — registering before that
+    would leave the instance with no admin, since /setup 409s once any user exists."""
     resp = auth_client.post(
         "/auth/register", json={"email": "first@example.com", "password": "supersecret1234"}
     )
-    assert resp.status_code == 201
-    assert resp.json()["user"]["is_workspace_admin"] is False
+    assert resp.status_code == 409
 
 
 def test_register_rejects_short_password(auth_client):
+    _setup_owner(auth_client)
     resp = auth_client.post("/auth/register", json={"email": "a@b.com", "password": "tooshort"})
     assert resp.status_code == 422
 
@@ -108,6 +108,7 @@ def test_register_rejects_duplicate_email(auth_client):
 
 
 def test_register_disabled_returns_403(auth_client):
+    _setup_owner(auth_client)
     with patch("src.routers.auth.get_config", return_value="false"):
         resp = auth_client.post(
             "/auth/register", json={"email": "blocked@example.com", "password": "supersecret1234"}

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src.core.auth import UserOut, require_auth, require_owner
+from src.core.auth import UserOut, require_auth, require_workspace_admin
 from src.core.db import get_db
 from src.routers.auth import router as auth_router
 from src.routers.config import router as config_router
@@ -53,7 +53,7 @@ def test_setup_required_with_user(auth_client):
 def test_setup_returns_token_and_owner(auth_client):
     body = _setup_owner(auth_client)
     assert "access_token" in body
-    assert body["user"]["is_owner"] is True
+    assert body["user"]["is_workspace_admin"] is True
     assert body["user"]["email"] == "owner@example.com"
 
 
@@ -80,7 +80,7 @@ def test_register_creates_non_owner(auth_client):
     assert resp.status_code == 201
     body = resp.json()
     assert "access_token" in body
-    assert body["user"]["is_owner"] is False
+    assert body["user"]["is_workspace_admin"] is False
     assert body["user"]["email"] == "member@example.com"
 
 
@@ -91,7 +91,7 @@ def test_register_before_setup_still_creates_non_owner(auth_client):
         "/auth/register", json={"email": "first@example.com", "password": "supersecret1234"}
     )
     assert resp.status_code == 201
-    assert resp.json()["user"]["is_owner"] is False
+    assert resp.json()["user"]["is_workspace_admin"] is False
 
 
 def test_register_rejects_short_password(auth_client):
@@ -154,7 +154,7 @@ def test_me_returns_profile(auth_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["email"] == "owner@example.com"
-    assert data["is_owner"] is True
+    assert data["is_workspace_admin"] is True
 
 
 def test_patch_me_unauthenticated(auth_client):
@@ -175,8 +175,8 @@ def test_patch_me_updates_name(auth_client):
 
 # ── Config router ─────────────────────────────────────────────────────────────
 
-_OWNER = UserOut(id=1, email="owner@example.com", name=None, is_owner=True)
-_VIEWER = UserOut(id=2, email="viewer@example.com", name=None, is_owner=False)
+_OWNER = UserOut(id=1, email="owner@example.com", name=None, is_workspace_admin=True)
+_VIEWER = UserOut(id=2, email="viewer@example.com", name=None, is_workspace_admin=False)
 
 _MOCK_CONFIG = {
     "worker_poll_seconds": "5",
@@ -205,7 +205,7 @@ def config_client_owner():
     """Authenticated as the owner."""
     a = FastAPI()
     a.dependency_overrides[require_auth] = lambda: _OWNER
-    a.dependency_overrides[require_owner] = lambda: _OWNER
+    a.dependency_overrides[require_workspace_admin] = lambda: _OWNER
     a.include_router(config_router, prefix="/config")
     return TestClient(a)
 

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -93,6 +93,7 @@ def test_callback_creates_user_and_sets_cookie(gh_client, db):
         patch("src.routers.github_auth.github_oauth.verify_state", return_value=True),
         patch("src.routers.github_auth.github_oauth.exchange_code_for_token", return_value="gho_x"),
         patch("src.routers.github_auth.github_oauth.fetch_identity", return_value=_identity()),
+        patch("src.routers.github_auth.org_provisioning.sync_org_admin_memberships", return_value=None),
     ):
         resp = gh_client.get("/auth/github/callback?code=c&state=s", follow_redirects=False)
     assert resp.status_code == 303

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -43,7 +43,7 @@ def _identity(**kw) -> GitHubIdentity:
 
 def test_first_user_becomes_owner(db):
     user = find_or_create_user(db, _identity())
-    assert user.is_owner is True
+    assert user.is_workspace_admin is True
     assert user.github_user_id == 1001
     assert user.password_hash is None
 
@@ -51,18 +51,18 @@ def test_first_user_becomes_owner(db):
 def test_second_user_is_member(db):
     find_or_create_user(db, _identity())
     second = find_or_create_user(db, _identity(github_user_id=2002, login="hubot", email="hubot@example.com"))
-    assert second.is_owner is False
+    assert second.is_workspace_admin is False
 
 
 def test_links_existing_email_user_and_keeps_role(db):
-    existing = User(email="owner@example.com", name="Owner", password_hash="x", is_owner=True)
+    existing = User(email="owner@example.com", name="Owner", password_hash="x", is_workspace_admin=True)
     db.add(existing)
     db.commit()
     db.refresh(existing)
     linked = find_or_create_user(db, _identity(github_user_id=555, email="owner@example.com"))
     assert linked.id == existing.id
     assert linked.github_user_id == 555
-    assert linked.is_owner is True
+    assert linked.is_workspace_admin is True
 
 
 def test_idempotent_by_github_id(db):

--- a/apps/api/tests/test_github_oauth.py
+++ b/apps/api/tests/test_github_oauth.py
@@ -41,7 +41,7 @@ def test_build_authorize_url(oauth_configured):
     qs = parse_qs(parsed.query)
     assert qs["client_id"] == [_CLIENT_ID]
     assert qs["redirect_uri"] == [_REDIRECT]
-    assert qs["scope"] == ["read:user user:email"]
+    assert qs["scope"] == ["read:user user:email read:org"]
     assert qs["state"] == ["st"]
 
 

--- a/apps/api/tests/test_github_oauth.py
+++ b/apps/api/tests/test_github_oauth.py
@@ -116,6 +116,34 @@ def test_fetch_identity_falls_back_to_emails_endpoint():
     assert client.get.call_count == 2
 
 
+def test_list_user_org_memberships_follows_pagination():
+    page1 = MagicMock(
+        links={"next": {"url": "https://api.github.com/user/memberships/orgs?page=2"}},
+        json=MagicMock(
+            return_value=[
+                {"role": "admin", "organization": {"id": 1, "login": "acme"}},
+            ]
+        ),
+    )
+    page2 = MagicMock(
+        links={},
+        json=MagicMock(
+            return_value=[
+                {"role": "member", "organization": {"id": 2, "login": "other-org"}},
+            ]
+        ),
+    )
+    with patch("src.services.github_oauth.httpx.Client") as mock_cls:
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.get = MagicMock(side_effect=[page1, page2])
+        mock_cls.return_value = client
+        memberships = github_oauth.list_user_org_memberships("gho_x")
+    assert client.get.call_count == 2
+    assert [(m.login, m.role) for m in memberships] == [("acme", "admin"), ("other-org", "member")]
+
+
 def test_not_configured_raises(monkeypatch):
     # Force unconfigured regardless of the ambient .env (a real App may be configured locally).
     monkeypatch.setattr(settings, "github_app_client_id", None)

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -9,8 +9,8 @@ from src.core.db import get_db
 from src.repositories import installation_repo
 from src.routers.installations import router as inst_router
 
-_USER = UserOut(id=1, email="u@e.com", name=None, is_owner=True)
-_NON_OWNER = UserOut(id=2, email="member@e.com", name=None, is_owner=False)
+_USER = UserOut(id=1, email="u@e.com", name=None, is_workspace_admin=True)
+_NON_OWNER = UserOut(id=2, email="member@e.com", name=None, is_workspace_admin=False)
 
 
 @pytest.fixture()

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -1,4 +1,4 @@
-"""Tests for the connected-orgs (GitHub App installations) list endpoint."""
+"""Tests for org-scoped and personal installation endpoints."""
 
 import pytest
 from fastapi import FastAPI
@@ -6,57 +6,95 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
-from src.repositories import installation_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.installations import router as inst_router
 
-_USER = UserOut(id=1, email="u@e.com", name=None, is_workspace_admin=True)
-_NON_OWNER = UserOut(id=2, email="member@e.com", name=None, is_workspace_admin=False)
+_ADMIN = UserOut(id=1, email="admin@e.com", name=None, is_workspace_admin=False)
+_MEMBER = UserOut(id=2, email="member@e.com", name=None, is_workspace_admin=False)
+_OUTSIDER = UserOut(id=3, email="outsider@e.com", name=None, is_workspace_admin=False)
 
 
-@pytest.fixture()
-def inst_client(db):
+def _client(db, user):
     app = FastAPI()
     app.include_router(inst_router)
     app.dependency_overrides[get_db] = lambda: db
-    app.dependency_overrides[require_auth] = lambda: _USER
+    app.dependency_overrides[require_auth] = lambda: user
     return TestClient(app)
 
 
 @pytest.fixture()
-def inst_client_non_owner(db):
-    app = FastAPI()
-    app.include_router(inst_router)
-    app.dependency_overrides[get_db] = lambda: db
-    app.dependency_overrides[require_auth] = lambda: _NON_OWNER
-    return TestClient(app)
+def acme_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_ADMIN.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_MEMBER.id, role="member")
+    return org
 
 
-def test_list_installations_empty(inst_client):
-    resp = inst_client.get("/github/app/installations")
+def test_list_org_installations_empty(db, acme_org):
+    resp = _client(db, _ADMIN).get("/orgs/acme/installations")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
-def test_list_installations_returns_rows(inst_client, db):
+def test_list_org_installations_returns_rows(db, acme_org):
     installation_repo.create(
-        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org.id
     )
-    resp = inst_client.get("/github/app/installations")
+    resp = _client(db, _MEMBER).get("/orgs/acme/installations")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
     assert data[0]["account_login"] == "acme"
-    assert data[0]["installation_id"] == 42
 
 
-def test_list_installations_requires_auth(db):
+def test_list_org_installations_outsider_forbidden(db, acme_org):
+    resp = _client(db, _OUTSIDER).get("/orgs/acme/installations")
+    assert resp.status_code == 403
+
+
+def test_list_org_installations_requires_auth(db, acme_org):
     app = FastAPI()
     app.include_router(inst_router)
     app.dependency_overrides[get_db] = lambda: db
-    resp = TestClient(app).get("/github/app/installations")
+    resp = TestClient(app).get("/orgs/acme/installations")
     assert resp.status_code == 401
 
 
-def test_list_installations_non_owner_forbidden(inst_client_non_owner):
-    resp = inst_client_non_owner.get("/github/app/installations")
+def test_sync_org_installation_requires_admin(db, acme_org):
+    resp = _client(db, _MEMBER).post(
+        "/orgs/acme/installations/sync",
+        json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+    )
     assert resp.status_code == 403
+
+
+def test_sync_org_installation_admin_ok(db, acme_org):
+    resp = _client(db, _ADMIN).post(
+        "/orgs/acme/installations/sync",
+        json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["synced"] is True
+
+
+def test_personal_installations_scoped_to_self(db):
+    installation_repo.create(
+        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=1, owner_user_id=_MEMBER.id
+    )
+    installation_repo.create(
+        db, account_login="someoneelse", account_type="User", auth_mode="app", installation_id=2, owner_user_id=_OUTSIDER.id
+    )
+    resp = _client(db, _MEMBER).get("/me/installations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["account_login"] == "shabnam"
+
+
+def test_sync_personal_installation(db):
+    resp = _client(db, _MEMBER).post(
+        "/me/installations/sync",
+        json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["synced"] is True

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -5,13 +5,19 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
+from src.core.db import User, get_db
 from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.installations import router as inst_router
 
-_ADMIN = UserOut(id=1, email="admin@e.com", name=None, is_workspace_admin=False)
-_MEMBER = UserOut(id=2, email="member@e.com", name=None, is_workspace_admin=False)
-_OUTSIDER = UserOut(id=3, email="outsider@e.com", name=None, is_workspace_admin=False)
+_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
 
 def _client(db, user):
@@ -24,23 +30,30 @@ def _client(db, user):
 
 @pytest.fixture()
 def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    member = _make_user(db, "member@e.com")
     org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_ADMIN.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_MEMBER.id, role="member")
-    return org
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return {"org": org, "admin": admin, "member": member}
 
 
 def test_list_org_installations_empty(db, acme_org):
-    resp = _client(db, _ADMIN).get("/orgs/acme/installations")
+    resp = _client(db, acme_org["admin"]).get("/orgs/acme/installations")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
 def test_list_org_installations_returns_rows(db, acme_org):
     installation_repo.create(
-        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=acme_org.id
+        db,
+        account_login="acme",
+        account_type="Organization",
+        auth_mode="app",
+        installation_id=42,
+        org_id=acme_org["org"].id,
     )
-    resp = _client(db, _MEMBER).get("/orgs/acme/installations")
+    resp = _client(db, acme_org["member"]).get("/orgs/acme/installations")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
@@ -61,7 +74,7 @@ def test_list_org_installations_requires_auth(db, acme_org):
 
 
 def test_sync_org_installation_requires_admin(db, acme_org):
-    resp = _client(db, _MEMBER).post(
+    resp = _client(db, acme_org["member"]).post(
         "/orgs/acme/installations/sync",
         json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
     )
@@ -69,7 +82,7 @@ def test_sync_org_installation_requires_admin(db, acme_org):
 
 
 def test_sync_org_installation_admin_ok(db, acme_org):
-    resp = _client(db, _ADMIN).post(
+    resp = _client(db, acme_org["admin"]).post(
         "/orgs/acme/installations/sync",
         json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
     )
@@ -78,13 +91,20 @@ def test_sync_org_installation_admin_ok(db, acme_org):
 
 
 def test_personal_installations_scoped_to_self(db):
+    me = _make_user(db, "shabnam@e.com")
+    someone_else = _make_user(db, "someoneelse@e.com")
     installation_repo.create(
-        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=1, owner_user_id=_MEMBER.id
+        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=1, owner_user_id=me.id
     )
     installation_repo.create(
-        db, account_login="someoneelse", account_type="User", auth_mode="app", installation_id=2, owner_user_id=_OUTSIDER.id
+        db,
+        account_login="someoneelse",
+        account_type="User",
+        auth_mode="app",
+        installation_id=2,
+        owner_user_id=someone_else.id,
     )
-    resp = _client(db, _MEMBER).get("/me/installations")
+    resp = _client(db, me).get("/me/installations")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 1
@@ -92,7 +112,8 @@ def test_personal_installations_scoped_to_self(db):
 
 
 def test_sync_personal_installation(db):
-    resp = _client(db, _MEMBER).post(
+    me = _make_user(db, "shabnam@e.com")
+    resp = _client(db, me).post(
         "/me/installations/sync",
         json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
     )

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -1,0 +1,108 @@
+"""Tests for the org invitation create/list/revoke/accept flow."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
+from src.routers.invitations import router as invitations_router
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    member = _make_user(db, "member@e.com")
+    invitee = _make_user(db, "bob@acme.com")
+    wrong_email = _make_user(db, "carol@acme.com")
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return {"org": org, "admin": admin, "member": member, "invitee": invitee, "wrong_email": wrong_email}
+
+
+def _client(db, user):
+    app = FastAPI()
+    app.include_router(invitations_router)
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[require_auth] = lambda: user
+    return TestClient(app)
+
+
+def test_create_invitation_requires_admin(db, acme_org):
+    resp = _client(db, acme_org["member"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 403
+
+
+def test_create_invitation_admin_ok(db, acme_org):
+    resp = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["invitation"]["email"] == "bob@acme.com"
+    assert body["invitation"]["status"] == "pending"
+    assert "/invite/" in body["invite_link"]
+
+
+def test_list_invitations_admin_only(db, acme_org):
+    _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    resp = _client(db, acme_org["admin"]).get("/orgs/acme/invitations")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = _client(db, acme_org["member"]).get("/orgs/acme/invitations")
+    assert resp.status_code == 403
+
+
+def test_preview_invitation_unauthenticated(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    app = FastAPI()
+    app.include_router(invitations_router)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).get(f"/invitations/{token}")
+    assert resp.status_code == 200
+    assert resp.json() == {"org_login": "acme", "email": "bob@acme.com", "status": "pending"}
+
+
+def test_accept_invitation_wrong_email_forbidden(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    resp = _client(db, acme_org["wrong_email"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 403
+
+
+def test_accept_invitation_ok(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 200
+    assert resp.json() == {"org_login": "acme", "role": "member"}
+
+    # Accepting again fails — invitation is no longer pending.
+    resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 409
+
+
+def test_revoke_invitation(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    invitation_id = created["invitation"]["id"]
+
+    resp = _client(db, acme_org["admin"]).post(f"/orgs/acme/invitations/{invitation_id}/revoke")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "revoked"
+
+    token = created["invite_link"].rsplit("/", 1)[-1]
+    resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 409

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -71,7 +71,8 @@ def test_preview_invitation_unauthenticated(db, acme_org):
     app.dependency_overrides[get_db] = lambda: db
     resp = TestClient(app).get(f"/invitations/{token}")
     assert resp.status_code == 200
-    assert resp.json() == {"org_login": "acme", "email": "bob@acme.com", "status": "pending"}
+    # The invitee's email is intentionally not disclosed on this unauthenticated endpoint.
+    assert resp.json() == {"org_login": "acme", "status": "pending"}
 
 
 def test_accept_invitation_wrong_email_forbidden(db, acme_org):
@@ -93,6 +94,16 @@ def test_accept_invitation_ok(db, acme_org):
     # Accepting again fails — invitation is no longer pending.
     resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
     assert resp.status_code == 409
+
+
+def test_accept_invitation_case_insensitive_email_match(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "Bob@Acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+
+    # Invitee's account email differs only in case from the invited address.
+    resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 200
+    assert resp.json() == {"org_login": "acme", "role": "member"}
 
 
 def test_revoke_invitation(db, acme_org):

--- a/apps/api/tests/test_org_provisioning.py
+++ b/apps/api/tests/test_org_provisioning.py
@@ -1,0 +1,81 @@
+"""Tests for src.services.org_provisioning's GitHub-admin auto-grant logic."""
+
+from unittest.mock import patch
+
+from src.core.db import User
+from src.repositories import org_membership_repo, org_repo
+from src.services import github_oauth, org_provisioning
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_first_connector_becomes_admin(db):
+    user = _make_user(db, "alice@example.com")
+
+    with (
+        patch.object(
+            github_oauth,
+            "list_user_orgs",
+            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
+        ),
+        patch.object(github_oauth, "get_org_membership_role", return_value="admin"),
+    ):
+        org_provisioning.sync_org_admin_memberships(db, user, "fake-token", "alice")
+
+    org = org_repo.get_by_login(db, "acme")
+    assert org is not None
+    membership = org_membership_repo.get(db, org_id=org.id, user_id=user.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_second_verified_admin_auto_joins_existing_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    existing_admin = _make_user(db, "alice@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=existing_admin.id, role="admin")
+
+    carol = _make_user(db, "carol@example.com")
+    with (
+        patch.object(
+            github_oauth,
+            "list_user_orgs",
+            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
+        ),
+        patch.object(github_oauth, "get_org_membership_role", return_value="admin"),
+    ):
+        org_provisioning.sync_org_admin_memberships(db, carol, "fake-token", "carol")
+
+    membership = org_membership_repo.get(db, org_id=org.id, user_id=carol.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_non_admin_github_member_not_auto_added(db):
+    dave = _make_user(db, "dave@example.com")
+
+    with (
+        patch.object(
+            github_oauth,
+            "list_user_orgs",
+            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
+        ),
+        patch.object(github_oauth, "get_org_membership_role", return_value="member"),
+    ):
+        org_provisioning.sync_org_admin_memberships(db, dave, "fake-token", "dave")
+
+    org = org_repo.get_by_login(db, "acme")
+    assert org is None  # never created — no admin ever connected it
+
+
+def test_github_api_failure_is_swallowed(db):
+    import httpx
+
+    erin = _make_user(db, "erin@example.com")
+    with patch.object(github_oauth, "list_user_orgs", side_effect=httpx.ConnectError("boom")):
+        org_provisioning.sync_org_admin_memberships(db, erin, "fake-token", "erin")  # must not raise

--- a/apps/api/tests/test_org_provisioning.py
+++ b/apps/api/tests/test_org_provisioning.py
@@ -18,15 +18,12 @@ def _make_user(db, email: str) -> User:
 def test_first_connector_becomes_admin(db):
     user = _make_user(db, "alice@example.com")
 
-    with (
-        patch.object(
-            github_oauth,
-            "list_user_orgs",
-            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
-        ),
-        patch.object(github_oauth, "get_org_membership_role", return_value="admin"),
+    with patch.object(
+        github_oauth,
+        "list_user_org_memberships",
+        return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="admin")],
     ):
-        org_provisioning.sync_org_admin_memberships(db, user, "fake-token", "alice")
+        org_provisioning.sync_org_admin_memberships(db, user, "fake-token")
 
     org = org_repo.get_by_login(db, "acme")
     assert org is not None
@@ -41,15 +38,12 @@ def test_second_verified_admin_auto_joins_existing_org(db):
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=existing_admin.id, role="admin")
 
     carol = _make_user(db, "carol@example.com")
-    with (
-        patch.object(
-            github_oauth,
-            "list_user_orgs",
-            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
-        ),
-        patch.object(github_oauth, "get_org_membership_role", return_value="admin"),
+    with patch.object(
+        github_oauth,
+        "list_user_org_memberships",
+        return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="admin")],
     ):
-        org_provisioning.sync_org_admin_memberships(db, carol, "fake-token", "carol")
+        org_provisioning.sync_org_admin_memberships(db, carol, "fake-token")
 
     membership = org_membership_repo.get(db, org_id=org.id, user_id=carol.id)
     assert membership is not None
@@ -59,15 +53,12 @@ def test_second_verified_admin_auto_joins_existing_org(db):
 def test_non_admin_github_member_not_auto_added(db):
     dave = _make_user(db, "dave@example.com")
 
-    with (
-        patch.object(
-            github_oauth,
-            "list_user_orgs",
-            return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="")],
-        ),
-        patch.object(github_oauth, "get_org_membership_role", return_value="member"),
+    with patch.object(
+        github_oauth,
+        "list_user_org_memberships",
+        return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="member")],
     ):
-        org_provisioning.sync_org_admin_memberships(db, dave, "fake-token", "dave")
+        org_provisioning.sync_org_admin_memberships(db, dave, "fake-token")
 
     org = org_repo.get_by_login(db, "acme")
     assert org is None  # never created — no admin ever connected it
@@ -77,5 +68,5 @@ def test_github_api_failure_is_swallowed(db):
     import httpx
 
     erin = _make_user(db, "erin@example.com")
-    with patch.object(github_oauth, "list_user_orgs", side_effect=httpx.ConnectError("boom")):
-        org_provisioning.sync_org_admin_memberships(db, erin, "fake-token", "erin")  # must not raise
+    with patch.object(github_oauth, "list_user_org_memberships", side_effect=httpx.ConnectError("boom")):
+        org_provisioning.sync_org_admin_memberships(db, erin, "fake-token")  # must not raise

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import get_db
+from src.core.db import User, get_db
 from src.repositories import org_membership_repo, org_repo
 from src.routers.actions_cache import router as cache_router
 from src.routers.audit import router as audit_router
@@ -16,6 +16,14 @@ from src.routers.tokens import router as tokens_router
 
 _OWNER = UserOut(id=1, email="owner@example.com", name=None, is_workspace_admin=True)
 _NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_workspace_admin=False)
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
 
 def _client(router, db, user, prefix=""):
@@ -86,14 +94,16 @@ def cache_app(db):
 
 @pytest.fixture()
 def acme_membership(db):
+    admin = _make_user(db, "cache-admin@example.com")
+    member = _make_user(db, "cache-member@example.com")
     org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_OWNER.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_NON_OWNER.id, role="member")
-    return org
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return {"org": org, "admin": admin, "member": member}
 
 
 def test_org_actions_cache_list_outsider_forbidden(cache_app, acme_membership):
-    outsider = UserOut(id=99, email="outsider@example.com", name=None, is_workspace_admin=False)
+    outsider = UserOut(id=99999, email="outsider@example.com", name=None, is_workspace_admin=False)
     cache_app.dependency_overrides[require_auth] = lambda: outsider
     resp = TestClient(cache_app).post(
         "/orgs/acme/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
@@ -103,7 +113,7 @@ def test_org_actions_cache_list_outsider_forbidden(cache_app, acme_membership):
 
 def test_org_actions_cache_clear_member_forbidden(cache_app, acme_membership):
     """Members can list caches but clearing requires org-admin."""
-    cache_app.dependency_overrides[require_auth] = lambda: _NON_OWNER
+    cache_app.dependency_overrides[require_auth] = lambda: acme_membership["member"]
     resp = TestClient(cache_app).post(
         "/orgs/acme/repos/acme/widget/actions-caches/clear",
         json={"token": "ghp_test", "actor": "member@example.com"},
@@ -113,7 +123,7 @@ def test_org_actions_cache_clear_member_forbidden(cache_app, acme_membership):
 
 def test_org_actions_cache_owner_mismatch_forbidden(cache_app, acme_membership):
     """An org admin can't act on a different GitHub owner than the org they're scoped to."""
-    cache_app.dependency_overrides[require_auth] = lambda: _OWNER
+    cache_app.dependency_overrides[require_auth] = lambda: acme_membership["admin"]
     resp = TestClient(cache_app).post(
         "/orgs/acme/repos/someone-else/widget/actions-caches", json={"token": "ghp_test"}
     )

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -16,8 +16,8 @@ from src.routers.audit import router as audit_router
 from src.routers.jobs import router as jobs_router
 from src.routers.tokens import router as tokens_router
 
-_OWNER = UserOut(id=1, email="owner@example.com", name=None, is_owner=True)
-_NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_owner=False)
+_OWNER = UserOut(id=1, email="owner@example.com", name=None, is_workspace_admin=True)
+_NON_OWNER = UserOut(id=2, email="member@example.com", name=None, is_workspace_admin=False)
 
 
 def _client(router, db, user, prefix=""):

--- a/apps/api/tests/test_owner_only_routes.py
+++ b/apps/api/tests/test_owner_only_routes.py
@@ -1,8 +1,5 @@
-"""Owner-only enforcement for routes that expose installation/token/analytics/job/audit data.
-
-Until a proper multi-tenant org model exists, all of this data effectively belongs to the
-single instance owner — a plain registered/OAuth account should only be able to manage its
-own profile (/auth/me), not read or mutate anyone else's connected orgs, tokens, or logs.
+"""Workspace-admin-only enforcement for jobs/audit/tokens (instance-wide data with no
+per-org column to scope by), plus org-role enforcement for the actions-cache routes.
 """
 
 import pytest
@@ -11,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
+from src.repositories import org_membership_repo, org_repo
 from src.routers.actions_cache import router as cache_router
 from src.routers.audit import router as audit_router
 from src.routers.jobs import router as jobs_router
@@ -75,29 +73,55 @@ def test_tokens_resolve_non_owner_forbidden(db):
 
 
 # ── actions cache ─────────────────────────────────────────────────────────────
-# Auth is resolved before the handler body runs, so a non-owner never reaches the
-# real GitHub API call — no need to mock GitHubClient for this check.
+# Org-role dependencies are resolved before the handler body runs, so a non-member/
+# non-admin never reaches the real GitHub API call — no need to mock GitHubClient here.
 
 @pytest.fixture()
-def cache_app():
+def cache_app(db):
     app = FastAPI()
-    app.include_router(cache_router, prefix="/repos")
-    app.dependency_overrides[get_db] = lambda: None
+    app.include_router(cache_router)
+    app.dependency_overrides[get_db] = lambda: db
     return app
 
 
-def test_actions_cache_list_non_owner_forbidden(cache_app):
-    cache_app.dependency_overrides[require_auth] = lambda: _NON_OWNER
+@pytest.fixture()
+def acme_membership(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_OWNER.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=_NON_OWNER.id, role="member")
+    return org
+
+
+def test_org_actions_cache_list_outsider_forbidden(cache_app, acme_membership):
+    outsider = UserOut(id=99, email="outsider@example.com", name=None, is_workspace_admin=False)
+    cache_app.dependency_overrides[require_auth] = lambda: outsider
     resp = TestClient(cache_app).post(
-        "/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
+        "/orgs/acme/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
     )
     assert resp.status_code == 403
 
 
-def test_actions_cache_clear_non_owner_forbidden(cache_app):
+def test_org_actions_cache_clear_member_forbidden(cache_app, acme_membership):
+    """Members can list caches but clearing requires org-admin."""
     cache_app.dependency_overrides[require_auth] = lambda: _NON_OWNER
     resp = TestClient(cache_app).post(
-        "/repos/acme/widget/actions-caches/clear",
+        "/orgs/acme/repos/acme/widget/actions-caches/clear",
         json={"token": "ghp_test", "actor": "member@example.com"},
     )
     assert resp.status_code == 403
+
+
+def test_org_actions_cache_owner_mismatch_forbidden(cache_app, acme_membership):
+    """An org admin can't act on a different GitHub owner than the org they're scoped to."""
+    cache_app.dependency_overrides[require_auth] = lambda: _OWNER
+    resp = TestClient(cache_app).post(
+        "/orgs/acme/repos/someone-else/widget/actions-caches", json={"token": "ghp_test"}
+    )
+    assert resp.status_code == 403
+
+
+def test_personal_actions_cache_requires_auth(cache_app):
+    resp = TestClient(cache_app).post(
+        "/me/repos/acme/widget/actions-caches", json={"token": "ghp_test"}
+    )
+    assert resp.status_code == 401

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,0 +1,92 @@
+"""Tests for src.core.rbac's org-role dependency."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.core.rbac import require_org_role
+from src.repositories import org_membership_repo, org_repo
+
+_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def rbac_app(db):
+    app = FastAPI()
+
+    @app.get("/orgs/{org_login}/member-only")
+    def member_route(ctx=Depends(require_org_role(min_role="member"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    @app.get("/orgs/{org_login}/admin-only")
+    def admin_route(ctx=Depends(require_org_role(min_role="admin"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+@pytest.fixture()
+def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    member = _make_user(db, "member@e.com")
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return org, admin, member
+
+
+def _client(app, user):
+    app.dependency_overrides[require_auth] = lambda: user
+    return TestClient(app)
+
+
+def test_member_route_allows_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+    assert resp.json() == {"org": "acme", "role": "member"}
+
+
+def test_member_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+
+
+def test_member_route_rejects_outsider(rbac_app, acme_org):
+    resp = _client(rbac_app, _OUTSIDER).get("/orgs/acme/member-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_rejects_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/admin-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/admin-only")
+    assert resp.status_code == 200
+
+
+def test_route_rejects_unknown_org(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/does-not-exist/member-only")
+    assert resp.status_code == 404
+
+
+def test_route_requires_auth(rbac_app, acme_org):
+    resp = TestClient(rbac_app).get("/orgs/acme/member-only")
+    assert resp.status_code == 401

--- a/apps/api/tests/test_repositories.py
+++ b/apps/api/tests/test_repositories.py
@@ -1,13 +1,15 @@
-from src.repositories import audit_repo, installation_repo, job_repo
+from src.repositories import audit_repo, installation_repo, job_repo, org_repo
 
 
 def test_installation_create(db):
+    org = org_repo.get_or_create(db, github_login="acme")
     row = installation_repo.create(
         db,
         account_login="acme",
         account_type="Organization",
         auth_mode="app",
         installation_id=42,
+        org_id=org.id,
     )
     assert row.id is not None
     assert row.token_ref == "tok_acme"

--- a/apps/api/tests/test_session_cookie.py
+++ b/apps/api/tests/test_session_cookie.py
@@ -17,6 +17,7 @@ def test_require_auth_accepts_session_cookie():
     user = require_auth(credentials=None, session=token)
     assert user.id == 1
     assert user.email == "a@b.com"
+    assert user.is_workspace_admin is False
 
 
 def test_require_auth_header_takes_precedence_over_cookie():
@@ -27,6 +28,7 @@ def test_require_auth_header_takes_precedence_over_cookie():
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=header_token)
     user = require_auth(credentials=creds, session=cookie_token)
     assert user.id == 2
+    assert user.is_workspace_admin is True
 
 
 def test_require_auth_rejects_when_missing():

--- a/apps/api/tests/test_session_cookie.py
+++ b/apps/api/tests/test_session_cookie.py
@@ -13,7 +13,7 @@ from src.core.auth import (
 
 
 def test_require_auth_accepts_session_cookie():
-    token = create_access_token(1, "a@b.com", is_owner=False, name="A")
+    token = create_access_token(1, "a@b.com", is_workspace_admin=False, name="A")
     user = require_auth(credentials=None, session=token)
     assert user.id == 1
     assert user.email == "a@b.com"
@@ -22,8 +22,8 @@ def test_require_auth_accepts_session_cookie():
 def test_require_auth_header_takes_precedence_over_cookie():
     from fastapi.security import HTTPAuthorizationCredentials
 
-    header_token = create_access_token(2, "header@b.com", is_owner=True, name=None)
-    cookie_token = create_access_token(9, "cookie@b.com", is_owner=False, name=None)
+    header_token = create_access_token(2, "header@b.com", is_workspace_admin=True, name=None)
+    cookie_token = create_access_token(9, "cookie@b.com", is_workspace_admin=False, name=None)
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=header_token)
     user = require_auth(credentials=creds, session=cookie_token)
     assert user.id == 2

--- a/apps/ui/app/invite/[token]/page.tsx
+++ b/apps/ui/app/invite/[token]/page.tsx
@@ -49,10 +49,15 @@ export default function InviteAcceptPage() {
               </p>
               {!user ? (
                 <p className="text-xs text-muted-foreground">
-                  Sign in with the account this invite was sent to, then come back to this link to accept.{" "}
-                  <a href="/login" className="text-primary hover:underline">
+                  Sign in with the account this invite was sent to, and you&rsquo;ll be brought back here to accept.
+                  {" "}
+                  <a
+                    href={`/login?next=${encodeURIComponent(`/invite/${token}`)}`}
+                    className="text-primary hover:underline"
+                  >
                     Sign in
                   </a>
+                  {" "}(GitHub sign-in returns you to the dashboard instead — just revisit this link afterward).
                 </p>
               ) : accept.isSuccess ? (
                 <p className="text-sm text-primary flex items-center gap-1.5">

--- a/apps/ui/app/invite/[token]/page.tsx
+++ b/apps/ui/app/invite/[token]/page.tsx
@@ -45,15 +45,14 @@ export default function InviteAcceptPage() {
             <>
               <p className="text-sm text-foreground">
                 You&rsquo;ve been invited to join <span className="font-semibold">{preview.org_login}</span> as a
-                member, using <span className="font-mono">{preview.email}</span>.
+                member.
               </p>
               {!user ? (
                 <p className="text-xs text-muted-foreground">
-                  Sign in with an account matching this email, then come back to this link to accept.
-                </p>
-              ) : user.email.toLowerCase() !== preview.email.toLowerCase() ? (
-                <p className="text-xs text-destructive">
-                  You&rsquo;re signed in as {user.email}, which doesn&rsquo;t match this invitation.
+                  Sign in with the account this invite was sent to, then come back to this link to accept.{" "}
+                  <a href="/login" className="text-primary hover:underline">
+                    Sign in
+                  </a>
                 </p>
               ) : accept.isSuccess ? (
                 <p className="text-sm text-primary flex items-center gap-1.5">

--- a/apps/ui/app/invite/[token]/page.tsx
+++ b/apps/ui/app/invite/[token]/page.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { PageHeader } from "@/components/page-header"
+import { Button } from "@/components/ui/button"
+import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react"
+import { api } from "@/lib/api/client"
+import { useAuth } from "@/lib/auth-context"
+
+export default function InviteAcceptPage() {
+  const params = useParams<{ token: string }>()
+  const router = useRouter()
+  const { user, isLoading: authLoading } = useAuth()
+  const token = params.token
+
+  const { data: preview, isLoading, isError, error } = useQuery({
+    queryKey: ["invitation-preview", token],
+    queryFn: () => api.invitations.preview(token),
+  })
+
+  const accept = useMutation({
+    mutationFn: () => api.invitations.accept(token),
+    onSuccess: () => router.push("/"),
+  })
+
+  return (
+    <div className="max-w-md mx-auto mt-16">
+      <PageHeader title="Org invitation" description="Accept an invitation to join an organization on Clevis." />
+
+      <div className="bg-card border border-border">
+        <div className="p-4 flex flex-col gap-3">
+          {isLoading || authLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" /> Loading…
+            </div>
+          ) : isError || !preview ? (
+            <p className="text-sm text-destructive flex items-center gap-1.5">
+              <AlertTriangle className="size-3.5" />
+              {error instanceof Error ? error.message : "Invitation not found"}
+            </p>
+          ) : preview.status !== "pending" ? (
+            <p className="text-sm text-muted-foreground">This invitation is no longer valid.</p>
+          ) : (
+            <>
+              <p className="text-sm text-foreground">
+                You&rsquo;ve been invited to join <span className="font-semibold">{preview.org_login}</span> as a
+                member, using <span className="font-mono">{preview.email}</span>.
+              </p>
+              {!user ? (
+                <p className="text-xs text-muted-foreground">
+                  Sign in with an account matching this email, then come back to this link to accept.
+                </p>
+              ) : user.email.toLowerCase() !== preview.email.toLowerCase() ? (
+                <p className="text-xs text-destructive">
+                  You&rsquo;re signed in as {user.email}, which doesn&rsquo;t match this invitation.
+                </p>
+              ) : accept.isSuccess ? (
+                <p className="text-sm text-primary flex items-center gap-1.5">
+                  <CheckCircle2 className="size-3.5" /> Joined {preview.org_login} — redirecting…
+                </p>
+              ) : (
+                <Button onClick={() => accept.mutate()} disabled={accept.isPending}>
+                  {accept.isPending ? "Joining…" : "Accept invitation"}
+                </Button>
+              )}
+              {accept.isError && <p className="text-xs text-destructive">{accept.error.message}</p>}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -19,10 +19,11 @@ function GithubMark() {
   )
 }
 
-// Only accept same-site relative paths (a single leading "/", not "//..." which
-// browsers treat as protocol-relative) to avoid this becoming an open redirect.
+// Only accept same-site relative paths, rejecting anything that could be interpreted as a
+// protocol-relative or absolute URL by the browser — including backslash variants like
+// "/\evil.com", which some browsers normalize to "//evil.com" — to avoid an open redirect.
 function safeNextPath(next: string | null): string {
-  if (next && next.startsWith("/") && !next.startsWith("//")) return next
+  if (next && next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")) return next
   return "/"
 }
 

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -19,12 +19,13 @@ function GithubMark() {
   )
 }
 
-// Only accept same-site relative paths, rejecting anything that could be interpreted as a
-// protocol-relative or absolute URL by the browser — including backslash variants like
-// "/\evil.com", which some browsers normalize to "//evil.com" — to avoid an open redirect.
+// Only accept unambiguous same-site relative paths: reject protocol-relative ("//..."),
+// backslash variants (some browsers normalize "/\..." to "//..."), and control characters
+// that could let URL parsing reinterpret this as an external navigation target.
 function safeNextPath(next: string | null): string {
-  if (next && next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")) return next
-  return "/"
+  if (!next || !next.startsWith("/") || next.startsWith("//")) return "/"
+  if (next.includes("\\") || /[\x00-\x1f\x7f]/.test(next)) return "/"
+  return next
 }
 
 export default function LoginPage() {

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useAuth } from "@/lib/auth-context"
 import { api } from "@/lib/api/client"
 import { Input } from "@/components/ui/input"
@@ -19,9 +19,18 @@ function GithubMark() {
   )
 }
 
+// Only accept same-site relative paths (a single leading "/", not "//..." which
+// browsers treat as protocol-relative) to avoid this becoming an open redirect.
+function safeNextPath(next: string | null): string {
+  if (next && next.startsWith("/") && !next.startsWith("//")) return next
+  return "/"
+}
+
 export default function LoginPage() {
   const { user, login, isLoading } = useAuth()
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const next = safeNextPath(searchParams.get("next"))
 
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -32,7 +41,7 @@ export default function LoginPage() {
   useEffect(() => {
     if (isLoading) return
     if (user) {
-      router.replace("/")
+      router.replace(next)
       return
     }
     api.auth.setupRequired()
@@ -42,7 +51,7 @@ export default function LoginPage() {
       .catch(() => {
         // API unreachable — stay on login page; user will see the form
       })
-  }, [isLoading, user, router])
+  }, [isLoading, user, router, next])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -50,7 +59,7 @@ export default function LoginPage() {
     setIsSubmitting(true)
     try {
       await login(email, password)
-      router.replace("/")
+      router.replace(next)
     } catch (err) {
       setError(err instanceof Error ? err.message : "Login failed")
     } finally {

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { PageHeader } from "@/components/page-header"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Loader2, Mail, X } from "lucide-react"
+import { api } from "@/lib/api/client"
+import type { InvitationOut } from "@/lib/api/types"
+
+export default function OrgMembersPage() {
+  const params = useParams<{ login: string }>()
+  const orgLogin = params.login
+  const queryClient = useQueryClient()
+  const [email, setEmail] = useState("")
+  const [lastLink, setLastLink] = useState<string | null>(null)
+
+  const { data: invitations = [], isLoading } = useQuery<InvitationOut[]>({
+    queryKey: ["invitations", orgLogin],
+    queryFn: () => api.invitations.list(orgLogin),
+  })
+
+  const invite = useMutation({
+    mutationFn: () => api.invitations.create(orgLogin, email.trim()),
+    onSuccess: (data) => {
+      setLastLink(data.invite_link)
+      setEmail("")
+      queryClient.invalidateQueries({ queryKey: ["invitations", orgLogin] })
+    },
+  })
+
+  const revoke = useMutation({
+    mutationFn: (id: number) => api.invitations.revoke(orgLogin, id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["invitations", orgLogin] }),
+  })
+
+  return (
+    <>
+      <PageHeader title="Members" description={`Manage who can access ${orgLogin} in Clevis.`} />
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="bg-card border border-border">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-title">Invite a member</span>
+          </div>
+          <div className="p-4 flex flex-col gap-3">
+            <div>
+              <label className="text-xs font-medium text-foreground block mb-1.5">Email</label>
+              <Input
+                placeholder="teammate@example.com"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && email && !invite.isPending && invite.mutate()}
+              />
+            </div>
+            <Button onClick={() => invite.mutate()} disabled={invite.isPending || !email}>
+              <Mail className="size-3.5" />
+              {invite.isPending ? "Inviting…" : "Send invite"}
+            </Button>
+            {invite.isError && <p className="text-xs text-destructive">{invite.error.message}</p>}
+            {lastLink && (
+              <div className="text-xs text-muted-foreground break-all bg-muted/30 border border-border/50 rounded-md p-2">
+                Share this link — no email is sent automatically:
+                <div className="font-mono text-foreground/80 mt-1">{lastLink}</div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-card border border-border lg:col-span-2">
+          <div className="px-4 py-3 border-b border-border">
+            <span className="section-title">Invitations</span>
+          </div>
+          {isLoading ? (
+            <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" /> Loading…
+            </div>
+          ) : invitations.length === 0 ? (
+            <div className="px-4 py-8">
+              <p className="text-sm text-muted-foreground font-mono">— no invitations yet</p>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Email</th>
+                    <th className="text-left text-muted-foreground font-medium px-4 py-2">Status</th>
+                    <th className="text-right text-muted-foreground font-medium px-4 py-2" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {invitations.map((inv) => (
+                    <tr key={inv.id}>
+                      <td className="px-4 py-2.5 text-foreground/80">{inv.email}</td>
+                      <td className="px-4 py-2.5 text-muted-foreground">{inv.status}</td>
+                      <td className="px-4 py-2.5 text-right">
+                        {inv.status === "pending" && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => revoke.mutate(inv.id)}
+                            disabled={revoke.isPending}
+                          >
+                            <X className="size-3" />
+                            Revoke
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -6,10 +6,11 @@ import { Trash2, Plus, Loader2, Check, ExternalLink } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
+import Link from "next/link"
 import { api } from "@/lib/api/client"
 import { useAuth } from "@/lib/auth-context"
 import { THEMES, useTheme } from "@/lib/theme"
-import type { InstallationMeta, SavedTokenMeta } from "@/lib/api/types"
+import type { InstallationMeta, MyOrgMembership, SavedTokenMeta } from "@/lib/api/types"
 
 // ── Profile section ──────────────────────────────────────────────────────────
 
@@ -133,7 +134,74 @@ function SectionError({ message, onRetry, retrying }: { message: string; onRetry
   )
 }
 
-// ── Connected organizations section (GitHub App) ─────────────────────────────
+// ── Org memberships section ───────────────────────────────────────────────────
+
+function OrgMembershipsSection() {
+  const { data: memberships = [], isLoading, isError, error, isFetching, refetch } = useQuery<MyOrgMembership[]>({
+    queryKey: ["my-orgs"],
+    queryFn: () => api.orgs.mine(),
+  })
+
+  return (
+    <div className="bg-card border border-border">
+      <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+        <span className="section-label">Your organizations</span>
+        {memberships.length > 0 && <span className="stat-chip">{memberships.length}</span>}
+      </div>
+
+      {isLoading ? (
+        <div className="px-4 py-6 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" /> Loading…
+        </div>
+      ) : isError ? (
+        <SectionError
+          message={error instanceof Error ? error.message : "Failed to load organizations."}
+          onRetry={() => refetch()}
+          retrying={isFetching}
+        />
+      ) : memberships.length === 0 ? (
+        <div className="px-4 py-6">
+          <p className="text-sm text-muted-foreground">
+            You&rsquo;re not a member of any organization yet. Sign in as a GitHub org admin to connect one, or
+            accept an invite link from an org admin.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Organization</th>
+                <th className="text-left text-muted-foreground font-medium px-4 py-2">Role</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {memberships.map((m) => (
+                <tr key={m.org_login} className="hover:bg-elevated transition-colors">
+                  <td className="px-4 py-2.5 font-mono text-foreground/80">{m.org_login}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground">{m.role}</td>
+                  <td className="px-4 py-2.5 text-right">
+                    {m.role === "admin" && (
+                      <Link
+                        href={`/settings/org/${encodeURIComponent(m.org_login)}/members`}
+                        className="text-xs text-primary hover:underline"
+                      >
+                        Manage members
+                      </Link>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Connected organizations (GitHub App, personal installs) ──────────────────
 
 function ConnectedOrgsSection() {
   const { data: installs = [], isLoading, isError, error, isFetching, refetch } = useQuery<InstallationMeta[]>({
@@ -146,7 +214,7 @@ function ConnectedOrgsSection() {
   return (
     <div className="bg-card border border-border">
       <div className="px-4 py-3 border-b border-border flex items-center justify-between">
-        <span className="section-label">Connected organizations</span>
+        <span className="section-label">Personal GitHub installs</span>
         {installs.length > 0 && <span className="stat-chip">{installs.length} connected</span>}
       </div>
 
@@ -445,6 +513,7 @@ export default function SettingsPage() {
       <div className="flex flex-col gap-4">
         <ProfileSection />
         <AppearanceSection />
+        <OrgMembershipsSection />
         <ConnectedOrgsSection />
         <SavedTokensSection />
         {user?.is_workspace_admin && <InstanceConfigSection />}

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -447,7 +447,7 @@ export default function SettingsPage() {
         <AppearanceSection />
         <ConnectedOrgsSection />
         <SavedTokensSection />
-        {user?.is_owner && <InstanceConfigSection />}
+        {user?.is_workspace_admin && <InstanceConfigSection />}
       </div>
     </>
   )

--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -7,13 +7,16 @@ import { api } from "@/lib/api/client"
 
 // Routes that don't require authentication
 const PUBLIC_ROUTES = ["/login", "/setup", "/register"]
+// Prefixes for routes that don't require authentication (dynamic segments)
+const PUBLIC_ROUTE_PREFIXES = ["/invite/"]
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth()
   const router = useRouter()
   const pathname = usePathname()
 
-  const isPublic = PUBLIC_ROUTES.includes(pathname)
+  const isPublic =
+    PUBLIC_ROUTES.includes(pathname) || PUBLIC_ROUTE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
 
   useEffect(() => {
     if (isLoading) return

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -5,7 +5,11 @@ import type {
   CacheListResponse,
   CheckValue,
   InstallationMeta,
+  InvitationCreateResponse,
+  InvitationOut,
+  InvitationPreview,
   JobOut,
+  MyOrgMembership,
   SavedTokenMeta,
 } from "./types"
 
@@ -124,8 +128,9 @@ function normalizeCheckValue(id: string, raw: unknown): CheckValue {
 
 export const api = {
   analytics: {
+    // Self-service: the caller brings their own token, scoped to their personal context.
     overview: async (owner: string, token: string): Promise<AnalyticsOverviewResponse> => {
-      const data = await post<AnalyticsOverviewResponse>("/analytics/overview", { owner, token })
+      const data = await post<AnalyticsOverviewResponse>("/me/analytics/overview", { owner, token })
       return {
         ...data,
         checks: data.checks.map((c) => ({ ...c, value: normalizeCheckValue(c.id, c.value) })),
@@ -134,12 +139,12 @@ export const api = {
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>
-      post<CacheListResponse>(`/repos/${owner}/${repo}/actions-caches`, { token }),
+      post<CacheListResponse>(`/me/repos/${owner}/${repo}/actions-caches`, { token }),
     clear: (
       owner: string,
       repo: string,
       body: { token: string; actor: string; dry_run: boolean; key?: string; ref?: string },
-    ) => post<CacheClearResponse>(`/repos/${owner}/${repo}/actions-caches/clear`, body),
+    ) => post<CacheClearResponse>(`/me/repos/${owner}/${repo}/actions-caches/clear`, body),
   },
   jobs: {
     list: () => get<JobOut[]>("/jobs"),
@@ -149,7 +154,19 @@ export const api = {
       get<AuditLogOut[]>(`/audit${action ? `?action=${encodeURIComponent(action)}` : ""}`),
   },
   installations: {
-    list: () => get<InstallationMeta[]>("/github/app/installations"),
+    list: () => get<InstallationMeta[]>("/me/installations"),
+  },
+  orgs: {
+    mine: () => get<MyOrgMembership[]>("/me/orgs"),
+  },
+  invitations: {
+    create: (orgLogin: string, email: string) =>
+      post<InvitationCreateResponse>(`/orgs/${encodeURIComponent(orgLogin)}/invitations`, { email }),
+    list: (orgLogin: string) => get<InvitationOut[]>(`/orgs/${encodeURIComponent(orgLogin)}/invitations`),
+    revoke: (orgLogin: string, invitationId: number) =>
+      post<InvitationOut>(`/orgs/${encodeURIComponent(orgLogin)}/invitations/${invitationId}/revoke`, {}),
+    preview: (token: string) => get<InvitationPreview>(`/invitations/${encodeURIComponent(token)}`),
+    accept: (token: string) => post<{ org_login: string; role: string }>(`/invitations/${encodeURIComponent(token)}/accept`, {}),
   },
   tokens: {
     list: () => get<SavedTokenMeta[]>("/tokens"),

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -167,16 +167,16 @@ export const api = {
   auth: {
     setupRequired: () => get<{ setup_required: boolean }>("/auth/setup-required"),
     setup: (email: string, password: string, name?: string) =>
-      post<{ access_token: string; user: { id: number; email: string; name: string | null; is_owner: boolean } }>(
+      post<{ access_token: string; user: { id: number; email: string; name: string | null; is_workspace_admin: boolean } }>(
         "/auth/setup",
         { email, password, name },
       ),
     register: (email: string, password: string, name?: string) =>
-      post<{ access_token: string; user: { id: number; email: string; name: string | null; is_owner: boolean } }>(
+      post<{ access_token: string; user: { id: number; email: string; name: string | null; is_workspace_admin: boolean } }>(
         "/auth/register",
         { email, password, name },
       ),
     patchMe: (name: string) =>
-      patch<{ id: number; email: string; name: string | null; is_owner: boolean }>("/auth/me", { name }),
+      patch<{ id: number; email: string; name: string | null; is_workspace_admin: boolean }>("/auth/me", { name }),
   },
 }

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -105,6 +105,5 @@ export interface InvitationCreateResponse {
 
 export interface InvitationPreview {
   org_login: string
-  email: string
-  status: string
+  status: "pending" | "accepted" | "revoked"
 }

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -83,3 +83,28 @@ export interface InstallationMeta {
   installation_id: number | null
   created_at: string
 }
+
+export interface MyOrgMembership {
+  org_login: string
+  role: "admin" | "member"
+}
+
+export interface InvitationOut {
+  id: number
+  org_id: number
+  email: string
+  status: "pending" | "accepted" | "revoked"
+  created_at: string
+  accepted_at: string | null
+}
+
+export interface InvitationCreateResponse {
+  invitation: InvitationOut
+  invite_link: string
+}
+
+export interface InvitationPreview {
+  org_login: string
+  email: string
+  status: string
+}

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -6,7 +6,7 @@ export interface AuthUser {
   id: number
   email: string
   name: string | null
-  is_owner: boolean
+  is_workspace_admin: boolean
 }
 
 interface AuthContextValue {
@@ -33,7 +33,12 @@ function parseJwtPayload(token: string): AuthUser | null {
     const id = Number(payload.sub)
     if (!id || !payload.email) return null
     if (payload.exp && payload.exp * 1000 < Date.now()) return null
-    return { id, email: payload.email, name: payload.name ?? null, is_owner: Boolean(payload.is_owner) }
+    return {
+      id,
+      email: payload.email,
+      name: payload.name ?? null,
+      is_workspace_admin: Boolean(payload.is_workspace_admin),
+    }
   } catch {
     return null
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added org-scoped RBAC with `GET /me/orgs`, plus invitation management (create, list, preview, revoke, accept) and corresponding UI flows.
  * Added org- and user-scoped installations, cache, and analytics endpoints with role-aware listing/sync.
* **Bug Fixes**
  * Updated authorization gating across audit, config, jobs, tokens, analytics, actions-cache, and org operations to use workspace-admin access.
* **Refactor**
  * Renamed authorization role flag from “owner” to “workspace admin” across API/JWT/session and updated related endpoint paths to `/orgs/...` and `/me/...`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->