### PR TITLE
fix: batch resolve open issues (#74–#104, #22 partial)

### DIFF
--- a/apps/api/alembic/versions/0013_installation_unique_constraints.py
+++ b/apps/api/alembic/versions/0013_installation_unique_constraints.py
@@ -1,0 +1,36 @@
+"""Unique constraints for github_installations upsert keys.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_github_installations_org_account",
+        "github_installations",
+        ["org_id", "account_login"],
+        unique=True,
+        postgresql_where=sa.text("org_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_github_installations_user_account",
+        "github_installations",
+        ["owner_user_id", "account_login"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_github_installations_user_account", table_name="github_installations")
+    op.drop_index("uq_github_installations_org_account", table_name="github_installations")

--- a/apps/api/src/core/_crypto.py
+++ b/apps/api/src/core/_crypto.py
@@ -1,37 +1,3 @@
-import base64
-import hashlib
+from checks.crypto import decrypt_job_token, encrypt_job_token
 
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
-# job is to make the derived key resistant to precomputed-hash attacks, not to add
-# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
-_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
-_PBKDF2_ITERATIONS = 480_000
-_V2_PREFIX = "v2:"
-
-
-def _legacy_fernet(raw_key: str) -> Fernet:
-    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
-    to decrypt ciphertext persisted before this change; never used for new encryption."""
-    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
-    return Fernet(derived)
-
-
-def _fernet_v2(raw_key: str) -> Fernet:
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
-    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
-    return Fernet(derived)
-
-
-def encrypt_job_token(token: str, key: str) -> str:
-    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
-
-
-def decrypt_job_token(encrypted: str, key: str) -> str:
-    if encrypted.startswith(_V2_PREFIX):
-        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
-    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
-    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()
+__all__ = ["decrypt_job_token", "encrypt_job_token"]

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -31,6 +31,20 @@ class GitHubInstallation(Base):
             "OR (org_id IS NULL AND owner_user_id IS NOT NULL)",
             name="ck_github_installations_org_xor_owner",
         ),
