### PR TITLE
fix(checks): report MFA scope gap as error instead of false fail (#98)

### DIFF
--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -52,7 +52,12 @@ class OrgMFARequired(Check):
         repos: list | None = None,  # unused — MFA check operates at org level
     ) -> dict:
         org = _get(f"{base_url}/orgs/{owner}", token)
-        enabled = bool(org.get("two_factor_requirement_enabled", False))
+        if "two_factor_requirement_enabled" not in org:
+            return {
+                "status": "error",
+                "value": "Token lacks org-owner scope to read MFA requirement status",
+            }
+        enabled = bool(org["two_factor_requirement_enabled"])
         return {"status": "pass" if enabled else "fail", "value": enabled}
 
 

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -1,0 +1,13 @@
+"""Tests for individual GitHub security checks."""
+
+import pytest
+
+from checks.github_checks import OrgMFARequired
+
+
+def test_org_mfa_missing_field_returns_error():
+    check = OrgMFARequired()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", lambda url, token: {"login": "acme"})
+        result = check.run(owner="acme", token="tok")
+    assert result["status"] == "error"


### PR DESCRIPTION
## Summary
Fixes #98.

When the org API omits `two_factor_requirement_enabled`, return `error` instead of silently scoring as disabled.

## Test plan
- [x] `pytest packages/checks/tests/test_github_checks.py::test_org_mfa_missing_field_returns_error -v`

Made with [Cursor](https://cursor.com)