### PR TITLE
fix(checks): support personal-account security scans (#144)

### DIFF
--- a/packages/checks/src/checks/runner.py
+++ b/packages/checks/src/checks/runner.py
@@ -1,24 +1,52 @@
 import logging
 
+import httpx
+
 from checks.github_checks import BranchProtectionEnabled, OrgMFARequired, SecretScanningEnabled, _get_all_pages
 
 logger = logging.getLogger(__name__)
 
 
+def _resolve_account(base_url: str, owner: str, token: str) -> tuple[str, str]:
+    """Return (repos_path, account_type) for owner login."""
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        user_resp = client.get(f"{base_url}/users/{owner}", headers=headers)
+        if user_resp.status_code == 200:
+            data = user_resp.json()
+            if data.get("type") == "User":
+                return f"/users/{owner}/repos", "User"
+        org_resp = client.get(f"{base_url}/orgs/{owner}", headers=headers)
+        if org_resp.status_code == 200:
+            return f"/orgs/{owner}/repos", "Organization"
+    raise RuntimeError(f"Could not resolve GitHub account for owner {owner!r}")
+
+
 def run_all_checks(owner: str, token: str, base_url: str = "https://api.github.com") -> dict:
-    repos = _get_all_pages(base_url, f"/orgs/{owner}/repos", token)
+    repos_path, account_type = _resolve_account(base_url, owner, token)
+    repos = _get_all_pages(base_url, repos_path, token)
 
     checks = [OrgMFARequired(), BranchProtectionEnabled(), SecretScanningEnabled()]
     results = []
     for check in checks:
-        try:
-            output = check.run(owner=owner, token=token, base_url=base_url, repos=repos)
-        except Exception:
-            logger.exception("check %s failed", check.metadata.check_id)
+        if account_type == "User" and check.metadata.check_id == "organization_members_mfa_required":
             output = {
-                "status": "error",
-                "value": f"Check failed: {check.metadata.check_id}",
+                "status": "not_applicable",
+                "value": "Organization MFA requirement does not apply to personal accounts",
             }
+        else:
+            try:
+                output = check.run(owner=owner, token=token, base_url=base_url, repos=repos)
+            except Exception:
+                logger.exception("check %s failed", check.metadata.check_id)
+                output = {
+                    "status": "error",
+                    "value": f"Check failed: {check.metadata.check_id}",
+                }
         results.append({
             "id": check.metadata.check_id,
             "title": check.metadata.title,

--- a/packages/checks/tests/test_runner_account_type.py
+++ b/packages/checks/tests/test_runner_account_type.py
@@ -1,0 +1,18 @@
+"""Tests for check runner account-type handling."""
+
+from unittest.mock import patch
+
+from checks.runner import run_all_checks
+
+
+def test_run_all_checks_uses_user_repos_for_personal_accounts():
+    repos = [{"name": "demo", "default_branch": "main", "security_and_analysis": {}}]
+    with patch("checks.runner._resolve_account", return_value=("/users/alice/repos", "User")), patch(
+        "checks.runner._get_all_pages", return_value=repos
+    ), patch("checks.github_checks._get") as mock_get:
+        mock_get.return_value = {"protected": True}
+        report = run_all_checks(owner="alice", token="tok")
+
+    mfa = next(item for item in report["checks"] if item["id"] == "organization_members_mfa_required")
+    assert mfa["status"] == "not_applicable"
+    assert report["repo_count"] == 1


### PR DESCRIPTION
## Summary
Fixes #144.

Use /users/{owner}/repos for personal accounts; org MFA check is not_applicable for users.

## Test plan
- [x] pytest packages/checks/tests/test_runner_account_type.py (1 passed)

Made with [Cursor](https://cursor.com)