### PR TITLE
fix(auth): return 401 for password login on GitHub-only accounts (#101)

### DIFF
--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -37,7 +37,9 @@ def _hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
-def _verify_password(password: str, password_hash: str) -> bool:
+def _verify_password(password: str, password_hash: str | None) -> bool:
+    if not password_hash:
+        return False
     return bcrypt.checkpw(password.encode(), password_hash.encode())
 
 

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -142,6 +142,18 @@ def test_login_unknown_email(auth_client):
     assert resp.status_code == 401
 
 
+def test_login_github_only_user_returns_401(auth_client, db):
+    from src.core.db import User
+
+    db.add(User(email="github-only@example.com", password_hash=None, is_workspace_admin=False))
+    db.commit()
+    resp = auth_client.post(
+        "/auth/login", json={"email": "github-only@example.com", "password": "anypassword12"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
 # me
 
 def test_me_unauthenticated(auth_client):


### PR DESCRIPTION
## Summary
Fixes #101.

Password login on GitHub-only accounts now returns 401 with a clear message instead of a generic 500.

## Test plan
- [x] `pytest apps/api/tests/test_auth.py -v -k github_only`