+        Index(
+            "uq_github_installations_org_account",
+            "org_id",
+            "account_login",
+            unique=True,
+            postgresql_where="org_id IS NOT NULL",
+        ),
+        Index(
+            "uq_github_installations_user_account",
+            "owner_user_id",
+            "account_login",
+            unique=True,
+            postgresql_where="owner_user_id IS NOT NULL",
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/apps/api/src/core/middleware.py
+++ b/apps/api/src/core/middleware.py
@@ -1,12 +1,12 @@
-import uuid
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from src.core.logging import request_id_var
+from src.core.request_id import resolve_request_id
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
-        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        request_id = resolve_request_id(request.headers.get("X-Request-ID"))
         token = request_id_var.set(request_id)
         try:
             response = await call_next(request)

--- a/apps/api/src/core/request_id.py
+++ b/apps/api/src/core/request_id.py
@@ -1,0 +1,21 @@
+"""Request ID validation for X-Request-ID propagation."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+_MAX_LEN = 128
+_SAFE_PATTERN = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+
+def resolve_request_id(header_value: str | None) -> str:
+    """Return a safe request ID from the client header, or generate a UUID."""
+    if header_value is None:
+        return str(uuid.uuid4())
+
+    value = header_value.strip()
+    if not value or len(value) > _MAX_LEN or not _SAFE_PATTERN.fullmatch(value):
+        return str(uuid.uuid4())
+
+    return value

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from src.core.db import GitHubInstallation
 
 
-def create(
+def upsert(
     db: Session,
     account_login: str,
     account_type: str,
@@ -14,7 +14,24 @@ def create(
 ) -> GitHubInstallation:
     if (org_id is None) == (owner_user_id is None):
         raise ValueError("Exactly one of org_id or owner_user_id must be set")
+
+    query = db.query(GitHubInstallation).filter(GitHubInstallation.account_login == account_login)
+    if org_id is not None:
+        query = query.filter(GitHubInstallation.org_id == org_id)
+    else:
+        query = query.filter(GitHubInstallation.owner_user_id == owner_user_id)
+
+    existing = query.first()
     token_ref = f"tok_{account_login}"
+    if existing:
+        existing.account_type = account_type
+        existing.auth_mode = auth_mode
+        existing.installation_id = installation_id
+        existing.token_ref = token_ref
+        db.commit()
+        db.refresh(existing)
+        return existing
+
     row = GitHubInstallation(
         account_login=account_login,
         account_type=account_type,
@@ -28,6 +45,26 @@ def create(
     db.commit()
     db.refresh(row)
     return row
+
+
+def create(
+    db: Session,
+    account_login: str,
+    account_type: str,
+    auth_mode: str,
+    installation_id: int | None = None,
+    org_id: int | None = None,
+    owner_user_id: int | None = None,
+) -> GitHubInstallation:
+    return upsert(
+        db,
+        account_login=account_login,
+        account_type=account_type,
+        auth_mode=auth_mode,
+        installation_id=installation_id,
+        org_id=org_id,
+        owner_user_id=owner_user_id,
+    )
 
 
 def list_for_org(db: Session, org_id: int) -> list[GitHubInstallation]:

--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
@@ -11,9 +12,20 @@ from src.services.github_client import GitHubClient
 router = APIRouter()
 
 
+def _github_cache_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    if isinstance(exc, httpx.RequestError):
+        return HTTPException(status_code=503, detail="GitHub API unreachable")
+    raise exc
+
+
 def _list_caches(owner: str, repo: str, payload: CacheListInput) -> CacheListResponse:
-    client = GitHubClient(payload.token.get_secret_value())
-    data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
+    try:
+        client = GitHubClient(payload.token.get_secret_value())
+        data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_cache_error(exc) from exc
     return {"repository": f"{owner}/{repo}", "total": data.get("total_count", 0), "actions_caches": data.get("actions_caches", [])}
 
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -37,7 +37,9 @@ def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
-def _verify_password(password: str, password_hash: str) -> bool:
+def _verify_password(password: str, password_hash: str | None) -> bool:
+    if not password_hash:
+        return False
     return bcrypt.checkpw(password.encode(), password_hash.encode())
 
 

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -68,18 +68,22 @@ def sync_personal_installation(
     user: UserOut = Depends(require_auth),
     db: Session = Depends(get_db),
 ):
-    if payload.account_type == "User":
-        db_user = db.query(User).filter(User.id == user.id).first()
-        if not db_user or not db_user.github_login:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Link your GitHub account before syncing a personal installation",
-            )
-        if payload.account_login != db_user.github_login:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="account_login must match your own GitHub account",
-            )
+    if payload.account_type != "User":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Personal installation sync only supports account_type User; use org sync for organizations",
+        )
+    db_user = db.query(User).filter(User.id == user.id).first()
+    if not db_user or not db_user.github_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Link your GitHub account before syncing a personal installation",
+        )
+    if payload.account_login != db_user.github_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="account_login must match your own GitHub account",
+        )
     row = installation_repo.create(
         db,
         account_login=payload.account_login,

--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -2,13 +2,16 @@ from checks.runner import run_all_checks
 
 from src.core.config import settings
 
+_SCOREABLE = {"pass", "fail"}
+
 
 def get_overview(owner: str, token: str) -> dict:
     base_url = settings.github_api_base
     report = run_all_checks(owner=owner, token=token, base_url=base_url)
     checks = report["checks"]
-    failed = [c for c in checks if c["status"] == "fail"]
-    score = 100 - int((len(failed) / max(1, len(checks))) * 100)
+    scoreable = [c for c in checks if c["status"] in _SCOREABLE]
+    failed = [c for c in scoreable if c["status"] == "fail"]
+    score = 100 - int((len(failed) / max(1, len(scoreable))) * 100)
     return {
         "owner": owner,
         "score": score,

--- a/apps/api/tests/test_actions_cache.py
+++ b/apps/api/tests/test_actions_cache.py
@@ -1,0 +1,34 @@
+"""Tests for actions-cache GitHub error mapping."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.routers.actions_cache import router as cache_router
+
+_USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def cache_client():
+    app = FastAPI()
+    app.include_router(cache_router)
+    app.dependency_overrides[require_auth] = lambda: _USER
+    return TestClient(app)
+
+
+def test_list_caches_maps_github_status_error_to_400(cache_client):
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x"))
+    error = httpx.HTTPStatusError("missing", request=response.request, response=response)
+    with patch("src.routers.actions_cache.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = cache_client.post(
+            "/me/repos/acme/demo/actions-caches",
+            json={"token": "ghp_testtoken123456789012345678901234"},
+        )
+    assert resp.status_code == 400
+    assert "404" in resp.json()["detail"]

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -142,6 +142,18 @@ def test_login_unknown_email(auth_client):
     assert resp.status_code == 401
 
 
+def test_login_github_only_user_returns_401(auth_client, db):
+    from src.core.db import User
+
+    db.add(User(email="github-only@example.com", password_hash=None, is_workspace_admin=False))
+    db.commit()
+    resp = auth_client.post(
+        "/auth/login", json={"email": "github-only@example.com", "password": "anypassword12"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
 # me
 
 def test_me_unauthenticated(auth_client):

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -137,3 +137,23 @@ def test_sync_personal_installation_login_mismatch_forbidden(db):
         json={"account_login": "someone-else", "account_type": "User", "installation_id": 3},
     )
     assert resp.status_code == 403
+
+
+def test_sync_personal_installation_rejects_organization_account_type(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    resp = _client(db, me).post(
+        "/me/installations/sync",
+        json={"account_login": "acme", "account_type": "Organization", "installation_id": 3},
+    )
+    assert resp.status_code == 403
+
+
+def test_sync_org_installation_upserts_existing_row(db, acme_org):
+    client = _client(db, acme_org["admin"])
+    payload = {"account_login": "acme", "account_type": "Organization", "installation_id": 7}
+    assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
+    payload["installation_id"] = 8
+    assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
+    rows = client.get("/orgs/acme/installations").json()
+    assert len(rows) == 1
+    assert rows[0]["installation_id"] == 8

--- a/apps/api/tests/test_request_id.py
+++ b/apps/api/tests/test_request_id.py
@@ -1,0 +1,41 @@
+"""Tests for X-Request-ID validation and middleware propagation."""
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.middleware import RequestIdMiddleware
+from src.core.request_id import resolve_request_id
+
+
+def test_resolve_request_id_generates_uuid_when_missing():
+    value = resolve_request_id(None)
+    uuid.UUID(value)
+
+
+def test_resolve_request_id_accepts_valid_client_id():
+    client_id = "req-abc123_456.test"
+    assert resolve_request_id(client_id) == client_id
+
+
+def test_resolve_request_id_rejects_oversized_value():
+    oversized = "a" * 129
+    generated = resolve_request_id(oversized)
+    assert generated != oversized
+    uuid.UUID(generated)
+
+
+def test_middleware_echoes_sanitized_request_id():
+    app = FastAPI()
+    app.add_middleware(RequestIdMiddleware)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Request-ID": "x" * 200})
+    echoed = response.headers["X-Request-ID"]
+    assert echoed != "x" * 200
+    uuid.UUID(echoed)

--- a/apps/ui/app/repos/[repo]/cache/page.tsx
+++ b/apps/ui/app/repos/[repo]/cache/page.tsx
@@ -13,6 +13,8 @@ import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { AlertTriangle, Eye, KeyRound, Loader2, Trash2 } from "lucide-react"
 import { api } from "@/lib/api/client"
+import { parseOwnerRepo } from "@/lib/repo-segment"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { formatBytes, relativeTime, classifyStaleness, stalenessColor } from "@/lib/format"
@@ -24,12 +26,19 @@ export default function CachePage() {
   const [tokenSaved, setTokenSaved] = useState(false)
   const [actor, setActor] = useState("")
 
-  const [owner, repo] = (params.repo || "").split("~")
+  const parsed = parseOwnerRepo(params.repo || "")
+  const owner = parsed?.owner ?? ""
+  const repo = parsed?.repo ?? ""
 
   // Auto-resolve saved token for this owner
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
-    onSuccess: (data) => { setToken(data.token); setTokenSaved(true) },
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
     onError: () => setTokenSaved(false),
   })
 
@@ -69,6 +78,17 @@ export default function CachePage() {
     name: ref,
     mb: Math.round((bytes / 1_048_576) * 100) / 100,
   }))
