### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owner for the entire repo — required PR review must come from here
+# unless/until this list is split out by directory as more maintainers join.
+* @nazarli-shabnam


### PR DESCRIPTION
## Summary

The active ruleset on `main` (`ruleset4main`) has `require_code_owner_review: true`, but there's no `CODEOWNERS` file in the repo — so that setting is currently a silent no-op, not an actual gate. Adds a `CODEOWNERS` file naming the sole current write-access collaborator as owner for the whole tree, so the existing ruleset setting actually does something.

Part of tightening branch protection alongside required status checks and review-thread-resolution (companion ruleset update applied directly via the API, not a PR, since it's a repo setting rather than a file).

## Test plan
- N/A — config-only change, nothing to run.