### PR TITLE
fix(ui): ignore stale /auth/me after concurrent session change

### DIFF
--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useCallback, useContext, useEffect, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 
 export interface AuthUser {
   id: number
@@ -48,19 +48,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [token, setToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const sessionEpochRef = useRef(0)
+
+  const bumpSessionEpoch = useCallback(() => {
+    sessionEpochRef.current += 1
+  }, [])
 
   const logout = useCallback(() => {
+    bumpSessionEpoch()
     // Clear the httpOnly cookie server-side (GitHub OAuth sessions); harmless for Bearer sessions.
     fetch(`${BASE}/auth/logout`, { method: "POST", credentials: "include" }).catch(() => {})
     localStorage.removeItem(_TOKEN_KEY)
     setToken(null)
     setUser(null)
-  }, [])
+  }, [bumpSessionEpoch])
 
   // On mount: restore a Bearer session optimistically, then validate against the server.
   // Validation works for BOTH auth modes — the Bearer header (email/password) and the httpOnly
   // session cookie (GitHub OAuth, where there is no localStorage token).
   useEffect(() => {
+    const epochAtStart = sessionEpochRef.current
     const stored = localStorage.getItem(_TOKEN_KEY)
 
     // Optimistic restore from a stored token — unblock the UI without a network round-trip
@@ -82,6 +89,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       signal: controller.signal,
     })
       .then(async (res) => {
+        if (sessionEpochRef.current !== epochAtStart) return
         if (res.status === 401) {
           if (stored) logout()
           return
@@ -109,20 +117,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const data = await res.json()
     if (!res.ok) throw new Error(data.detail ?? "Login failed")
     const { access_token, user: u } = data as { access_token: string; user: AuthUser }
+    bumpSessionEpoch()
     localStorage.setItem(_TOKEN_KEY, access_token)
     setToken(access_token)
     setUser(u)
-  }, [])
+  }, [bumpSessionEpoch])
 
   const updateUser = useCallback((patch: Partial<AuthUser>) => {
     setUser((prev) => (prev ? { ...prev, ...patch } : prev))
   }, [])
 
   const setSession = useCallback((jwtToken: string, authUser: AuthUser) => {
+    bumpSessionEpoch()
     localStorage.setItem(_TOKEN_KEY, jwtToken)
     setToken(jwtToken)
     setUser(authUser)
-  }, [])
+  }, [bumpSessionEpoch])
 
   return (
     <AuthContext.Provider value={{ user, token, isLoading, login, logout, updateUser, setSession }}>

--- a/apps/ui/tests/lib/auth-context.test.tsx
+++ b/apps/ui/tests/lib/auth-context.test.tsx
@@ -1,0 +1,144 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthProvider, useAuth, type AuthUser } from "@/lib/auth-context";
+
+const TOKEN_KEY = "clevis:token";
+
+function b64url(value: object): string {
+  return btoa(JSON.stringify(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt(sub: number, email: string): string {
+  const header = b64url({ alg: "none", typ: "JWT" });
+  const payload = b64url({
+    sub: String(sub),
+    email,
+    name: null,
+    is_workspace_admin: false,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+  return `${header}.${payload}.sig`;
+}
+
+const passwordUser: AuthUser = {
+  id: 2,
+  email: "password@example.com",
+  name: "Password User",
+  is_workspace_admin: false,
+};
+
+const cookieUser: AuthUser = {
+  id: 1,
+  email: "github@example.com",
+  name: "GitHub User",
+  is_workspace_admin: true,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("AuthProvider mount /auth/me race", () => {
+  let meDeferred: {
+    promise: Promise<Response>;
+    resolve: (response: Response) => void;
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    meDeferred = (() => {
+      let resolve!: (response: Response) => void;
+      const promise = new Promise<Response>((res) => {
+        resolve = res;
+      });
+      return { promise, resolve };
+    })();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/auth/me")) {
+          return meDeferred.promise;
+        }
+        if (url.endsWith("/auth/login")) {
+          return Promise.resolve(
+            jsonResponse({
+              access_token: makeJwt(passwordUser.id, passwordUser.email),
+              user: passwordUser,
+            }),
+          );
+        }
+        if (url.endsWith("/auth/logout")) {
+          return Promise.resolve(new Response(null, { status: 204 }));
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not overwrite a concurrent password login with a stale /auth/me response", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.login("password@example.com", "supersecret1234");
+    });
+
+    expect(result.current.user).toEqual(passwordUser);
+    expect(result.current.token).toBeTruthy();
+
+    await act(async () => {
+      meDeferred.resolve(jsonResponse(cookieUser));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toEqual(passwordUser);
+  });
+
+  it("ignores a stale /auth/me response after logout", async () => {
+    localStorage.setItem(TOKEN_KEY, makeJwt(cookieUser.id, cookieUser.email));
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AuthProvider>{children}</AuthProvider>
+    );
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await act(async () => {
+      result.current.logout();
+    });
+
+    expect(result.current.user).toBeNull();
+
+    await act(async () => {
+      meDeferred.resolve(jsonResponse(cookieUser));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #100.

- Track a session epoch in `AuthProvider`; bump it on `login`, `setSession`, and `logout`.
- Mount-time `/auth/me` validation no-ops when a newer session was established while the fetch was in flight.

## Test plan
Local (macOS, Node 22 + vitest):
```
vitest run tests/lib/auth-context.test.tsx
# 2 passed
tsc --noEmit
# passed
```

Covers:
1. Password login completing before a stale cookie `/auth/me` response — user stays on password account.
2. Logout before `/auth/me` resolves — user stays logged out.

GitHub CI runs UI typecheck, lint, vitest, and build on PR.

Made with [Cursor](https://cursor.com)