### PR TITLE
fix(ui): replace misleading stub empty states (#137)

### DIFF
--- a/apps/ui/app/my/issues/page.tsx
+++ b/apps/ui/app/my/issues/page.tsx
@@ -7,7 +7,7 @@ export default function MyIssuesPage() {
   return (
     <>
       <PageHeader title="My Issues" description="Issues assigned to you." />
-      <EmptyStatePage message="— no organization connected" />
+      <EmptyStatePage message="My issues — coming soon" />
     </>
   )
 }

--- a/apps/ui/app/my/prs/page.tsx
+++ b/apps/ui/app/my/prs/page.tsx
@@ -7,7 +7,7 @@ export default function MyPRsPage() {
   return (
     <>
       <PageHeader title="My PRs" description="Pull requests you've authored." />
-      <EmptyStatePage message="— no organization connected" />
+      <EmptyStatePage message="My pull requests — coming soon" />
     </>
   )
 }

--- a/apps/ui/app/my/reviews/page.tsx
+++ b/apps/ui/app/my/reviews/page.tsx
@@ -7,7 +7,7 @@ export default function MyReviewsPage() {
   return (
     <>
       <PageHeader title="My Reviews" description="PRs awaiting your review." />
-      <EmptyStatePage message="— no organization connected" />
+      <EmptyStatePage message="My reviews — coming soon" />
     </>
   )
 }

--- a/apps/ui/app/pulls/page.tsx
+++ b/apps/ui/app/pulls/page.tsx
@@ -7,7 +7,7 @@ export default function PullRequestsPage() {
   return (
     <>
       <PageHeader title="Pull Requests" description="Open PRs across your organization." />
-      <EmptyStatePage message="— no organization connected" />
+      <EmptyStatePage message="Pull requests — coming soon" />
     </>
   )
 }

--- a/apps/ui/app/releases/page.tsx
+++ b/apps/ui/app/releases/page.tsx
@@ -7,7 +7,7 @@ export default function ReleasesPage() {
   return (
     <>
       <PageHeader title="Releases" description="Release history across your organization." />
-      <EmptyStatePage message="— no organization connected" />
+      <EmptyStatePage message="Releases — coming soon" />
     </>
   )
 }


### PR DESCRIPTION
## Summary
Fixes #137.

Unbuilt nav pages showed "no organization connected" unconditionally. Use honest coming-soon copy instead.

## Test plan
- [x] UI typecheck

Made with [Cursor](https://cursor.com)