### PR TITLE
fix(api): trust proxy headers so OAuth redirect_uri uses https

### DIFF
--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -9,4 +9,11 @@ fi
 export DATABASE_URL="postgresql+psycopg://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}"
 export AUTH_SECRET
 python -m alembic upgrade head
-exec uvicorn src.main:app --host 0.0.0.0 --port 8080
+# --proxy-headers/--forwarded-allow-ips: trust X-Forwarded-Proto from Traefik so
+# request.url_for() (used to build the GitHub OAuth callback/redirect_uri) reports the
+# original https scheme instead of the http uvicorn actually receives behind the proxy.
+# Without this, GitHub rejects the OAuth flow with "redirect_uri is not associated with
+# this application" since the registered callback is https but the sent one was http.
+# '*' is safe here — Traefik and the API only ever talk over the internal Docker network,
+# never a public one.
+exec uvicorn src.main:app --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips='*'


### PR DESCRIPTION
## Summary

GitHub sign-in in production shows: *"Be careful! The redirect_uri is not associated with this application."*

Root cause, confirmed live:

```
curl -I https://api.clevis.org/auth/github/login
Location: https://github.com/login/oauth/authorize?...&redirect_uri=http%3A%2F%2Fapi.clevis.org%2Fauth%2Fgithub%2Fcallback&...
```

Decoded: `redirect_uri=http://api.clevis.org/auth/github/callback` — **http**, not https. Traefik terminates TLS and forwards plain HTTP to the `api` container internally; `apps/api/src/routers/github_auth.py`'s `_callback_url()` uses `request.url_for("github_callback")`, which reports whatever scheme uvicorn actually received (http) unless uvicorn is told to trust the proxy's `X-Forwarded-Proto` header. Since the GitHub App almost certainly has the `https://` callback registered, the scheme mismatch is an exact-string match failure on GitHub's side.

## Fix

`apps/api/entrypoint.sh`: added `--proxy-headers --forwarded-allow-ips='*'` to the uvicorn invocation. `'*'` is safe here — per `docker-compose.yml`'s own documented security posture, the API has no host port bindings; only Traefik (or something already on the internal Docker network) can reach it, so there's no untrusted external source that could spoof `X-Forwarded-*` headers directly against the container.

## Test plan

This is an infra/deployment-level fix (a uvicorn CLI flag) that can't be exercised through FastAPI's `TestClient` — `TestClient` talks to the ASGI app directly and bypasses uvicorn's HTTP/proxy-header layer entirely, so there's no meaningful pytest regression test for this specific change. Verification is live, against the actual deployment:

- [x] Confirmed the bug live: `curl -I https://api.clevis.org/auth/github/login` showed `redirect_uri=http%3A%2F%2F...`
- [ ] After deploy: re-run the same curl and confirm `redirect_uri=https%3A%2F%2F...`
- [ ] After deploy: click "Sign in with GitHub" in the real app and confirm the OAuth flow completes without the "redirect_uri is not associated" error