### PR TITLE
fix(api): add GitHub App webhook endpoint (#142)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -19,6 +19,7 @@ from src.routers import (
     jobs,
     orgs,
     tokens,
+    webhooks,
 )
 
 # CORS allowed origins are a deploy-time security boundary, set via the CORS_ORIGINS env var.
@@ -65,3 +66,4 @@ app.include_router(jobs.router, prefix="/jobs", tags=["jobs"])
 app.include_router(audit.router, prefix="/audit", tags=["audit"])
 app.include_router(tokens.router, prefix="/tokens", tags=["tokens"])
 app.include_router(config.router, prefix="/config", tags=["config"])
+app.include_router(webhooks.router, tags=["webhooks"])

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -83,3 +83,8 @@ def list_for_user(db: Session, owner_user_id: int) -> list[GitHubInstallation]:
         .order_by(GitHubInstallation.created_at.desc())
         .all()
     )
+
+
+def delete_by_installation_id(db: Session, installation_id: int) -> None:
+    db.query(GitHubInstallation).filter(GitHubInstallation.installation_id == installation_id).delete()
+    db.commit()

--- a/apps/api/src/routers/webhooks.py
+++ b/apps/api/src/routers/webhooks.py
@@ -1,0 +1,50 @@
+"""GitHub App webhook receiver."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import get_db
+from src.repositories import installation_repo
+
+router = APIRouter()
+
+
+def _verify_signature(body: bytes, signature_header: str | None) -> None:
+    secret = settings.github_app_webhook_secret
+    if secret is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Webhooks not configured")
+    if not signature_header or not signature_header.startswith("sha256="):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing webhook signature")
+    expected = hmac.new(
+        secret.get_secret_value().encode(),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature_header, f"sha256={expected}"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid webhook signature")
+
+
+@router.post("/webhooks/github")
+async def github_webhook(request: Request, db: Session = Depends(get_db)) -> Response:
+    body = await request.body()
+    _verify_signature(body, request.headers.get("X-Hub-Signature-256"))
+    event = request.headers.get("X-GitHub-Event", "")
+    payload = json.loads(body)
+
+    if event == "installation":
+        action = payload.get("action")
+        installation = payload.get("installation") or {}
+        installation_id = installation.get("id")
+        if installation_id is None:
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        if action == "deleted":
+            installation_repo.delete_by_installation_id(db, installation_id)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/tests/test_webhooks.py
+++ b/apps/api/tests/test_webhooks.py
@@ -1,0 +1,70 @@
+"""Tests for GitHub App webhook endpoint."""
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from src.core.auth import UserOut
+from src.core.config import settings
+from src.core.db import User, get_db
+from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.routers.webhooks import router as webhooks_router
+
+
+def _make_user(db, email: str) -> UserOut:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+
+@pytest.fixture()
+def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    return {"org": org, "admin": admin}
+
+
+@pytest.fixture()
+def webhook_client(db, monkeypatch):
+    monkeypatch.setattr(settings, "github_app_webhook_secret", SecretStr("test-secret"))
+    app = FastAPI()
+    app.include_router(webhooks_router)
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def _signed_headers(body: bytes, secret: str = "test-secret") -> dict[str, str]:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {
+        "X-Hub-Signature-256": f"sha256={digest}",
+        "X-GitHub-Event": "installation",
+    }
+
+
+def test_webhook_rejects_invalid_signature(webhook_client):
+    body = json.dumps({"action": "deleted", "installation": {"id": 1}}).encode()
+    resp = webhook_client.post("/webhooks/github", content=body, headers={"X-GitHub-Event": "installation"})
+    assert resp.status_code == 401
+
+
+def test_webhook_deletes_installation_on_deleted_event(webhook_client, db, acme_org):
+    installation_repo.create(
+        db,
+        account_login="acme",
+        account_type="Organization",
+        auth_mode="app",
+        installation_id=555,
+        org_id=acme_org["org"].id,
+    )
+    body = json.dumps({"action": "deleted", "installation": {"id": 555}}).encode()
+    resp = webhook_client.post("/webhooks/github", content=body, headers=_signed_headers(body))
+    assert resp.status_code == 204
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []


### PR DESCRIPTION
## Summary
Fixes #142.

POST /webhooks/github verifies X-Hub-Signature-256 and removes installations on deleted events.

## Test plan
- [x] pytest apps/api/tests/test_webhooks.py (2 passed)

Made with [Cursor](https://cursor.com)