### PR TITLE
fix(api): verify installation_id against GitHub on sync (#141)

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -24,6 +24,7 @@ from src.schemas.installation import (
     SyncInstallationsInput,
     SyncInstallationsResponse,
 )
+from src.services.installation_verify import verify_sync_payload
 
 router = APIRouter()
 
@@ -43,6 +44,7 @@ def sync_org_installation(
     db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(payload.account_login, ctx)
+    verify_sync_payload(payload)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,
@@ -84,6 +86,7 @@ def sync_personal_installation(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="account_login must match your own GitHub account",
         )
+    verify_sync_payload(payload)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,

--- a/apps/api/src/services/installation_verify.py
+++ b/apps/api/src/services/installation_verify.py
@@ -1,0 +1,56 @@
+"""Verify GitHub App installation metadata against client sync payloads."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import HTTPException, status
+
+from src.core.config import settings
+from src.schemas.installation import SyncInstallationsInput
+from src.services import github_app
+
+
+def fetch_installation(installation_id: int) -> dict:
+    """Load installation metadata from GitHub using an App JWT."""
+    app_jwt = github_app.generate_app_jwt()
+    url = f"{settings.github_api_base}/app/installations/{installation_id}"
+    headers = {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.get(url, headers=headers)
+    if resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Installation not found on GitHub")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def verify_sync_payload(payload: SyncInstallationsInput) -> None:
+    """Ensure the client-supplied installation_id matches GitHub's account metadata."""
+    if payload.auth_mode != "app":
+        return
+    if payload.installation_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="installation_id is required when auth_mode is app",
+        )
+    try:
+        installation = fetch_installation(payload.installation_id)
+    except github_app.GitHubAppNotConfigured as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+    account = installation.get("account") or {}
+    if account.get("login") != payload.account_login:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="installation_id does not belong to the supplied account_login",
+        )
+    if account.get("type") != payload.account_type:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="installation account type does not match payload account_type",
+        )

--- a/apps/api/tests/test_installation_verify.py
+++ b/apps/api/tests/test_installation_verify.py
@@ -1,0 +1,40 @@
+"""Tests for GitHub App installation verification during sync."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.schemas.installation import SyncInstallationsInput
+from src.services import installation_verify
+
+
+def test_verify_sync_payload_accepts_matching_installation():
+    payload = SyncInstallationsInput(
+        account_login="acme",
+        account_type="Organization",
+        installation_id=42,
+    )
+    installation = {"account": {"login": "acme", "type": "Organization"}}
+    with patch("src.services.installation_verify.fetch_installation", return_value=installation):
+        installation_verify.verify_sync_payload(payload)
+
+
+def test_verify_sync_payload_rejects_login_mismatch():
+    payload = SyncInstallationsInput(
+        account_login="acme",
+        account_type="Organization",
+        installation_id=42,
+    )
+    installation = {"account": {"login": "other", "type": "Organization"}}
+    with patch("src.services.installation_verify.fetch_installation", return_value=installation):
+        with pytest.raises(HTTPException) as exc:
+            installation_verify.verify_sync_payload(payload)
+    assert exc.value.status_code == 403
+
+
+def test_verify_sync_payload_requires_installation_id_for_app_mode():
+    payload = SyncInstallationsInput(account_login="acme", account_type="Organization")
+    with pytest.raises(HTTPException) as exc:
+        installation_verify.verify_sync_payload(payload)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
Fixes #141.

Verify client-supplied installation_id against GitHub Installations API before persisting sync rows.

## Test plan
- [x] pytest apps/api/tests/test_installation_verify.py (3 passed)

Made with [Cursor](https://cursor.com)