### PR TITLE
fix(api): map actions-cache GitHub errors to 400/503 (#103)

### DIFF
--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
@@ -11,9 +12,20 @@ from src.services.github_client import GitHubClient
 router = APIRouter()
 
 
+def _github_cache_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    if isinstance(exc, httpx.RequestError):
+        return HTTPException(status_code=503, detail="GitHub API unreachable")
+    raise exc
+
+
 def _list_caches(owner: str, repo: str, payload: CacheListInput) -> CacheListResponse:
-    client = GitHubClient(payload.token.get_secret_value())
-    data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
+    try:
+        client = GitHubClient(payload.token.get_secret_value())
+        data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise _github_cache_error(exc) from exc
     return {"repository": f"{owner}/{repo}", "total": data.get("total_count", 0), "actions_caches": data.get("actions_caches", [])}
 
 

--- a/apps/api/tests/test_actions_cache.py
+++ b/apps/api/tests/test_actions_cache.py
@@ -1,0 +1,34 @@
+"""Tests for actions-cache GitHub error mapping."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.routers.actions_cache import router as cache_router
+
+_USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def cache_client():
+    app = FastAPI()
+    app.include_router(cache_router)
+    app.dependency_overrides[require_auth] = lambda: _USER
+    return TestClient(app)
+
+
+def test_list_caches_maps_github_status_error_to_400(cache_client):
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/x"))
+    error = httpx.HTTPStatusError("missing", request=response.request, response=response)
+    with patch("src.routers.actions_cache.GitHubClient") as mock_client:
+        mock_client.return_value.request.side_effect = error
+        resp = cache_client.post(
+            "/me/repos/acme/demo/actions-caches",
+            json={"token": "ghp_testtoken123456789012345678901234"},
+        )
+    assert resp.status_code == 400
+    assert "404" in resp.json()["detail"]


### PR DESCRIPTION
## Summary
Fixes #103.

Map GitHub API failures from the actions-cache endpoints to appropriate HTTP status codes (400/503) instead of unhandled 500s.

## Test plan
- [x] `pytest apps/api/tests/test_actions_cache.py -v`

Made with [Cursor](https://cursor.com)