### PR TITLE
fix(ui): redirect Collaborators to working members page (#138)

### DIFF
--- a/apps/ui/app/collaborators/page.tsx
+++ b/apps/ui/app/collaborators/page.tsx
@@ -1,23 +1,46 @@
-export const metadata = { title: "Collaborators · clevis" }
+"use client"
 
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useQuery } from "@tanstack/react-query"
+import { Loader2 } from "lucide-react"
 import { PageHeader } from "@/components/page-header"
-import { EmptyState } from "@/components/empty-state"
-import { Users } from "lucide-react"
+import { EmptyStatePage } from "@/components/empty-state"
+import { api } from "@/lib/api/client"
 
 export default function CollaboratorsPage() {
+  const router = useRouter()
+  const { data: orgs, isLoading } = useQuery({
+    queryKey: ["orgs", "mine"],
+    queryFn: () => api.orgs.mine(),
+  })
+
+  const adminOrg = orgs?.find((o) => o.role === "admin")
+
+  useEffect(() => {
+    if (adminOrg) {
+      router.replace(`/settings/org/${adminOrg.github_login}/members`)
+    }
+  }, [adminOrg, router])
+
+  if (isLoading || adminOrg) {
+    return (
+      <>
+        <PageHeader title="Collaborators" description="Manage your organization's team and invitations." />
+        <div className="px-4 py-8 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" /> Loading…
+        </div>
+      </>
+    )
+  }
+
   return (
     <>
-      <PageHeader
-        title="Collaborators"
-        description="Manage your organization's team and invitations."
+      <PageHeader title="Collaborators" description="Manage your organization's team and invitations." />
+      <EmptyStatePage
+        message="Member management lives under Settings for each organization you admin"
+        action={{ href: "/settings", label: "open Settings" }}
       />
-      <div className="bg-card border border-border">
-        <EmptyState
-          icon={Users}
-          title="Collaborators coming soon"
-          description="View your organization roster, manage pending invitations, and fix member permissions from a single dashboard."
-        />
-      </div>
     </>
   )
 }


### PR DESCRIPTION
## Summary
Fixes #138.

Redirect org admins from /collaborators to /settings/org/{login}/members; others get a Settings link.

## Test plan
- [ ] Manual: visit /collaborators as org admin

Made with [Cursor](https://cursor.com)