### PR TITLE
chore(api,worker): dedupe _crypto.py into shared checks.crypto module (#83)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,7 @@ pnpm-debug.log*
 .agents/
 .github/
 
-# Image that COPYs only apps/api + packages/checks
+# Images that COPY only apps/api (worker Dockerfile also uses repo root context)
 apps/ui/
 deploy/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build + Push Worker
         uses: docker/build-push-action@v6
         with:
-          context: apps/worker
+          context: .
           file: apps/worker/Dockerfile
           push: true
           tags: |

--- a/apps/api/src/core/_crypto.py
+++ b/apps/api/src/core/_crypto.py
@@ -1,37 +1,3 @@
-import base64
-import hashlib
+from checks.crypto import decrypt_job_token, encrypt_job_token
 
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
-# job is to make the derived key resistant to precomputed-hash attacks, not to add
-# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
-_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
-_PBKDF2_ITERATIONS = 480_000
-_V2_PREFIX = "v2:"
-
-
-def _legacy_fernet(raw_key: str) -> Fernet:
-    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
-    to decrypt ciphertext persisted before this change; never used for new encryption."""
-    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
-    return Fernet(derived)
-
-
-def _fernet_v2(raw_key: str) -> Fernet:
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
-    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
-    return Fernet(derived)
-
-
-def encrypt_job_token(token: str, key: str) -> str:
-    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
-
-
-def decrypt_job_token(encrypted: str, key: str) -> str:
-    if encrypted.startswith(_V2_PREFIX):
-        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
-    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
-    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()
+__all__ = ["decrypt_job_token", "encrypt_job_token"]

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY apps/worker/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY apps/worker/src ./src
-COPY apps/worker/entrypoint.sh .
 COPY packages/checks /app/packages/checks
 RUN pip install --no-cache-dir /app/packages/checks
+COPY apps/worker/src ./src
+COPY apps/worker/entrypoint.sh .
 ENV PYTHONPATH=/app/src
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]

--- a/apps/worker/src/_crypto.py
+++ b/apps/worker/src/_crypto.py
@@ -1,37 +1,3 @@
-import base64
-import hashlib
+from checks.crypto import decrypt_job_token, encrypt_job_token
 
-from cryptography.fernet import Fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-
-# Fixed application-level salt for the PBKDF2 key derivation below. It isn't secret — its
-# job is to make the derived key resistant to precomputed-hash attacks, not to add
-# per-ciphertext randomness (JOB_SECRET_KEY itself is what must stay secret).
-_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
-_PBKDF2_ITERATIONS = 480_000
-_V2_PREFIX = "v2:"
-
-
-def _legacy_fernet(raw_key: str) -> Fernet:
-    """Unsalted single-round SHA-256 derivation used before the v2 scheme below. Kept only
-    to decrypt ciphertext persisted before this change; never used for new encryption."""
-    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
-    return Fernet(derived)
-
-
-def _fernet_v2(raw_key: str) -> Fernet:
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
-    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
-    return Fernet(derived)
-
-
-def encrypt_job_token(token: str, key: str) -> str:
-    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
-
-
-def decrypt_job_token(encrypted: str, key: str) -> str:
-    if encrypted.startswith(_V2_PREFIX):
-        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
-    # Un-prefixed ciphertext predates the v2 scheme — fall back to the legacy derivation.
-    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()
+__all__ = ["decrypt_job_token", "encrypt_job_token"]

--- a/packages/checks/pyproject.toml
+++ b/packages/checks/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "clevis-checks"
 version = "0.1.0"
+dependencies = ["cryptography==44.0.2"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/packages/checks/src/checks/crypto.py
+++ b/packages/checks/src/checks/crypto.py
@@ -1,0 +1,31 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+_PBKDF2_SALT = b"clevis-job-token-fernet-v2"
+_PBKDF2_ITERATIONS = 480_000
+_V2_PREFIX = "v2:"
+
+
+def _legacy_fernet(raw_key: str) -> Fernet:
+    derived = base64.urlsafe_b64encode(hashlib.sha256(raw_key.encode()).digest())
+    return Fernet(derived)
+
+
+def _fernet_v2(raw_key: str) -> Fernet:
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=_PBKDF2_SALT, iterations=_PBKDF2_ITERATIONS)
+    derived = base64.urlsafe_b64encode(kdf.derive(raw_key.encode()))
+    return Fernet(derived)
+
+
+def encrypt_job_token(token: str, key: str) -> str:
+    return _V2_PREFIX + _fernet_v2(key).encrypt(token.encode()).decode()
+
+
+def decrypt_job_token(encrypted: str, key: str) -> str:
+    if encrypted.startswith(_V2_PREFIX):
+        return _fernet_v2(key).decrypt(encrypted[len(_V2_PREFIX):].encode()).decode()
+    return _legacy_fernet(key).decrypt(encrypted.encode()).decode()

--- a/packages/checks/tests/test_crypto.py
+++ b/packages/checks/tests/test_crypto.py
@@ -1,0 +1,37 @@
+"""Round-trip and backward-compatibility tests for token encryption (checks.crypto)."""
+
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+
+from checks.crypto import decrypt_job_token, encrypt_job_token
+
+_KEY = "test-job-secret-key"
+
+
+def _legacy_encrypt(token: str, key: str) -> str:
+    """Mirrors the pre-fix unsalted single-round SHA-256 derivation, to prove
+    already-encrypted (pre-migration) ciphertext still decrypts correctly."""
+    derived = base64.urlsafe_b64encode(hashlib.sha256(key.encode()).digest())
+    return Fernet(derived).encrypt(token.encode()).decode()
+
+
+def test_round_trip_new_format():
+    encrypted = encrypt_job_token("ghp_supersecret", _KEY)
+    assert encrypted.startswith("v2:")
+    assert decrypt_job_token(encrypted, _KEY) == "ghp_supersecret"
+
+
+def test_decrypts_legacy_unprefixed_ciphertext():
+    legacy_ciphertext = _legacy_encrypt("ghp_oldtoken", _KEY)
+    assert decrypt_job_token(legacy_ciphertext, _KEY) == "ghp_oldtoken"
+
+
+def test_wrong_key_fails_new_format():
+    encrypted = encrypt_job_token("ghp_supersecret", _KEY)
+    try:
+        decrypt_job_token(encrypted, "wrong-key")
+        assert False, "expected decryption to fail with the wrong key"
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
Fixes #83.

Deduplicate `_crypto.py` into a shared `checks.crypto` module used by both API and worker.

## Test plan
- [x] `pytest apps/api/tests/test_crypto.py apps/worker/tests/ -v`