### PR TITLE
fix(checks): return not_applicable for empty-repo orgs (#87)

### DIFF
--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -2,13 +2,16 @@ from checks.runner import run_all_checks
 
 from src.core.config import settings
 
+_SCOREABLE = {"pass", "fail", "error"}
+
 
 def get_overview(owner: str, token: str) -> dict:
     base_url = settings.github_api_base
     report = run_all_checks(owner=owner, token=token, base_url=base_url)
     checks = report["checks"]
-    failed = [c for c in checks if c["status"] in ("fail", "error")]
-    score = 100 - int((len(failed) / max(1, len(checks))) * 100)
+    scoreable = [c for c in checks if c["status"] in _SCOREABLE]
+    failed = [c for c in scoreable if c["status"] in ("fail", "error")]
+    score = 100 - int((len(failed) / max(1, len(scoreable))) * 100)
     return {
         "owner": owner,
         "score": score,

--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -87,6 +87,8 @@ class BranchProtectionEnabled(Check):
     ) -> dict:
         if repos is None:
             repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if not repos:
+            return {"status": "not_applicable", "value": {"checked": 0, "protected": 0}}
         checked = 0
         protected = 0
         unknown = 0
@@ -129,6 +131,8 @@ class SecretScanningEnabled(Check):
     ) -> dict:
         if repos is None:
             repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+        if not repos:
+            return {"status": "not_applicable", "value": {"enabled": 0, "total": 0}}
         enabled = 0
         total = len(repos)
         for repo in repos:

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -21,6 +21,12 @@ def test_secret_scanning_null_security_and_analysis_does_not_crash():
     assert result["status"] in {"pass", "fail"}
 
 
+def test_secret_scanning_empty_org_is_not_applicable():
+    check = SecretScanningEnabled()
+    result = check.run(owner="acme", token="tok", repos=[])
+    assert result["status"] == "not_applicable"
+
+
 def test_branch_protection_rate_limit_counts_as_unknown():
     check = BranchProtectionEnabled()
     repos = [{"name": "demo", "default_branch": "main"}]


### PR DESCRIPTION
## Summary
Fixes #87.

Orgs with zero repositories report `not_applicable` instead of a hard fail; analytics score excludes non pass/fail statuses.

## Test plan
- [x] `pytest packages/checks/tests/test_github_checks.py::test_secret_scanning_empty_org_is_not_applicable -v`

Made with [Cursor](https://cursor.com)