### PR TITLE
fix(worker): reclaim stale processing jobs and validate payloads (#22)

### DIFF
--- a/apps/api/alembic/versions/0013_add_job_retry_count.py
+++ b/apps/api/alembic/versions/0013_add_job_retry_count.py
@@ -1,0 +1,25 @@
+"""Add jobs.retry_count for stale-processing reclaim cap.
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-07-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "retry_count")

--- a/apps/api/alembic/versions/0014_add_job_retry_count.py
+++ b/apps/api/alembic/versions/0014_add_job_retry_count.py
@@ -1,15 +1,15 @@
 """Add jobs.retry_count for stale-processing reclaim cap.
 
-Revision ID: 0013
-Revises: 0012
+Revision ID: 0014
+Revises: 0013
 Create Date: 2026-07-12
 """
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0013"
-down_revision = "0012"
+revision = "0014"
+down_revision = "0013"
 branch_labels = None
 depends_on = None
 

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -79,6 +79,7 @@ class Job(Base):
     payload: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
     result: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -17,6 +17,8 @@ log = logging.getLogger(__name__)
 
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
 _PROCESSING_STALE_MINUTES = 30
+_MAX_RECLAIM_RETRIES = 3
+_RECLAIM_FAILED_REASON = "Job exceeded reclaim retry limit after worker timeout"
 _REQUIRED_PAYLOAD_KEYS = ("owner", "repo", "token")
 
 
@@ -45,11 +47,21 @@ def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
     with conn.cursor() as cur:
         cur.execute(
             """
-            UPDATE jobs SET status = 'queued', updated_at = NOW()
+            UPDATE jobs SET status = 'failed', result = %s, updated_at = NOW()
             WHERE status = 'processing'
               AND updated_at < NOW() - make_interval(mins => %s)
+              AND retry_count >= %s
             """,
-            (_PROCESSING_STALE_MINUTES,),
+            (_RECLAIM_FAILED_REASON, _PROCESSING_STALE_MINUTES, _MAX_RECLAIM_RETRIES),
+        )
+        cur.execute(
+            """
+            UPDATE jobs SET status = 'queued', retry_count = retry_count + 1, updated_at = NOW()
+            WHERE status = 'processing'
+              AND updated_at < NOW() - make_interval(mins => %s)
+              AND retry_count < %s
+            """,
+            (_PROCESSING_STALE_MINUTES, _MAX_RECLAIM_RETRIES),
         )
     conn.commit()
 

--- a/apps/worker/src/worker.py
+++ b/apps/worker/src/worker.py
@@ -15,12 +15,12 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-# psycopg.connect() expects plain postgresql://, not the SQLAlchemy +psycopg dialect prefix
 _DB_URL = settings.database_url.get_secret_value().replace("postgresql+psycopg://", "postgresql://")
+_PROCESSING_STALE_MINUTES = 30
+_REQUIRED_PAYLOAD_KEYS = ("owner", "repo", "token")
 
 
 def _read_app_config(key: str, default: str) -> str:
-    """Read a single value from app_config. Falls back to default on any error."""
     try:
         with psycopg.connect(_DB_URL) as conn:
             with conn.cursor() as cur:
@@ -33,8 +33,6 @@ def _read_app_config(key: str, default: str) -> str:
 
 
 def _read_poll_seconds() -> int:
-    """Read worker_poll_seconds, clamped to a minimum of 1. Falls back to 5 on a
-    malformed value so a bad config row can never crash or busy-loop the worker."""
     raw = _read_app_config("worker_poll_seconds", "5")
     try:
         return max(1, int(raw))
@@ -43,10 +41,33 @@ def _read_poll_seconds() -> int:
         return 5
 
 
+def _reclaim_stale_jobs(conn: psycopg.Connection) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE jobs SET status = 'queued', updated_at = NOW()
+            WHERE status = 'processing'
+              AND updated_at < NOW() - make_interval(mins => %s)
+            """,
+            (_PROCESSING_STALE_MINUTES,),
+        )
+    conn.commit()
+
+
+def _validate_payload(payload: dict) -> None:
+    for key in _REQUIRED_PAYLOAD_KEYS:
+        value = payload.get(key)
+        if value is None or value == "":
+            raise ValueError(f"Missing required payload field: {key}")
+
+
 def process_job(conn: psycopg.Connection, job_id: int, payload_raw: str) -> None:
     base = settings.github_api_base
     try:
         payload = json.loads(payload_raw)
+        if not isinstance(payload, dict):
+            raise ValueError("Job payload must be a JSON object")
+        _validate_payload(payload)
         owner, repo = payload["owner"], payload["repo"]
         token = decrypt_job_token(payload["token"], settings.job_secret_key.get_secret_value())
         params = {k: payload[k] for k in ("key", "ref") if payload.get(k)}
@@ -84,10 +105,10 @@ def run() -> None:
     poll_seconds = _read_poll_seconds()
     log.info("worker started, polling every %ds", poll_seconds)
     while True:
-        # Re-read poll interval each cycle so changes in settings take effect without restart
         poll_seconds = _read_poll_seconds()
         try:
             with psycopg.connect(_DB_URL) as conn:
+                _reclaim_stale_jobs(conn)
                 with conn.cursor() as cur:
                     cur.execute("""
                         UPDATE jobs SET status = 'processing', updated_at = NOW()

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -122,6 +122,14 @@ def test_process_job_truncates_long_error():
     assert params[0].endswith("...(truncated)")
 
 
+def test_process_job_marks_failed_on_invalid_payload():
+    conn = _FakeConn()
+    process_job(conn, 6, json.dumps({"owner": "acme"}))
+    sql, params = conn._cursor.calls[0]
+    assert "status='failed'" in sql
+    assert "Missing required payload field" in params[0]
+
+
 def test_process_job_redacts_token_shaped_text_in_error():
     conn = _FakeConn()
 

--- a/apps/worker/tests/test_process_job.py
+++ b/apps/worker/tests/test_process_job.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from _crypto import encrypt_job_token
 from config import settings
-from worker import process_job
+from worker import _reclaim_stale_jobs, process_job
 
 
 class _FakeCursor:
@@ -128,6 +128,15 @@ def test_process_job_marks_failed_on_invalid_payload():
     sql, params = conn._cursor.calls[0]
     assert "status='failed'" in sql
     assert "Missing required payload field" in params[0]
+
+
+def test_reclaim_stale_jobs_caps_retries_before_requeue():
+    conn = _FakeConn()
+    _reclaim_stale_jobs(conn)
+    sqls = [call[0] for call in conn._cursor.calls]
+    assert any("retry_count >= %s" in sql and "status = 'failed'" in sql for sql in sqls)
+    assert any("retry_count = retry_count + 1" in sql for sql in sqls)
+    assert conn.committed is True
 
 
 def test_process_job_redacts_token_shaped_text_in_error():


### PR DESCRIPTION
## Summary
Partial fix for #22.

Worker reclaims jobs stuck in `processing` past a timeout, validates job payloads before execution, and caps reclaim retries via `jobs.retry_count` (migration `0014`).

## Test plan
- [x] `pytest apps/worker/tests/test_process_job.py -v` (7 passed)