### PR TITLE
fix(api): sanitize client X-Request-ID before logging

### DIFF
--- a/apps/api/src/core/middleware.py
+++ b/apps/api/src/core/middleware.py
@@ -1,12 +1,12 @@
-import uuid
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.core.logging import request_id_var
+from src.core.request_id import resolve_request_id
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        request_id = resolve_request_id(request.headers.get("X-Request-ID"))
         token = request_id_var.set(request_id)
         try:
             response = await call_next(request)

--- a/apps/api/src/core/request_id.py
+++ b/apps/api/src/core/request_id.py
@@ -1,0 +1,23 @@
+"""Request ID validation for X-Request-ID propagation."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+# Clients may send correlation IDs; cap size and restrict charset so logs
+# cannot be polluted with unbounded or crafted values.
+_MAX_LEN = 128
+_SAFE_PATTERN = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+def resolve_request_id(header_value: str | None) -> str:
+    """Return a safe request ID from the client header, or generate a UUID."""
+    if header_value is None:
+        return str(uuid.uuid4())
+
+    value = header_value.strip()
+    if not value or len(value) > _MAX_LEN or not _SAFE_PATTERN.fullmatch(value):
+        return str(uuid.uuid4())
+
+    return value

--- a/apps/api/tests/test_request_id.py
+++ b/apps/api/tests/test_request_id.py
@@ -1,0 +1,62 @@
+"""Tests for X-Request-ID validation and middleware propagation."""
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.middleware import RequestIdMiddleware
+from src.core.request_id import resolve_request_id
+
+
+def test_resolve_request_id_generates_uuid_when_missing():
+    value = resolve_request_id(None)
+    uuid.UUID(value)
+
+
+def test_resolve_request_id_accepts_valid_client_id():
+    client_id = "req-abc123_456.test"
+    assert resolve_request_id(client_id) == client_id
+
+
+def test_resolve_request_id_rejects_oversized_value():
+    oversized = "a" * 129
+    generated = resolve_request_id(oversized)
+    assert generated != oversized
+    uuid.UUID(generated)
+
+
+def test_resolve_request_id_rejects_unsafe_characters():
+    crafted = "legit-id<script>"
+    generated = resolve_request_id(crafted)
+    assert generated != crafted
+    uuid.UUID(generated)
+
+
+def test_middleware_echoes_sanitized_request_id():
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Request-ID": "x" * 200})
+    echoed = response.headers["X-Request-ID"]
+    assert echoed != "x" * 200
+    uuid.UUID(echoed)
+
+
+def test_middleware_forwards_valid_client_request_id():
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    request_id = "trace-2026-07-11T09:00:00Z"
+    response = client.get("/ping", headers={"X-Request-ID": request_id})
+    assert response.headers["X-Request-ID"] == request_id


### PR DESCRIPTION
## Summary
Fixes #104.

- Add `resolve_request_id()` to cap `X-Request-ID` at 128 chars and allow only `[A-Za-z0-9._:-]`.
- Fall back to a generated UUID when the header is missing or invalid.
- Middleware echoes the sanitized ID in the response header.

## Test plan
Local (macOS, Python 3.12):
```
pytest apps/api/tests/test_request_id.py -v
# 6 passed in 0.38s
```

GitHub CI runs the full Python + UI + Docker matrix on PR.

Made with [Cursor](https://cursor.com)