### PR TITLE
fix(api): sanitize job errors, reconcile org-admin membership, expire invitations

### DIFF
--- a/apps/api/alembic/versions/0012_add_invitation_expiry.py
+++ b/apps/api/alembic/versions/0012_add_invitation_expiry.py
@@ -1,0 +1,33 @@
+"""add invitations.expires_at
+
+Invite links are unauthenticated, shareable join credentials
+(secrets.token_urlsafe(32)) with no natural expiry — previously valid
+forever until an org admin manually revoked them. Adds a 7-day expiry,
+computed at creation time in invitation_repo.create(). Existing rows
+are backfilled to created_at + 7 days so already-pending invites don't
+become immediately expired or need special-casing.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("invitations", sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.execute(
+        sa.text("UPDATE invitations SET expires_at = created_at + interval '7 days' WHERE expires_at IS NULL")
+    )
+    op.alter_column("invitations", "expires_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("invitations", "expires_at")

--- a/apps/api/src/core/_sanitize.py
+++ b/apps/api/src/core/_sanitize.py
@@ -1,0 +1,22 @@
+import re
+
+# Job.result is stored and later exposed verbatim via GET /jobs to workspace admins.
+# Cap length and strip anything that looks like a token/credential fragment as defense
+# in depth against GitHub API error text echoing request details (URLs, headers, params).
+_MAX_ERROR_LENGTH = 500
+_TRUNCATION_SUFFIX = "...(truncated)"
+
+_REDACT_PATTERNS = [
+    re.compile(r"gh[oprsu]_[A-Za-z0-9]{20,}"),  # GitHub PAT/OAuth/app token prefixes
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"[Bb]earer\s+\S+"),
+    re.compile(r"[Aa]uthorization:\s*\S+"),
+]
+
+
+def sanitize_error(text: str) -> str:
+    for pattern in _REDACT_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    if len(text) > _MAX_ERROR_LENGTH:
+        text = text[: _MAX_ERROR_LENGTH - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
+    return text

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -134,6 +134,7 @@ class Invitation(Base):
     invited_by_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
 class AppConfig(Base):

--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -1,8 +1,11 @@
 import secrets
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
 from src.core.db import Invitation
+
+INVITATION_LIFETIME = timedelta(days=7)
 
 
 def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Invitation:
@@ -12,6 +15,7 @@ def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Inv
         token=secrets.token_urlsafe(32),
         status="pending",
         invited_by_user_id=invited_by_user_id,
+        expires_at=datetime.now(timezone.utc) + INVITATION_LIFETIME,
     )
     db.add(invitation)
     db.commit()

--- a/apps/api/src/repositories/job_repo.py
+++ b/apps/api/src/repositories/job_repo.py
@@ -3,6 +3,7 @@ import json
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from src.core._sanitize import sanitize_error
 from src.core.db import Job
 
 
@@ -38,6 +39,6 @@ def mark_done(db: Session, job_id: int, result: str) -> None:
 
 def mark_failed(db: Session, job_id: int, error: str) -> None:
     db.query(Job).filter(Job.id == job_id).update(
-        {"status": "failed", "result": error, "updated_at": func.now()}
+        {"status": "failed", "result": sanitize_error(error), "updated_at": func.now()}
     )
     db.commit()

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -37,3 +37,20 @@ def list_for_user(db: Session, user_id: int) -> list[OrgMembership]:
 
 def list_for_org(db: Session, org_id: int) -> list[OrgMembership]:
     return db.query(OrgMembership).filter(OrgMembership.org_id == org_id).all()
+
+
+def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership | None:
+    membership = get(db, org_id, user_id)
+    if membership is None:
+        return None
+    membership.role = role
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def delete(db: Session, org_id: int, user_id: int) -> None:
+    db.query(OrgMembership).filter(
+        OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
+    ).delete()
+    db.commit()

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -8,6 +8,10 @@ def get_by_login(db: Session, github_login: str) -> Org | None:
     return db.query(Org).filter(Org.github_login == github_login).first()
 
 
+def get_by_id(db: Session, org_id: int) -> Org | None:
+    return db.query(Org).filter(Org.id == org_id).first()
+
+
 def get_or_create(db: Session, github_login: str, github_org_id: int | None = None) -> Org:
     org = get_by_login(db, github_login)
     if org is not None:

--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -34,6 +34,20 @@ def _ui_base() -> str:
     return settings.cors_origins[0] if settings.cors_origins else ""
 
 
+def _is_expired(invitation) -> bool:
+    return invitation.status == "pending" and invitation.expires_at <= datetime.now(timezone.utc)
+
+
+def _effective_status(invitation) -> str:
+    return "expired" if _is_expired(invitation) else invitation.status
+
+
+def _expire(db: Session, invitation) -> None:
+    invitation.status = "expired"
+    db.commit()
+    db.refresh(invitation)
+
+
 @router.post("/orgs/{org_login}/invitations", response_model=InvitationCreateResponse)
 def create_invitation(
     body: InvitationCreate,
@@ -53,7 +67,19 @@ def list_invitations(
     ctx: OrgContext = Depends(require_org_role(min_role="admin")),
     db: Session = Depends(get_db),
 ):
-    return invitation_repo.list_for_org(db, org_id=ctx.org.id)
+    invitations = invitation_repo.list_for_org(db, org_id=ctx.org.id)
+    return [
+        InvitationOut(
+            id=inv.id,
+            org_id=inv.org_id,
+            email=inv.email,
+            status=_effective_status(inv),
+            created_at=inv.created_at,
+            accepted_at=inv.accepted_at,
+            expires_at=inv.expires_at,
+        )
+        for inv in invitations
+    ]
 
 
 @router.post("/orgs/{org_login}/invitations/{invitation_id}/revoke", response_model=InvitationOut)
@@ -78,6 +104,8 @@ def preview_invitation(token: str, db: Session = Depends(get_db)):
     invitation = invitation_repo.get_by_token(db, token)
     if invitation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    if _is_expired(invitation):
+        _expire(db, invitation)
     org = db.query(Org).filter(Org.id == invitation.org_id).first()
     return {"org_login": org.github_login, "status": invitation.status}
 
@@ -91,6 +119,10 @@ def accept_invitation(
     invitation = invitation_repo.get_by_token(db, token)
     if invitation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    if _is_expired(invitation):
+        _expire(db, invitation)
+    if invitation.status == "expired":
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Invitation has expired")
     if invitation.status != "pending":
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Invitation is no longer pending")
     if invitation.email.lower() != user.email.lower():

--- a/apps/api/src/schemas/invitation.py
+++ b/apps/api/src/schemas/invitation.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr
 
-InvitationStatus = Literal["pending", "accepted", "revoked"]
+InvitationStatus = Literal["pending", "accepted", "revoked", "expired"]
 
 
 class InvitationCreate(BaseModel):
@@ -19,6 +19,7 @@ class InvitationOut(BaseModel):
     status: InvitationStatus
     created_at: datetime
     accepted_at: datetime | None
+    expires_at: datetime
 
 
 class InvitationCreateResponse(BaseModel):

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -1,15 +1,26 @@
 """
