### PR TITLE
fix(checks): treat branch-protection 403/429 as unknown (#82)

### DIFF
--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -36,6 +36,15 @@ def _get_all_pages(base_url: str, path: str, token: str) -> list:
     return results
 
 
+def _branch_protection_status(exc: httpx.HTTPStatusError) -> str:
+    code = exc.response.status_code
+    if code == 404:
+        return "unprotected"
+    if code in (403, 429):
+        return "unknown"
+    return "unprotected"
+
+
 class OrgMFARequired(Check):
     metadata = CheckMetadata(
         check_id="organization_members_mfa_required",
@@ -80,6 +89,7 @@ class BranchProtectionEnabled(Check):
             repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
         checked = 0
         protected = 0
+        unknown = 0
         for repo in repos:
             checked += 1
             branch = repo.get("default_branch")
@@ -87,10 +97,17 @@ class BranchProtectionEnabled(Check):
                 details = _get(f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}", token)
                 if details.get("protected"):
                     protected += 1
-            except httpx.HTTPStatusError:
-                pass  # treat inaccessible branches as unprotected
-        compliant = checked > 0 and checked == protected
-        return {"status": "pass" if compliant else "fail", "value": {"checked": checked, "protected": protected}}
+            except httpx.HTTPStatusError as exc:
+                if _branch_protection_status(exc) == "unknown":
+                    unknown += 1
+        evaluable = checked - unknown
+        if evaluable == 0:
+            return {"status": "error", "value": {"checked": checked, "protected": protected, "unknown": unknown}}
+        compliant = protected == evaluable
+        return {
+            "status": "pass" if compliant else "fail",
+            "value": {"checked": checked, "protected": protected, "unknown": unknown},
+        }
 
 
 class SecretScanningEnabled(Check):

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -1,8 +1,9 @@
 """Tests for individual GitHub security checks."""
 
+import httpx
 import pytest
 
-from checks.github_checks import OrgMFARequired, SecretScanningEnabled
+from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled
 
 
 def test_org_mfa_missing_field_returns_error():
@@ -18,3 +19,18 @@ def test_secret_scanning_null_security_and_analysis_does_not_crash():
     repos = [{"name": "demo", "security_and_analysis": None}]
     result = check.run(owner="acme", token="tok", repos=repos)
     assert result["status"] in {"pass", "fail"}
+
+
+def test_branch_protection_rate_limit_counts_as_unknown():
+    check = BranchProtectionEnabled()
+    repos = [{"name": "demo", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(403, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+    assert result["value"]["unknown"] == 1


### PR DESCRIPTION
## Summary
Fixes #82.

403/429 responses when reading branch protection no longer score as unprotected.

## Test plan
- [x] `pytest packages/checks/tests/test_github_checks.py::test_branch_protection_rate_limit_counts_as_unknown -v`

Made with [Cursor](https://cursor.com)