### PR TITLE
feat(api): surface pending org invitations after login (#145)

### DIFF
--- a/apps/api/src/routers/invitations.py
+++ b/apps/api/src/routers/invitations.py
@@ -25,6 +25,7 @@ from src.schemas.invitation import (
     InvitationCreateResponse,
     InvitationOut,
     InvitationPreview,
+    PendingInvitationOut,
 )
 
 router = APIRouter()
@@ -80,6 +81,29 @@ def list_invitations(
         )
         for inv in invitations
     ]
+
+
+@router.get("/me/invitations/pending", response_model=list[PendingInvitationOut])
+def list_my_pending_invitations(
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    invitations = invitation_repo.list_pending_for_email(db, user.email)
+    results: list[PendingInvitationOut] = []
+    for invitation in invitations:
+        if _is_expired(invitation):
+            continue
+        org = db.query(Org).filter(Org.id == invitation.org_id).first()
+        if org is None:
+            continue
+        results.append(
+            PendingInvitationOut(
+                org_login=org.github_login,
+                token=invitation.token,
+                expires_at=invitation.expires_at,
+            )
+        )
+    return results
 
 
 @router.post("/orgs/{org_login}/invitations/{invitation_id}/revoke", response_model=InvitationOut)

--- a/apps/api/src/schemas/invitation.py
+++ b/apps/api/src/schemas/invitation.py
@@ -37,3 +37,9 @@ class InvitationPreview(BaseModel):
 class InvitationAcceptResponse(BaseModel):
     org_login: str
     role: str
+
+
+class PendingInvitationOut(BaseModel):
+    org_login: str
+    token: str
+    expires_at: datetime

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -169,3 +169,14 @@ def test_list_invitations_reflects_expired_status(db, acme_org):
     assert len(body) == 1
     assert body[0]["status"] == "expired"
     assert "expires_at" in body[0]
+
+
+def test_list_my_pending_invitations(db, acme_org):
+    created = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"}).json()
+    resp = _client(db, acme_org["invitee"]).get("/me/invitations/pending")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["org_login"] == "acme"
+    token = created["invite_link"].rsplit("/", 1)[-1]
+    assert body[0]["token"] == token

--- a/apps/ui/app/page.tsx
+++ b/apps/ui/app/page.tsx
@@ -65,9 +65,29 @@ export default function OverviewPage() {
     retry: false,
   })
 
+  const pendingInvitesQuery = useQuery({
+    queryKey: ["invitations", "pending"],
+    queryFn: () => api.invitations.pending(),
+  })
+
   return (
     <>
       <PageHeader title="Overview" description="Your GitHub organization at a glance." />
+
+      {(pendingInvitesQuery.data?.length ?? 0) > 0 && (
+        <div className="mb-4 border border-primary/30 bg-primary/5 px-4 py-3 text-sm">
+          <p className="font-medium text-foreground mb-2">Pending organization invitations</p>
+          <ul className="space-y-1">
+            {pendingInvitesQuery.data!.map((invite) => (
+              <li key={invite.token}>
+                <Link href={`/invite/${invite.token}`} className="text-primary hover:underline">
+                  Join {invite.org_login}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-px mb-6 border border-border bg-border">
         <LiveStatCard

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -8,6 +8,7 @@ import type {
   InvitationCreateResponse,
   InvitationOut,
   InvitationPreview,
+  PendingInvitationOut,
   JobOut,
   MyOrgMembership,
   SavedTokenMeta,
@@ -177,6 +178,7 @@ export const api = {
     revoke: (orgLogin: string, invitationId: number) =>
       post<InvitationOut>(`/orgs/${encodeURIComponent(orgLogin)}/invitations/${invitationId}/revoke`, {}),
     preview: (token: string) => get<InvitationPreview>(`/invitations/${encodeURIComponent(token)}`),
+    pending: () => get<PendingInvitationOut[]>("/me/invitations/pending"),
     accept: (token: string) => post<{ org_login: string; role: string }>(`/invitations/${encodeURIComponent(token)}/accept`, {}),
   },
   tokens: {

--- a/apps/ui/lib/api/types.ts
+++ b/apps/ui/lib/api/types.ts
@@ -108,3 +108,9 @@ export interface InvitationPreview {
   org_login: string
   status: "pending" | "accepted" | "revoked"
 }
+
+export interface PendingInvitationOut {
+  org_login: string
+  token: string
+  expires_at: string
+}


### PR DESCRIPTION
## Summary
Fixes #145.

GET /me/invitations/pending plus Overview banner with join links for matching email.

## Test plan
- [x] pytest apps/api/tests/test_invitations.py::test_list_my_pending_invitations

Made with [Cursor](https://cursor.com)