### PR TITLE
fix(auth): redirect GitHub OAuth errors to the login page instead of raw API JSON

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Report a bug in clevis
+title: "fix(<scope>): <short summary>"
+labels: bug
+assignees: ''
+---
+
+## Problem
+
+What's wrong, and where (file/function/endpoint)? Cite the actual code if you can.
+
+## Failure scenario
+
+A concrete sequence of steps or inputs that triggers the bug.
+
+## Suggested fix
+
+If you have one in mind. Optional.
+
+## Severity
+
+Low / Medium / High, and why.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement for clevis
+title: "feat(<scope>): <short summary>"
+labels: enhancement
+assignees: ''
+---
+
+## Problem / motivation
+
+What's missing or painful today? Who runs into this?
+
+## Proposed solution
+
+What you'd like to see happen.
+
+## Alternatives considered
+
+Other approaches you thought about, and why you didn't pick them. Optional.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+Closes #<!-- issue number, if any -->
+
+## Checks
+
+Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.
+
+- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed)
+- [ ] `python -m compileall apps/api/src apps/worker/src` (if API/worker changed)
+- [ ] Relevant `pytest` tests pass (if API/worker changed)
+- [ ] Docker images still build, if `Dockerfile`/deps changed
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -13,7 +13,7 @@ membership is auto-granted based on verified GitHub org-admin status.
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -33,6 +33,11 @@ def _callback_url(request: Request) -> str:
 
 def _ui_redirect_target() -> str:
     return settings.cors_origins[0] if settings.cors_origins else "/"
+
+
+def _ui_login_error_redirect(error_code: str) -> RedirectResponse:
+    base = settings.cors_origins[0] if settings.cors_origins else ""
+    return RedirectResponse(f"{base}/login?error={error_code}", status_code=303)
 
 
 def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> User:
@@ -70,8 +75,8 @@ def github_login(request: Request):
     try:
         state = github_oauth.sign_state()
         url = github_oauth.build_authorize_url(state=state, redirect_uri=_callback_url(request))
-    except github_oauth.GitHubOAuthNotConfigured as exc:
-        raise HTTPException(status_code=503, detail=str(exc))
+    except github_oauth.GitHubOAuthNotConfigured:
+        return _ui_login_error_redirect("github_not_configured")
     return RedirectResponse(url, status_code=307)
 
 
@@ -83,15 +88,15 @@ def github_callback(
     db: Session = Depends(get_db),
 ):
     if not code or not state or not github_oauth.verify_state(state):
-        raise HTTPException(status_code=400, detail="Invalid OAuth state or code")
+        return _ui_login_error_redirect("github_invalid_state")
     try:
         user_token = github_oauth.exchange_code_for_token(code, redirect_uri=_callback_url(request))
         identity = github_oauth.fetch_identity(user_token)
-    except github_oauth.GitHubOAuthNotConfigured as exc:
-        raise HTTPException(status_code=503, detail=str(exc))
+    except github_oauth.GitHubOAuthNotConfigured:
+        return _ui_login_error_redirect("github_not_configured")
     except github_oauth.GitHubOAuthError as exc:
         logger.warning("GitHub OAuth callback failed: %s", exc)
-        raise HTTPException(status_code=400, detail=str(exc))
+        return _ui_login_error_redirect("github_oauth_failed")
     user = find_or_create_user(db, identity)
     org_provisioning.sync_org_admin_memberships(db, user, user_token)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -80,12 +80,13 @@ def test_login_redirects_to_github(gh_client, oauth_configured):
     assert resp.headers["location"].startswith("https://github.com/login/oauth/authorize")
 
 
-def test_login_unconfigured_returns_503(gh_client, monkeypatch):
+def test_login_unconfigured_redirects_to_ui_with_error(gh_client, monkeypatch):
     # Force unconfigured regardless of the ambient .env (a real App may be configured locally).
     monkeypatch.setattr(settings, "github_app_client_id", None)
     monkeypatch.setattr(settings, "github_app_client_secret", None)
     resp = gh_client.get("/auth/github/login", follow_redirects=False)
-    assert resp.status_code == 503
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_not_configured")
 
 
 def test_callback_creates_user_and_sets_cookie(gh_client, db):
@@ -104,4 +105,17 @@ def test_callback_creates_user_and_sets_cookie(gh_client, db):
 def test_callback_rejects_bad_state(gh_client):
     with patch("src.routers.github_auth.github_oauth.verify_state", return_value=False):
         resp = gh_client.get("/auth/github/callback?code=c&state=bad", follow_redirects=False)
-    assert resp.status_code == 400
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_invalid_state")
+
+
+def test_callback_redirects_to_ui_on_oauth_error(gh_client):
+    from src.services.github_oauth import GitHubOAuthError
+
+    with (
+        patch("src.routers.github_auth.github_oauth.verify_state", return_value=True),
+        patch("src.routers.github_auth.github_oauth.exchange_code_for_token", side_effect=GitHubOAuthError("bad_verification_code")),
+    ):
+        resp = gh_client.get("/auth/github/callback?code=c&state=s", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"].endswith("/login?error=github_oauth_failed")

--- a/apps/ui/app/login/page.tsx
+++ b/apps/ui/app/login/page.tsx
@@ -28,6 +28,17 @@ function safeNextPath(next: string | null): string {
   return next
 }
 
+const GITHUB_ERROR_MESSAGES: Record<string, string> = {
+  github_not_configured: "GitHub sign-in isn't set up on this server yet. Use email and password, or ask an admin to configure it.",
+  github_invalid_state: "Your GitHub sign-in attempt expired or was invalid. Please try again.",
+  github_oauth_failed: "GitHub sign-in failed. Please try again.",
+}
+
+function githubErrorMessage(code: string | null): string {
+  if (!code) return ""
+  return GITHUB_ERROR_MESSAGES[code] || "GitHub sign-in failed. Please try again."
+}
+
 export default function LoginPage() {
   const { user, login, isLoading } = useAuth()
   const router = useRouter()
@@ -36,8 +47,18 @@ export default function LoginPage() {
 
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
-  const [error, setError] = useState("")
+  const [error, setError] = useState(() => githubErrorMessage(searchParams.get("error")))
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Strip ?error= from the URL once read, so a refresh doesn't re-show a stale message.
+  useEffect(() => {
+    if (!searchParams.get("error")) return
+    const params = new URLSearchParams(searchParams)
+    params.delete("error")
+    const qs = params.toString()
+    router.replace(qs ? `/login?${qs}` : "/login")
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Redirect if already authenticated or setup is needed
   useEffect(() => {


### PR DESCRIPTION
## Summary
- "Sign in with GitHub" does a full-page navigation straight to the API's `/auth/github/login`, so any OAuth error (app not configured, invalid/expired state, exchange failure) rendered as bare API JSON in the browser instead of a proper page.
- `/auth/github/login` and `/auth/github/callback` now redirect back to the UI's `/login?error=<code>` on failure instead of raising an `HTTPException`.
- The login page reads the `error` param, shows a friendly inline message (reusing the existing error UI used for password login), and strips the param from the URL so a refresh doesn't re-show it.

## Test plan
- [x] `pytest apps/api/tests/test_github_auth.py` — updated the two tests that asserted the old JSON/status-code behavior, added a new test for the OAuth-exchange-failure redirect path
- [x] `pytest -q` (full suite) — 150 passed
- [x] `bun run typecheck` / `bun run lint` in `apps/ui` — clean