+
+  if (!parsed) {
+    return (
+      <>
+        <PageHeader title="Actions Cache" description="Invalid repository route." />
+        <div className="bg-card border border-border px-4 py-6 text-sm text-muted-foreground">
+          Expected URL format: <span className="font-mono">/repos/owner~repo/cache</span>
+        </div>
+      </>
+    )
+  }
 
   return (
     <>

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { AlertTriangle, KeyRound } from "lucide-react"
 import { api } from "@/lib/api/client"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { DonutChart } from "@/components/charts/donut-chart"
 import type { CheckResult } from "@/lib/api/types"
 
@@ -84,8 +85,13 @@ export default function SecurityPage() {
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
-    onSuccess: (data) => { setToken(data.token); setTokenSaved(true) },
-    onError:   () => setTokenSaved(false),
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
+    onError: () => setTokenSaved(false),
   })
 
   useEffect(() => {

--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -22,6 +22,8 @@ export default function OrgMembersPage() {
     queryFn: () => api.invitations.list(orgLogin),
   })
 
+  const [revokingId, setRevokingId] = useState<number | null>(null)
+
   const invite = useMutation({
     mutationFn: () => api.invitations.create(orgLogin, email.trim()),
     onSuccess: (data) => {
@@ -33,6 +35,8 @@ export default function OrgMembersPage() {
 
   const revoke = useMutation({
     mutationFn: (id: number) => api.invitations.revoke(orgLogin, id),
+    onMutate: (id) => setRevokingId(id),
+    onSettled: () => setRevokingId(null),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["invitations", orgLogin] }),
   })
 
@@ -103,7 +107,7 @@ export default function OrgMembersPage() {
                             size="sm"
                             variant="outline"
                             onClick={() => revoke.mutate(inv.id)}
-                            disabled={revoke.isPending}
+                            disabled={revokingId === inv.id}
                           >
                             <X className="size-3" />
                             Revoke

--- a/apps/ui/app/settings/page.tsx
+++ b/apps/ui/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { api } from "@/lib/api/client"
+import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values"
 import { useAuth } from "@/lib/auth-context"
 import { THEMES, useTheme } from "@/lib/theme"
 import type { InstallationMeta, MyOrgMembership, SavedTokenMeta } from "@/lib/api/types"
@@ -428,7 +429,7 @@ function InstanceConfigSection() {
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   useEffect(() => {
-    if (config) setValues(config)
+    if (config) setValues((prev) => initialConfigValues(prev, config))
   }, [config])
 
   async function saveKey(key: string) {
@@ -436,7 +437,11 @@ function InstanceConfigSection() {
     setErrors((prev) => ({ ...prev, [key]: "" }))
     try {
       await api.config.update(key, values[key] ?? "")
-      qc.invalidateQueries({ queryKey: ["config"] })
+      const updated = await qc.fetchQuery<Record<string, string>>({
+        queryKey: ["config"],
+        queryFn: api.config.getAll,
+      })
+      setValues((prev) => mergeSavedConfigValue(prev, updated, key))
     } catch (err) {
       setErrors((prev) => ({ ...prev, [key]: err instanceof Error ? err.message : "Save failed" }))
     } finally {

--- a/apps/ui/components/auth-guard.tsx
+++ b/apps/ui/components/auth-guard.tsx
@@ -11,7 +11,7 @@ const PUBLIC_ROUTES = ["/login", "/setup", "/register"]
 const PUBLIC_ROUTE_PREFIXES = ["/invite/"]
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { user, isLoading } = useAuth()
+  const { user, isLoading, logout } = useAuth()
   const router = useRouter()
   const pathname = usePathname()
 
@@ -41,11 +41,12 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
   // Listen for 401 events from the API client
   useEffect(() => {
     function handle401() {
+      logout()
       router.replace("/login")
     }
     window.addEventListener("clevis:unauthorized", handle401)
     return () => window.removeEventListener("clevis:unauthorized", handle401)
-  }, [router])
+  }, [logout, router])
 
   // Show nothing while checking auth or redirecting
   if (isLoading) {

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -100,6 +100,10 @@ async function del(path: string): Promise<void> {
     method: "DELETE",
     headers: { ...getAuthHeaders() },
   })
+  if (res.status === 401) {
+    if (typeof window !== "undefined") localStorage.removeItem(_TOKEN_KEY)
+    window.dispatchEvent(new Event("clevis:unauthorized"))
+  }
   if (!res.ok) {
     const json = await res.json().catch(() => ({}))
     throw new Error((json as { detail?: string }).detail ?? `Request failed: ${res.status}`)
@@ -139,12 +143,19 @@ export const api = {
   },
   cache: {
     list: (owner: string, repo: string, token: string) =>
-      post<CacheListResponse>(`/me/repos/${owner}/${repo}/actions-caches`, { token }),
+      post<CacheListResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions-caches`,
+        { token },
+      ),
     clear: (
       owner: string,
       repo: string,
       body: { token: string; actor: string; dry_run: boolean; key?: string; ref?: string },
-    ) => post<CacheClearResponse>(`/me/repos/${owner}/${repo}/actions-caches/clear`, body),
+    ) =>
+      post<CacheClearResponse>(
+        `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions-caches/clear`,
+        body,
+      ),
   },
   jobs: {
     list: () => get<JobOut[]>("/jobs"),

--- a/apps/ui/lib/auth-context.tsx
+++ b/apps/ui/lib/auth-context.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useCallback, useContext, useEffect, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 
 export interface AuthUser {
   id: number
@@ -13,8 +13,10 @@ interface AuthContextValue {
   user: AuthUser | null
   token: string | null
   isLoading: boolean
+  logoutWarning: string | null
   login(email: string, password: string): Promise<void>
   logout(): void
+  clearLogoutWarning(): void
   updateUser(u: Partial<AuthUser>): void
   setSession(jwtToken: string, authUser: AuthUser): void
 }
@@ -23,10 +25,11 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 
 const _TOKEN_KEY = "clevis:token"
 const BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080"
+const _LOGOUT_WARNING =
+  "Logged out locally, but the server session may still be active. Avoid shared devices until you can retry."
 
 function parseJwtPayload(token: string): AuthUser | null {
   try {
-    // JWT uses base64url — normalize to standard base64 before atob()
     const segment = token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")
     const padded = segment.padEnd(Math.ceil(segment.length / 4) * 4, "=")
     const payload = JSON.parse(atob(padded))
@@ -48,22 +51,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [token, setToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [logoutWarning, setLogoutWarning] = useState<string | null>(null)
+  const sessionEpochRef = useRef(0)
+
+  const bumpSessionEpoch = useCallback(() => {
+    sessionEpochRef.current += 1
+  }, [])
+
+  const clearLogoutWarning = useCallback(() => {
+    setLogoutWarning(null)
+  }, [])
 
   const logout = useCallback(() => {
-    // Clear the httpOnly cookie server-side (GitHub OAuth sessions); harmless for Bearer sessions.
-    fetch(`${BASE}/auth/logout`, { method: "POST", credentials: "include" }).catch(() => {})
+    bumpSessionEpoch()
+    fetch(`${BASE}/auth/logout`, { method: "POST", credentials: "include" })
+      .then((res) => {
+        if (!res.ok) setLogoutWarning(_LOGOUT_WARNING)
+      })
+      .catch(() => setLogoutWarning(_LOGOUT_WARNING))
     localStorage.removeItem(_TOKEN_KEY)
     setToken(null)
     setUser(null)
-  }, [])
+  }, [bumpSessionEpoch])
 
-  // On mount: restore a Bearer session optimistically, then validate against the server.
-  // Validation works for BOTH auth modes — the Bearer header (email/password) and the httpOnly
-  // session cookie (GitHub OAuth, where there is no localStorage token).
   useEffect(() => {
+    const epochAtStart = sessionEpochRef.current
     const stored = localStorage.getItem(_TOKEN_KEY)
 
-    // Optimistic restore from a stored token — unblock the UI without a network round-trip
     if (stored) {
       const optimistic = parseJwtPayload(stored)
       if (optimistic) {
@@ -73,15 +87,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       }
     }
 
-    // Timed out so a stalled /auth/me can never leave the app stuck on the full-screen spinner.
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), 15000)
     fetch(`${BASE}/auth/me`, {
       headers: stored ? { Authorization: `Bearer ${stored}` } : {},
-      credentials: "include", // sends the httpOnly cookie for GitHub OAuth sessions
+      credentials: "include",
       signal: controller.signal,
     })
       .then(async (res) => {
+        if (sessionEpochRef.current !== epochAtStart) return
         if (res.status === 401) {
           if (stored) logout()
           return
@@ -91,9 +105,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (stored) setToken(stored)
         setUser(data)
       })
-      .catch(() => {
-        // Network unreachable or timed out — keep any optimistic session
-      })
+      .catch(() => {})
       .finally(() => {
         clearTimeout(timer)
         setIsLoading(false)
@@ -109,23 +121,39 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const data = await res.json()
     if (!res.ok) throw new Error(data.detail ?? "Login failed")
     const { access_token, user: u } = data as { access_token: string; user: AuthUser }
+    bumpSessionEpoch()
+    clearLogoutWarning()
     localStorage.setItem(_TOKEN_KEY, access_token)
     setToken(access_token)
     setUser(u)
-  }, [])
+  }, [bumpSessionEpoch, clearLogoutWarning])
 
   const updateUser = useCallback((patch: Partial<AuthUser>) => {
     setUser((prev) => (prev ? { ...prev, ...patch } : prev))
   }, [])
 
   const setSession = useCallback((jwtToken: string, authUser: AuthUser) => {
+    bumpSessionEpoch()
+    clearLogoutWarning()
     localStorage.setItem(_TOKEN_KEY, jwtToken)
     setToken(jwtToken)
     setUser(authUser)
-  }, [])
+  }, [bumpSessionEpoch, clearLogoutWarning])
 
   return (
-    <AuthContext.Provider value={{ user, token, isLoading, login, logout, updateUser, setSession }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        token,
+        isLoading,
+        logoutWarning,
+        login,
+        logout,
+        clearLogoutWarning,
+        updateUser,
+        setSession,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/apps/ui/lib/config-values.ts
+++ b/apps/ui/lib/config-values.ts
@@ -1,0 +1,16 @@
+/** Helpers for instance-config form state vs server refetches. */
+
+export function initialConfigValues(
+  current: Record<string, string>,
+  server: Record<string, string>,
+): Record<string, string> {
+  return Object.keys(current).length === 0 ? server : current
+}
+
+export function mergeSavedConfigValue(
+  current: Record<string, string>,
+  server: Record<string, string>,
+  savedKey: string,
+): Record<string, string> {
+  return { ...current, [savedKey]: server[savedKey] ?? current[savedKey] ?? "" }
+}

--- a/apps/ui/lib/repo-segment.ts
+++ b/apps/ui/lib/repo-segment.ts
@@ -1,0 +1,9 @@
+/** Parse /repos/{owner~repo} dynamic segment from the UI router. */
+
+export function parseOwnerRepo(segment: string): { owner: string; repo: string } | null {
+  const parts = segment.split("~")
+  if (parts.length !== 2) return null
+  const [owner, repo] = parts
+  if (!owner.trim() || !repo.trim()) return null
+  return { owner: owner.trim(), repo: repo.trim() }
+}

--- a/apps/ui/lib/token-resolve.ts
+++ b/apps/ui/lib/token-resolve.ts
@@ -1,0 +1,5 @@
+/** Guard token auto-resolve so stale responses cannot bind the wrong org. */
+
+export function shouldApplyResolvedToken(requestedOrg: string, currentOwner: string): boolean {
+  return requestedOrg.trim() === currentOwner.trim()
+}

--- a/apps/ui/tests/lib/open-issues-helpers.test.ts
+++ b/apps/ui/tests/lib/open-issues-helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { initialConfigValues, mergeSavedConfigValue } from "@/lib/config-values";
+import { parseOwnerRepo } from "@/lib/repo-segment";
+import { shouldApplyResolvedToken } from "@/lib/token-resolve";
+
+describe("config-values", () => {
+  it("preserves unsaved edits when config refetches", () => {
+    const current = { worker_poll_seconds: "45", registration_enabled: "false" };
+    const server = { worker_poll_seconds: "30", registration_enabled: "true" };
+    expect(initialConfigValues(current, server)).toEqual(current);
+  });
+});
+
+describe("repo-segment", () => {
+  it("rejects malformed owner~repo segments", () => {
+    expect(parseOwnerRepo("only-owner")).toBeNull();
+    expect(parseOwnerRepo("owner~")).toBeNull();
+  });
+
+  it("parses valid owner~repo segments", () => {
+    expect(parseOwnerRepo("acme~demo")).toEqual({ owner: "acme", repo: "demo" });
+  });
+});
+
+describe("token-resolve", () => {
+  it("ignores stale resolve responses for a different owner", () => {
+    expect(shouldApplyResolvedToken("acme", "other-org")).toBe(false);
+    expect(shouldApplyResolvedToken("acme", "acme")).toBe(true);
+  });
+});

--- a/apps/worker/src/_crypto.py
+++ b/apps/worker/src/_crypto.py
@@ -1,37 +1,3 @@
-import base64
-import hashlib
+from checks.crypto import decrypt_job_token, encrypt_job_token
 
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
-# job is to make the derived key resistant to precomputed-hash attacks, not to add
-# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
-_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
-_PBKDF2_ITERATIONS = 480_000
-_V2_PREFIX = "v2:"
-
-
-def _legacy_fernet(raw_key: str) -> Fernet:
-    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
-    to decrypt ciphertext persisted before this change; never used for new encryption."""
-    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
-    return Fernet(derived)
-
-
-def _fernet_v2(raw_key: str) -> Fernet:
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
-    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
-    return Fernet(derived)
-
-
-def encrypt_job_token(token: str, key: str) -> str:
-    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
-
-
-def decrypt_job_token(encrypted: str, key: str) -> str:
-    if encrypted.startswith(_V2_PREFIX):
-        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
-    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
-    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()
+__all__ = ["decrypt_job_token", "encrypt_job_token"]

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -15,12 +15,12 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-# psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+_PROCESSING_STALE_MINUTES = 30
+_REQUIRED_PAYLOAD_KEYS = ("owner", "repo", "token")
 
 
 def _read_app_config(key: str, default: str) -> str:
-    """Read a single value from app_config. Falls back to default on any error."""
     try:
         with psycopg.connect(_DB_URL) as conn:
             with conn.cursor() as cur:
@@ -33,8 +33,6 @@ def _read_app_config(key: str, default: str) -> str:
 
 
 def _read_poll_seconds() -> int:
-    """Read worker_poll_seconds, clamped to a minimum of 1. Falls back to 5 on a
-    malformed value so a bad config row can never crash or busy-loop the worker."""
     raw = _read_app_config("worker_poll_seconds", "5")
     try:
         return max(1, int(raw))
@@ -43,10 +41,33 @@ def _read_poll_seconds() -> int:
         return 5
 
 
+def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE jobs SET status = 'queued', updated_at = NOW()
+            WHERE status = 'processing'
+              AND updated_at < NOW() - make_interval(mins => %s)
+            """,
+            (_PROCESSING_STALE_MINUTES,),
+        )
+    conn.commit()
+
+
+def _validate_payload(payload: dict) -> None:
+    for key in _REQUIRED_PAYLOAD_KEYS:
+        value = payload.get(key)
+        if value is None or value == "":
+            raise ValueError(f"Missing required payload field: {key}")
+
+
 def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None:
     base = settings.github_api_base
     try:
         payload = json.loads(payload_raw)
+        if not isinstance(payload, dict):
+            raise ValueError("Job payload must be a JSON object")
+        _validate_payload(payload)
         owner, repo = payload["owner"], payload["repo"]
         token = decrypt_job_token(payload["token"], settings.job_secret_key.get_secret_value())
         params = {k: payload[k] for k in ("key", "ref") if payload.get(k)}
@@ -84,10 +105,10 @@ def run() -> None:
     poll_seconds = _read_poll_seconds()
     log.info("worker started, polling every %ds", poll_seconds)
     while True:
-        # Re-read poll interval each cycle so changes in settings take effect without restart
         poll_seconds = _read_poll_seconds()
         try:
             with psycopg.connect(_DB_URL) as conn:
+                _reclaim_stale_jobs(conn)
                 with conn.cursor() as cur:
                     cur.execute("""
                         UPDATE jobs SET status = 'processing', updated_at = NOW()

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -122,6 +122,14 @@ def test_process_job_truncates_long_error():
     assert params[0].endswith("...(truncated)")
 
 
+def test_process_job_marks_failed_on_invalid_payload():
+    conn = _FakeConn()
+    process_job(conn, 6, json.dumps({"owner": "acme"}))
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert "Missing required payload field" in params[0]
+
+
 def test_process_job_redacts_token_shaped_text_in_error():
     conn = _FakeConn()
 

--- a/packages/checks/src/checks/crypto.py
+++ b/packages/checks/src/checks/crypto.py
@@ -1,0 +1,31 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
+_PBKDF2_ITERATIONS = 480_000
+_V2_PREFIX = "v2:"
+
+
+def _legacy_fernet(raw_key: str) -> Fernet:
+    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
+    return Fernet(derived)
+
+
+def _fernet_v2(raw_key: str) -> Fernet:
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
+    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
+    return Fernet(derived)
+
+
+def encrypt_job_token(token: str, key: str) -> str:
+    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
+
+
+def decrypt_job_token(encrypted: str, key: str) -> str:
+    if encrypted.startswith(_V2_PREFIX):
+        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
+    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()

--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -36,6 +36,15 @@ def _get_all_pages(base_url: str, path: str, token: str) -> list:
     return results
 
 
+def _branch_protection_status(exc: httpx.HTTPStatusError) -> str:
+    code = exc.response.status_code
+    if code == 404:
+        return "unprotected"
+    if code in (403, 429):
+        return "unknown"
+    return "unprotected"
+
+
 class OrgMFARequired(Check):
     metadata = CheckMetadata(
         check_id="organization_members_mfa_required",
@@ -52,7 +61,12 @@ class OrgMFARequired(Check):
         repos: list | None = None,  # unused — MFA check operates at org level
     ) -> dict:
         org = _get(f"{base_url}/orgs/{owner}", token)
-        enabled = bool(org.get("two_factor_requirement_enabled", False))
+        if "two_factor_requirement_enabled" not in org:
+            return {
+                "status": "error",
+                "value": "Token lacks org-owner scope to read MFA requirement status",
+            }
+        enabled = bool(org["two_factor_requirement_enabled"])
         return {"status": "pass" if enabled else "fail", "value": enabled}
 
 
@@ -73,8 +87,11 @@ class BranchProtectionEnabled(Check):
     ) -> dict:
         if repos is None:
             repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if not repos:
+            return {"status": "not_applicable", "value": {"checked": 0, "protected": 0, "unknown": 0}}
         checked = 0
         protected = 0
+        unknown = 0
         for repo in repos:
             checked += 1
             branch = repo.get("default_branch")
@@ -82,10 +99,21 @@ class BranchProtectionEnabled(Check):
                 details = _get(f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}", token)
                 if details.get("protected"):
                     protected += 1
-            except httpx.HTTPStatusError:
-                pass  # treat inaccessible branches as unprotected
-        compliant = checked > 0 and checked == protected
-        return {"status": "pass" if compliant else "fail", "value": {"checked": checked, "protected": protected}}
+            except httpx.HTTPStatusError as exc:
+                outcome = _branch_protection_status(exc)
+                if outcome == "unknown":
+                    unknown += 1
+                # 404 counts as unprotected (not incrementing protected)
+            except httpx.HTTPError:
+                unknown += 1
+        evaluable = checked - unknown
+        if evaluable == 0:
+            return {"status": "error", "value": {"checked": checked, "protected": protected, "unknown": unknown}}
+        compliant = protected == evaluable
+        return {
+            "status": "pass" if compliant else "fail",
+            "value": {"checked": checked, "protected": protected, "unknown": unknown},
+        }
 
 
 class SecretScanningEnabled(Check):
@@ -105,11 +133,23 @@ class SecretScanningEnabled(Check):
     ) -> dict:
         if repos is None:
             repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if not repos:
+            return {"status": "not_applicable", "value": {"enabled": 0, "total": 0, "unknown": 0}}
         enabled = 0
+        unknown = 0
         total = len(repos)
         for repo in repos:
-            sec = repo.get("security_and_analysis", {})
+            sec = repo.get("security_and_analysis") or {}
+            if not sec:
+                unknown += 1
+                continue
             if sec.get("secret_scanning", {}).get("status") == "enabled":
                 enabled += 1
-        compliant = total > 0 and enabled == total
-        return {"status": "pass" if compliant else "fail", "value": {"enabled": enabled, "total": total}}
+        evaluable = total - unknown
+        if evaluable == 0:
+            return {"status": "error", "value": {"enabled": enabled, "total": total, "unknown": unknown}}
+        compliant = enabled == evaluable
+        return {
+            "status": "pass" if compliant else "fail",
+            "value": {"enabled": enabled, "total": total, "unknown": unknown},
+        }

--- a/packages/checks/src/checks/runner.py
+++ b/packages/checks/src/checks/runner.py
@@ -1,14 +1,24 @@
+import logging
+
 from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled, _get_all_pages
+
+logger = logging.getLogger(__name__)
 
 
 def run_all_checks(owner: str, token: str, base_url: str = "https://api.github.com") -> dict:
-    # Fetch repos once and share with all checks that need them (B-05: avoid double pagination)
     repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
 
     checks = [OrgMFARequired(), BranchProtectionEnabled(), SecretScanningEnabled()]
     results = []
     for check in checks:
-        output = check.run(owner=owner, token=token, base_url=base_url, repos=repos)
+        try:
+            output = check.run(owner=owner, token=token, base_url=base_url, repos=repos)
+        except Exception:
+            logger.exception("check %s failed", check.metadata.check_id)
+            output = {
+                "status": "error",
+                "value": f"Check failed: {check.metadata.check_id}",
+            }
         results.append({
             "id": check.metadata.check_id,
             "title": check.metadata.title,

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -1,0 +1,43 @@
+"""Tests for individual GitHub security checks."""
+
+import httpx
+import pytest
+
+from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled
+
+
+def test_org_mfa_missing_field_returns_error():
+    check = OrgMFARequired()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", lambda url, token: {"login": "acme"})
+        result = check.run(owner="acme", token="tok")
+    assert result["status"] == "error"
+
+
+def test_secret_scanning_null_security_and_analysis_does_not_crash():
+    check = SecretScanningEnabled()
+    repos = [{"name": "demo", "security_and_analysis": None}]
+    result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+    assert result["value"]["unknown"] == 1
+
+
+def test_secret_scanning_empty_org_is_not_applicable():
+    check = SecretScanningEnabled()
+    result = check.run(owner="acme", token="tok", repos=[])
+    assert result["status"] == "not_applicable"
+
+
+def test_branch_protection_rate_limit_counts_as_unknown():
+    check = BranchProtectionEnabled()
+    repos = [{"name": "demo", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(403, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+    assert result["value"]["unknown"] == 1

--- a/packages/checks/tests/test_runner_isolation.py
+++ b/packages/checks/tests/test_runner_isolation.py
@@ -1,0 +1,20 @@
+"""Per-check isolation in run_all_checks."""
+
+from unittest.mock import patch
+
+from checks.runner import run_all_checks
+
+
+def test_run_all_checks_continues_when_one_check_raises():
+    with (
+        patch("checks.runner._get_all_pages", return_value=[]),
+        patch("checks.github_checks.OrgMFARequired.run", side_effect=RuntimeError("boom")),
+        patch("checks.github_checks.BranchProtectionEnabled.run", return_value={"status": "not_applicable", "value": {}}),
+        patch("checks.github_checks.SecretScanningEnabled.run", return_value={"status": "not_applicable", "value": {}}),
+    ):
+        result = run_all_checks(owner="acme", token="tok")
+
+    statuses = {c["id"]: c["status"] for c in result["checks"]}
+    assert statuses["organization_members_mfa_required"] == "error"
+    assert statuses["repository_default_branch_protection_enabled"] == "not_applicable"
+    assert statuses["repository_secret_scanning_enabled"] == "not_applicable"


### PR DESCRIPTION
## Summary

Single batch PR addressing the open bug reports on the issue tracker. Fixes already open in #105–#107 (#104, #100, #85) are included here too — close those if this merges, or rebase this branch after they land.

| Issue | Fix |
|-------|-----|
| #74 | `security_and_analysis: null` → neutral/error, no crash |
| #75 | `AuthGuard` calls `logout()` on 401 |
| #76/#101 | GitHub-only accounts get 401, not 500 |
| #79 | Installation sync upserts + migration 0013 unique indexes |
| #81 | Per-check try/except in `run_all_checks` |
| #82/#99 | Branch protection 403/429 → unknown bucket |
| #83 | Shared `checks.crypto` module (API + worker re-export) |
| #84 | Parse/validate `owner~repo` + encode cache paths |
| #87 | Empty org → `not_applicable`, excluded from score |
| #88 | Per-row revoke pending state |
| #89 | Logout network failure surfaces `logoutWarning` |
| #96 | `del()` handles 401 like other verbs |
| #97 | Token resolve guarded by current owner |
| #98 | MFA missing field → error, not false fail |
| #100 | Session epoch guard on mount `/auth/me` |
| #102 | Personal sync rejects `Organization` account_type |
| #103 | Actions-cache maps GitHub errors to 400/503 |
| #104 | X-Request-ID length/charset sanitization |
| #85 | Config form per-key merge on save |
| #22 | Partial: stale `processing` job reclaim + payload validation |

## Test plan
```
pytest packages/checks/tests -v                    # 7 passed (local)
pytest apps/worker/tests -v                         # 6 passed (local)
pytest apps/api/tests/test_request_id.py \
       apps/api/tests/test_actions_cache.py -v      # 5 passed (local)
vitest run tests/lib/open-issues-helpers.test.ts   # 4 passed (local)
tsc --noEmit                                        # passed (local)
```
Full suite + Postgres migrations run in GitHub CI once workflows are approved for this fork PR.

Made with [Cursor](https://cursor.com)