### PR TITLE
fix(ui): guard token auto-resolve against stale cross-org responses (#97)

### DIFF
--- a/apps/ui/app/repos/[repo]/cache/page.tsx
+++ b/apps/ui/app/repos/[repo]/cache/page.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { AlertTriangle, Eye, KeyRound, Loader2, Trash2 } from "lucide-react"
 import { api } from "@/lib/api/client"
 import { parseOwnerRepo } from "@/lib/repo-segment"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { formatBytes, relativeTime, classifyStaleness, stalenessColor } from "@/lib/format"
@@ -32,7 +33,12 @@ export default function CachePage() {
   // Auto-resolve saved token for this owner
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
-    onSuccess: (data) => { setToken(data.token); setTokenSaved(true) },
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
     onError: () => setTokenSaved(false),
   })
 

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { AlertTriangle, KeyRound } from "lucide-react"
 import { api } from "@/lib/api/client"
+import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { DonutChart } from "@/components/charts/donut-chart"
 import type { CheckResult } from "@/lib/api/types"
 
@@ -84,8 +85,13 @@ export default function SecurityPage() {
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
-    onSuccess: (data) => { setToken(data.token); setTokenSaved(true) },
-    onError:   () => setTokenSaved(false),
+    onSuccess: (data, org) => {
+      if (shouldApplyResolvedToken(org, owner)) {
+        setToken(data.token)
+        setTokenSaved(true)
+      }
+    },
+    onError: () => setTokenSaved(false),
   })
 
   useEffect(() => {

--- a/apps/ui/lib/token-resolve.ts
+++ b/apps/ui/lib/token-resolve.ts
@@ -1,0 +1,5 @@
+/** Guard token auto-resolve so stale responses cannot bind the wrong org. */
+
+export function shouldApplyResolvedToken(requestedOrg: string, currentOwner: string): boolean {
+  return requestedOrg.trim() === currentOwner.trim()
+}

--- a/apps/ui/tests/lib/token-resolve.test.ts
+++ b/apps/ui/tests/lib/token-resolve.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldApplyResolvedToken } from "@/lib/token-resolve";
+
+describe("token-resolve", () => {
+  it("ignores stale resolve responses for a different owner", () => {
+    expect(shouldApplyResolvedToken("acme", "other-org")).toBe(false);
+    expect(shouldApplyResolvedToken("acme", "acme")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #97.

Token auto-resolve on security and cache pages ignores responses that no longer match the current owner.

## Test plan
- [x] `vitest run tests/lib/token-resolve.test.ts`
- [x] `cd apps/ui && bun run typecheck`

Made with [Cursor](https://cursor.com)