### PR TITLE
fix(checks): tolerate null security_and_analysis without crashing (#74)

### DIFF
--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -113,7 +113,7 @@ class SecretScanningEnabled(Check):
         enabled = 0
         total = len(repos)
         for repo in repos:
-            sec = repo.get("security_and_analysis", {})
+            sec = repo.get("security_and_analysis") or {}
             if sec.get("secret_scanning", {}).get("status") == "enabled":
                 enabled += 1
         compliant = total > 0 and enabled == total

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from checks.github_checks import OrgMFARequired
+from checks.github_checks import OrgMFARequired, SecretScanningEnabled
 
 
 def test_org_mfa_missing_field_returns_error():
@@ -11,3 +11,10 @@ def test_org_mfa_missing_field_returns_error():
         mp.setattr("checks.github_checks._get", lambda url, token: {"login": "acme"})
         result = check.run(owner="acme", token="tok")
     assert result["status"] == "error"
+
+
+def test_secret_scanning_null_security_and_analysis_does_not_crash():
+    check = SecretScanningEnabled()
+    repos = [{"name": "demo", "security_and_analysis": None}]
+    result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] in {"pass", "fail"}


### PR DESCRIPTION
## Summary
Fixes #74.

Treat explicit `security_and_analysis: null` as empty instead of calling `.get` on `None`.

## Test plan
- [x] `pytest packages/checks/tests/test_github_checks.py::test_secret_scanning_null_security_and_analysis_does_not_crash -v`

Made with [Cursor](https://cursor.com)