### PR TITLE
fix(ui): preserve unsaved config edits on field save

### DIFF
--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { api } from "@/lib/api/client"
+import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values"
 import { useAuth } from "@/lib/auth-context"
 import { THEMES, useTheme } from "@/lib/theme"
 import type { InstallationMeta, MyOrgMembership, SavedTokenMeta } from "@/lib/api/types"
@@ -428,7 +429,7 @@ function InstanceConfigSection() {
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   useEffect(() => {
-    if (config) setValues(config)
+    if (config) setValues((prev) => initialConfigValues(prev, config))
   }, [config])
 
   async function saveKey(key: string) {
@@ -436,7 +437,11 @@ function InstanceConfigSection() {
     setErrors((prev) => ({ ...prev, [key]: "" }))
     try {
       await api.config.update(key, values[key] ?? "")
-      qc.invalidateQueries({ queryKey: ["config"] })
+      const updated = await qc.fetchQuery<Record<string, string>>({
+        queryKey: ["config"],
+        queryFn: api.config.getAll,
+      })
+      setValues((prev) => mergeSavedConfigValue(prev, updated, key))
     } catch (err) {
       setErrors((prev) => ({ ...prev, [key]: err instanceof Error ? err.message : "Save failed" }))
     } finally {

--- a/apps/ui/lib/config-values.ts
+++ b/apps/ui/lib/config-values.ts
@@ -1,0 +1,16 @@
+/** Helpers for instance-config form state vs server refetches. */
+
+export function initialConfigValues(
+  current: Record<string, string>,
+  server: Record<string, string>,
+): Record<string, string> {
+  return Object.keys(current).length === 0 ? server : current
+}
+
+export function mergeSavedConfigValue(
+  current: Record<string, string>,
+  server: Record<string, string>,
+  savedKey: string,
+): Record<string, string> {
+  return { ...current, [savedKey]: server[savedKey] ?? current[savedKey] ?? "" }
+}

--- a/apps/ui/tests/lib/config-values.test.ts
+++ b/apps/ui/tests/lib/config-values.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values";
+
+describe("initialConfigValues", () => {
+  it("seeds the form from the server on first load", () => {
+    const server = { worker_poll_seconds: "30", registration_enabled: "true" };
+    expect(initialConfigValues({}, server)).toEqual(server);
+  });
+
+  it("preserves unsaved edits when config refetches", () => {
+    const current = {
+      worker_poll_seconds: "45",
+      registration_enabled: "false",
+    };
+    const server = {
+      worker_poll_seconds: "30",
+      registration_enabled: "true",
+    };
+    expect(initialConfigValues(current, server)).toEqual(current);
+  });
+});
+
+describe("mergeSavedConfigValue", () => {
+  it("updates only the saved key after a successful save", () => {
+    const current = {
+      worker_poll_seconds: "45",
+      registration_enabled: "false",
+    };
+    const server = {
+      worker_poll_seconds: "45",
+      registration_enabled: "true",
+    };
+    expect(mergeSavedConfigValue(current, server, "worker_poll_seconds")).toEqual({
+      worker_poll_seconds: "45",
+      registration_enabled: "false",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #85.

- Seed instance config form values only on first load (`initialConfigValues`).
- After saving one field, merge only that key from the refetched config (`mergeSavedConfigValue`) instead of wholesale-replacing all fields.

## Test plan
Local:
```
vitest run tests/lib/config-values.test.ts
# 3 passed
tsc --noEmit
# passed
```

GitHub CI runs UI typecheck, lint, vitest, and build on PR.

Made with [Cursor](https://cursor.com)