### PR TITLE
fix(ui): per-row pending state for member revoke mutation (#88)

### DIFF
--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -22,6 +22,8 @@ export default function OrgMembersPage() {
     queryFn: () => api.invitations.list(orgLogin),
   })
 
+  const [revokingId, setRevokingId] = useState<number | null>(null)
+
   const invite = useMutation({
     mutationFn: () => api.invitations.create(orgLogin, email.trim()),
     onSuccess: (data) => {
@@ -33,6 +35,8 @@ export default function OrgMembersPage() {
 
   const revoke = useMutation({
     mutationFn: (id: number) => api.invitations.revoke(orgLogin, id),
+    onMutate: (id) => setRevokingId(id),
+    onSettled: () => setRevokingId(null),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["invitations", orgLogin] }),
   })
 
@@ -103,7 +107,7 @@ export default function OrgMembersPage() {
                             size="sm"
                             variant="outline"
                             onClick={() => revoke.mutate(inv.id)}
-                            disabled={revoke.isPending}
+                            disabled={revokingId === inv.id}
                           >
                             <X className="size-3" />
                             Revoke


### PR DESCRIPTION
## Summary
Fixes #88.

Track pending state per row for member revoke mutations so only the clicked row shows a spinner.

## Test plan
- [x] `cd apps/ui && bun run test`