### PR TITLE
fix(ui): track concurrent revoke rows with a Set (#129)

### DIFF
--- a/apps/ui/app/settings/org/[login]/members/page.tsx
+++ b/apps/ui/app/settings/org/[login]/members/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Loader2, Mail, X } from "lucide-react"
 import { api } from "@/lib/api/client"
+import { addRevokingId, isRevoking, removeRevokingId } from "@/lib/revoke-pending"
 import type { InvitationOut } from "@/lib/api/types"
 
 export default function OrgMembersPage() {
@@ -22,7 +23,7 @@ export default function OrgMembersPage() {
     queryFn: () => api.invitations.list(orgLogin),
   })
 
-  const [revokingId, setRevokingId] = useState<number | null>(null)
+  const [revokingIds, setRevokingIds] = useState<Set<number>>(() => new Set())
 
   const invite = useMutation({
     mutationFn: () => api.invitations.create(orgLogin, email.trim()),
@@ -35,8 +36,8 @@ export default function OrgMembersPage() {
 
   const revoke = useMutation({
     mutationFn: (id: number) => api.invitations.revoke(orgLogin, id),
-    onMutate: (id) => setRevokingId(id),
-    onSettled: () => setRevokingId(null),
+    onMutate: (id) => setRevokingIds((prev) => addRevokingId(prev, id)),
+    onSettled: (_data, _error, id) => setRevokingIds((prev) => removeRevokingId(prev, id)),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["invitations", orgLogin] }),
   })
 
@@ -107,7 +108,7 @@ export default function OrgMembersPage() {
                             size="sm"
                             variant="outline"
                             onClick={() => revoke.mutate(inv.id)}
-                            disabled={revokingId === inv.id}
+                            disabled={isRevoking(revokingIds, inv.id)}
                           >
                             <X className="size-3" />
                             Revoke

--- a/apps/ui/lib/revoke-pending.ts
+++ b/apps/ui/lib/revoke-pending.ts
@@ -1,0 +1,17 @@
+/** Track multiple in-flight revoke mutations without clobbering earlier rows. */
+
+export function addRevokingId(ids: ReadonlySet<number>, id: number): Set<number> {
+  const next = new Set(ids)
+  next.add(id)
+  return next
+}
+
+export function removeRevokingId(ids: ReadonlySet<number>, id: number): Set<number> {
+  const next = new Set(ids)
+  next.delete(id)
+  return next
+}
+
+export function isRevoking(ids: ReadonlySet<number>, id: number): boolean {
+  return ids.has(id)
+}

--- a/apps/ui/tests/lib/revoke-pending.test.ts
+++ b/apps/ui/tests/lib/revoke-pending.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { addRevokingId, isRevoking, removeRevokingId } from "@/lib/revoke-pending";
+
+describe("revoke-pending", () => {
+  it("tracks multiple concurrent revokes independently", () => {
+    let pending = new Set<number>();
+
+    pending = addRevokingId(pending, 1);
+    pending = addRevokingId(pending, 2);
+
+    expect(isRevoking(pending, 1)).toBe(true);
+    expect(isRevoking(pending, 2)).toBe(true);
+
+    pending = removeRevokingId(pending, 1);
+
+    expect(isRevoking(pending, 1)).toBe(false);
+    expect(isRevoking(pending, 2)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace single `revokingId` state with a `Set<number>` so each invitation row tracks its own in-flight revoke independently
- Extract small `revoke-pending` helpers and add a unit test for the concurrent-revoke scenario described in the issue

Fixes #129

## Test plan
- [x] `bun run test tests/lib/revoke-pending.test.ts` (pass)
- [x] `bun run typecheck` (pass)
- [ ] Manual: org Members page — revoke two pending invites quickly; both buttons stay disabled until each request settles


Made with [Cursor](https://cursor.com)