### PR TITLE
fix(ui): handle 401 in del() HTTP helper like other verbs (#96)

### DIFF
--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -100,6 +100,10 @@ async function del(path: string): Promise<void> {
     method: "DELETE",
     headers: { ...getAuthHeaders() },
   })
+  if (res.status === 401) {
+    if (typeof window !== "undefined") localStorage.removeItem(_TOKEN_KEY)
+    window.dispatchEvent(new Event("clevis:unauthorized"))
+  }
   if (!res.ok) {
     const json = await res.json().catch(() => ({}))
     throw new Error((json as { detail?: string }).detail ?? `Request failed: ${res.status}`)


### PR DESCRIPTION
## Summary\nFixes #96.\n\n`del()` in the API client now clears auth state on 401, matching get/post/patch/put.\n\n## Test plan\n- [x] `cd apps/ui && bun run typecheck`

Made with [Cursor](https://cursor.com)