-Auto-provisions Clevis orgs/admin-memberships from verified GitHub org-admin status.
+Auto-provisions and reconciles Clevis org memberships from verified GitHub org status.
 
 Runs at OAuth login time, where a live user token is transiently available (see
 src/routers/github_auth.py). Fetches the user's org memberships (role included) from
-GitHub in a single call; for every org where they're an admin, get-or-creates the Clevis
-Org and an admin OrgMembership for them. This covers both "first person to connect this
-org" and "another verified GitHub admin signing in later" — GitHub already vouches for
-admins, so no invite is required. Non-admin GitHub members are never touched here; they
-only gain access through the explicit invite-accept flow.
+GitHub in a single call, then does two things:
 
-Best-effort: any GitHub API failure is logged and swallowed so it never blocks login.
+1. For every org where they're currently a GitHub admin, get-or-creates the Clevis Org
+   and grants/refreshes an admin OrgMembership for them. This covers both "first person
+   to connect this org" and "another verified GitHub admin signing in later" — GitHub
+   already vouches for admins, so no invite is required.
+2. Reconciles every *existing* Clevis OrgMembership for this user against the freshly
+   fetched GitHub state: demotes to "member" if GitHub now says member, and deletes the
+   row entirely if GitHub no longer lists the org for this user at all (removed or the
+   org went private to them). This prevents privilege escalated via GitHub admin status
+   from outliving its GitHub grant — Clevis previously only ever created/no-op'd
+   memberships and never revoked them.
+
+Non-admin GitHub members who have no prior Clevis membership are never auto-added here;
+they only gain access through the explicit invite-accept flow.
+
+Best-effort: any GitHub API failure is logged and swallowed so it never blocks login (and
+existing memberships are left untouched rather than being wiped on a transient failure).
 """
 
 import logging
@@ -34,8 +45,22 @@ def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None
         )
         return
 
+    gh_role_by_org_id = {m.github_org_id: m.role for m in memberships}
+
     for gh_membership in memberships:
         if gh_membership.role != "admin":
             continue
         org = org_repo.get_or_create(db, github_login=gh_membership.login, github_org_id=gh_membership.github_org_id)
-        org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+        membership = org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+        if membership.role != "admin":
+            org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
+
+    for membership in org_membership_repo.list_for_user(db, user.id):
+        org = org_repo.get_by_id(db, membership.org_id)
+        if org is None or org.github_org_id is None:
+            continue
+        gh_role = gh_role_by_org_id.get(org.github_org_id)
+        if gh_role is None:
+            org_membership_repo.delete(db, org_id=membership.org_id, user_id=user.id)
+        elif gh_role == "member" and membership.role != "member":
+            org_membership_repo.update_role(db, org_id=membership.org_id, user_id=user.id, role="member")

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -1,5 +1,7 @@
 """Tests for the org invitation create/list/revoke/accept flow."""
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -117,3 +119,53 @@ def test_revoke_invitation(db, acme_org):
     token = created["invite_link"].rsplit("/", 1)[-1]
     resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
     assert resp.status_code == 409
+
+
+def _expire_invitation(db, invitation_id: int) -> None:
+    from src.core.db import Invitation
+
+    invitation = db.query(Invitation).filter(Invitation.id == invitation_id).first()
+    invitation.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    db.commit()
+
+
+def test_create_invitation_sets_expiry(db, acme_org):
+    before = datetime.now(timezone.utc)
+    resp = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    after = datetime.now(timezone.utc)
+    expires_at = datetime.fromisoformat(resp.json()["invitation"]["expires_at"])
+    assert before + timedelta(days=7) <= expires_at <= after + timedelta(days=7)
+
+
+def test_accept_expired_invitation_returns_410(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+    _expire_invitation(db, created["invitation"]["id"])
+
+    resp = _client(db, acme_org["invitee"]).post(f"/invitations/{token}/accept")
+    assert resp.status_code == 410
+
+
+def test_preview_expired_invitation_shows_expired_status(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    token = created["invite_link"].rsplit("/", 1)[-1]
+    _expire_invitation(db, created["invitation"]["id"])
+
+    app = FastAPI()
+    app.include_router(invitations_router)
+    app.dependency_overrides[get_db] = lambda: db
+    resp = TestClient(app).get(f"/invitations/{token}")
+    assert resp.status_code == 200
+    assert resp.json() == {"org_login": "acme", "status": "expired"}
+
+
+def test_list_invitations_reflects_expired_status(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    _expire_invitation(db, created["invitation"]["id"])
+
+    resp = _client(db, acme_org["admin"]).get("/orgs/acme/invitations")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["status"] == "expired"
+    assert "expires_at" in body[0]

--- a/apps/api/tests/test_org_provisioning.py
+++ b/apps/api/tests/test_org_provisioning.py
@@ -70,3 +70,70 @@ def test_github_api_failure_is_swallowed(db):
     erin = _make_user(db, "erin@example.com")
     with patch.object(github_oauth, "list_user_org_memberships", side_effect=httpx.ConnectError("boom")):
         org_provisioning.sync_org_admin_memberships(db, erin, "fake-token")  # must not raise
+
+
+def test_demoted_github_admin_loses_clevis_admin_role(db):
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    frank = _make_user(db, "frank@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=frank.id, role="admin")
+
+    with patch.object(
+        github_oauth,
+        "list_user_org_memberships",
+        return_value=[github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="member")],
+    ):
+        org_provisioning.sync_org_admin_memberships(db, frank, "fake-token")
+
+    membership = org_membership_repo.get(db, org_id=org.id, user_id=frank.id)
+    assert membership is not None
+    assert membership.role == "member"
+
+
+def test_removed_github_member_loses_clevis_membership_entirely(db):
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    grace = _make_user(db, "grace@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=grace.id, role="admin")
+
+    with patch.object(github_oauth, "list_user_org_memberships", return_value=[]):
+        org_provisioning.sync_org_admin_memberships(db, grace, "fake-token")
+
+    membership = org_membership_repo.get(db, org_id=org.id, user_id=grace.id)
+    assert membership is None
+
+
+def test_unrelated_org_membership_untouched_when_other_org_reconciled(db):
+    acme = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    globex = org_repo.get_or_create(db, github_login="globex", github_org_id=2)
+    heidi = _make_user(db, "heidi@example.com")
+    org_membership_repo.get_or_create(db, org_id=acme.id, user_id=heidi.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=globex.id, user_id=heidi.id, role="admin")
+
+    with patch.object(
+        github_oauth,
+        "list_user_org_memberships",
+        return_value=[
+            github_oauth.GitHubOrgMembership(github_org_id=1, login="acme", role="admin"),
+            github_oauth.GitHubOrgMembership(github_org_id=2, login="globex", role="member"),
+        ],
+    ):
+        org_provisioning.sync_org_admin_memberships(db, heidi, "fake-token")
+
+    acme_membership = org_membership_repo.get(db, org_id=acme.id, user_id=heidi.id)
+    globex_membership = org_membership_repo.get(db, org_id=globex.id, user_id=heidi.id)
+    assert acme_membership.role == "admin"
+    assert globex_membership.role == "member"
+
+
+def test_stale_clevis_membership_untouched_on_github_api_failure(db):
+    import httpx
+
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    ivan = _make_user(db, "ivan@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=ivan.id, role="admin")
+
+    with patch.object(github_oauth, "list_user_org_memberships", side_effect=httpx.ConnectError("boom")):
+        org_provisioning.sync_org_admin_memberships(db, ivan, "fake-token")
+
+    membership = org_membership_repo.get(db, org_id=org.id, user_id=ivan.id)
+    assert membership is not None
+    assert membership.role == "admin"

--- a/apps/api/tests/test_repositories.py
+++ b/apps/api/tests/test_repositories.py
@@ -47,3 +47,21 @@ def test_job_mark_failed(db):
     match = next(j for j in jobs if j["id"] == job_id)
     assert match["status"] == "failed"
     assert match["result"] == "timeout"
+
+
+def test_job_mark_failed_truncates_long_error(db):
+    job_id = job_repo.enqueue(db, "github.clear_actions_cache", {"owner": "acme", "repo": "api"})
+    job_repo.mark_failed(db, job_id, "x" * 1000)
+    jobs = job_repo.list_jobs(db)
+    match = next(j for j in jobs if j["id"] == job_id)
+    assert len(match["result"]) <= 500
+    assert match["result"].endswith("...(truncated)")
+
+
+def test_job_mark_failed_redacts_token_shaped_text(db):
+    job_id = job_repo.enqueue(db, "github.clear_actions_cache", {"owner": "acme", "repo": "api"})
+    job_repo.mark_failed(db, job_id, "failed with ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+    jobs = job_repo.list_jobs(db)
+    match = next(j for j in jobs if j["id"] == job_id)
+    assert "ghp_" not in match["result"]
+    assert "[redacted]" in match["result"]

--- a/apps/worker/src/_sanitize.py
+++ b/apps/worker/src/_sanitize.py
@@ -1,0 +1,23 @@
+import re
+
+# Job.result is stored and later exposed verbatim via GET /jobs to workspace admins.
+# Cap length and strip anything that looks like a token/credential fragment as defense
+# in depth against GitHub API error text echoing request details (URLs, headers, params).
+_MAX_ERROR_LENGTH = 500
+_TRUNCATION_SUFFIX = "...(truncated)"
+
+_REDACT_PATTERNS = [
+    re.compile(r"gh[oprsu]_[A-Za-z0-9]{20,}"),  # GitHub PAT/OAuth/app token prefixes
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"[Bb]earer\s+\S+"),
+    re.compile(r"[Aa]uthorization:\s*\S+"),
+]
+
+
+def sanitize_error(error: Exception) -> str:
+    text = str(error)
+    for pattern in _REDACT_PATTERNS:
+        text = pattern.sub("[redacted]", text)
+    if len(text) > _MAX_ERROR_LENGTH:
+        text = text[: _MAX_ERROR_LENGTH - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
+    return text

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -6,6 +6,7 @@ import httpx
 import psycopg
 
 from _crypto import decrypt_job_token
+from _sanitize import sanitize_error
 from config import settings
 
 logging.basicConfig(
@@ -74,7 +75,7 @@ def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None
         with conn.cursor() as cur:
             cur.execute(
                 "UPDATE jobs SET status='failed', result=%s, updated_at=NOW() WHERE id=%s",
-                (str(error), job_id),
+                (sanitize_error(error), job_id),
             )
     conn.commit()
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -103,3 +103,39 @@ def test_process_job_marks_failed_on_network_error():
     assert "status='failed'" in sql
     assert "timeout" in params[0]
     assert conn.committed is True
+
+
+def test_process_job_truncates_long_error():
+    conn = _FakeConn()
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(side_effect=ConnectionError("x" * 1000))
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 4, _payload())
+
+    sql, params = conn._cursor.calls[0]
+    assert len(params[0]) <= 500
+    assert params[0].endswith("...(truncated)")
+
+
+def test_process_job_redacts_token_shaped_text_in_error():
+    conn = _FakeConn()
+
+    with patch("worker.httpx.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.delete = MagicMock(
+            side_effect=ConnectionError("failed with ghp_abcdefghijklmnopqrstuvwxyz0123456789")
+        )
+        mock_client_cls.return_value = mock_client
+
+        process_job(conn, 5, _payload())
+
+    sql, params = conn._cursor.calls[0]
+    assert "ghp_" not in params[0]
+    assert "[redacted]" in params[0]


### PR DESCRIPTION
## Summary
- Sanitize/truncate raw exception strings before storing them in `Job.result`, so GitHub API error text can no longer leak request details verbatim via `GET /jobs` (fixes #86).
- Reconcile Clevis `OrgMembership` role against GitHub on every OAuth login: demote to `member` or delete the row when GitHub no longer vouches for admin/membership, instead of only ever creating/no-op'ing (fixes #72).
- Add a 7-day expiry to org invitations, enforced on accept (410 Gone) and preview, surfaced in the admin invitation list (fixes #69).

## Test plan
- [x] `pytest -q` — 149 passed
- [x] `alembic upgrade head` and `alembic check` — no drift
- [x] New/updated tests cover truncation+redaction of job errors, admin demotion/removal reconciliation, and invitation expiry (accept/preview/list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)