### PR TITLE
fix(api): mint installation token on sync (#140)

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
+from src.core.config import settings
 from src.core.db import User, get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.repositories import installation_repo
@@ -24,8 +25,16 @@ from src.schemas.installation import (
     SyncInstallationsInput,
     SyncInstallationsResponse,
 )
+from src.services import github_app
 
 router = APIRouter()
+
+
+def _ensure_installation_token(installation_id: int | None) -> None:
+    """Mint an installation token so App auth is exercised on sync."""
+    if installation_id is None or settings.github_app_id is None:
+        return
+    github_app.get_installation_token(installation_id)
 
 
 @router.get("/orgs/{org_login}/installations", response_model=list[InstallationOut])
@@ -51,6 +60,7 @@ def sync_org_installation(
         installation_id=payload.installation_id,
         org_id=ctx.org.id,
     )
+    _ensure_installation_token(payload.installation_id)
     return {"synced": True, "token_ref": row.token_ref}
 
 
@@ -92,4 +102,5 @@ def sync_personal_installation(
         installation_id=payload.installation_id,
         owner_user_id=user.id,
     )
+    _ensure_installation_token(payload.installation_id)
     return {"synced": True, "token_ref": row.token_ref}

--- a/apps/api/tests/test_installation_token_wire.py
+++ b/apps/api/tests/test_installation_token_wire.py
@@ -1,0 +1,43 @@
+"""Tests that installation sync exercises GitHub App token minting."""
+
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import org_membership_repo, org_repo
+from src.routers.installations import router as inst_router
+
+
+def _make_user(db, email: str, github_login: str | None = None) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False, github_login=github_login)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+def _client(db, user):
+    app = FastAPI()
+    app.include_router(inst_router)
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[require_auth] = lambda: user
+    return TestClient(app)
+
+
+def test_org_sync_mints_installation_token(db):
+    admin = _make_user(db, "admin@e.com")
+    org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org_repo.get_or_create(db, github_login="acme").id, user_id=admin.id, role="admin")
+    payload = {
+        "account_login": "acme",
+        "account_type": "Organization",
+        "installation_id": 99,
+        "auth_mode": "app",
+    }
+    with patch("src.routers.installations.github_app.get_installation_token") as mint:
+        resp = _client(db, admin).post("/orgs/acme/installations/sync", json=payload)
+    assert resp.status_code == 200
+    mint.assert_called_once_with(99)


### PR DESCRIPTION
## Summary
Fixes #140.

Call get_installation_token during sync when the GitHub App is configured.

## Test plan
- [x] pytest apps/api/tests/test_installation_token_wire.py (1 passed)

Made with [Cursor](https://cursor.com)