### PR TITLE
fix(api): wire GitHub App installation tokens into analytics and cache (#140)

### DIFF
--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -67,6 +67,25 @@ def create(
     )
 
 
+def get_for_org(db: Session, org_id: int, account_login: str) -> GitHubInstallation | None:
+    return (
+        db.query(GitHubInstallation)
+        .filter(GitHubInstallation.org_id == org_id, GitHubInstallation.account_login == account_login)
+        .first()
+    )
+
+
+def get_for_user(db: Session, owner_user_id: int, account_login: str) -> GitHubInstallation | None:
+    return (
+        db.query(GitHubInstallation)
+        .filter(
+            GitHubInstallation.owner_user_id == owner_user_id,
+            GitHubInstallation.account_login == account_login,
+        )
+        .first()
+    )
+
+
 def list_for_org(db: Session, org_id: int) -> list[GitHubInstallation]:
     return (
         db.query(GitHubInstallation)

--- a/apps/api/src/routers/actions_cache.py
+++ b/apps/api/src/routers/actions_cache.py
@@ -8,6 +8,7 @@ from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.schemas.cache import CacheClearInput, CacheClearResponse, CacheListInput, CacheListResponse
 from src.services.cache_service import clear
 from src.services.github_client import GitHubClient
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
 
 router = APIRouter()
 
@@ -20,13 +21,17 @@ def _github_cache_error(exc: Exception) -> HTTPException:
     raise exc
 
 
-def _list_caches(owner: str, repo: str, payload: CacheListInput) -> CacheListResponse:
+def _list_caches(owner: str, repo: str, token: str) -> CacheListResponse:
     try:
-        client = GitHubClient(payload.token.get_secret_value())
+        client = GitHubClient(token)
         data = client.request("GET", f"/repos/{owner}/{repo}/actions/caches")
     except (httpx.HTTPStatusError, httpx.RequestError) as exc:
         raise _github_cache_error(exc) from exc
     return {"repository": f"{owner}/{repo}", "total": data.get("total_count", 0), "actions_caches": data.get("actions_caches", [])}
+
+
+def _client_token(payload: CacheListInput | CacheClearInput) -> str | None:
+    return payload.token.get_secret_value() if payload.token else None
 
 
 @router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
@@ -36,9 +41,14 @@ def org_list_caches(
     repo: str,
     payload: CacheListInput,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(owner, ctx)
-    return _list_caches(owner, repo, payload)
+    try:
+        token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_caches(owner, repo, token)
 
 
 @router.post("/orgs/{org_login}/repos/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
@@ -52,7 +62,13 @@ def org_clear_caches(
     db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(owner, ctx)
-    return clear(db, owner, repo, payload, actor=user.email)
+    token = ""
+    if not payload.dry_run:
+        try:
+            token = resolve_org_token(db, org_id=ctx.org.id, account_login=owner, client_token=_client_token(payload))
+        except NoGitHubTokenAvailable as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    return clear(db, owner, repo, payload, actor=user.email, token=token)
 
 
 @router.post("/me/repos/{owner}/{repo}/actions-caches", response_model=CacheListResponse)
@@ -60,9 +76,16 @@ def personal_list_caches(
     owner: str,
     repo: str,
     payload: CacheListInput,
-    _user: UserOut = Depends(require_auth),
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
 ):
-    return _list_caches(owner, repo, payload)
+    try:
+        token = resolve_personal_token(
+            db, owner_user_id=user.id, account_login=owner, client_token=_client_token(payload)
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return _list_caches(owner, repo, token)
 
 
 @router.post("/me/repos/{owner}/{repo}/actions-caches/clear", response_model=CacheClearResponse)
@@ -73,4 +96,12 @@ def personal_clear_caches(
     db: Session = Depends(get_db),
     user: UserOut = Depends(require_auth),
 ):
-    return clear(db, owner, repo, payload, actor=user.email)
+    token = ""
+    if not payload.dry_run:
+        try:
+            token = resolve_personal_token(
+                db, owner_user_id=user.id, account_login=owner, client_token=_client_token(payload)
+            )
+        except NoGitHubTokenAvailable as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    return clear(db, owner, repo, payload, actor=user.email, token=token)

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -3,22 +3,23 @@ import logging
 import anyio
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
+from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
 from src.services.analytics_service import get_overview
+from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
-async def _run_overview(payload: AnalyticsInput) -> AnalyticsResponse:
+async def _run_overview(owner: str, token: str) -> AnalyticsResponse:
     try:
-        return await anyio.to_thread.run_sync(
-            lambda: get_overview(owner=payload.owner, token=payload.token.get_secret_value())
-        )
+        return await anyio.to_thread.run_sync(lambda: get_overview(owner=owner, token=token))
     except httpx.HTTPStatusError as exc:
         raise HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
     except httpx.RequestError:
@@ -32,11 +33,32 @@ async def _run_overview(payload: AnalyticsInput) -> AnalyticsResponse:
 async def org_analytics_overview(
     payload: AnalyticsInput,
     ctx: OrgContext = Depends(require_org_role(min_role="member")),
+    db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(payload.owner, ctx)
-    return await _run_overview(payload)
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = await anyio.to_thread.run_sync(
+            lambda: resolve_org_token(db, org_id=ctx.org.id, account_login=payload.owner, client_token=client_token)
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return await _run_overview(payload.owner, token)
 
 
 @router.post("/me/analytics/overview", response_model=AnalyticsResponse)
-async def personal_analytics_overview(payload: AnalyticsInput, _user: UserOut = Depends(require_auth)):
-    return await _run_overview(payload)
+async def personal_analytics_overview(
+    payload: AnalyticsInput,
+    user: UserOut = Depends(require_auth),
+    db: Session = Depends(get_db),
+):
+    client_token = payload.token.get_secret_value() if payload.token else None
+    try:
+        token = await anyio.to_thread.run_sync(
+            lambda: resolve_personal_token(
+                db, owner_user_id=user.id, account_login=payload.owner, client_token=client_token
+            )
+        )
+    except NoGitHubTokenAvailable as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return await _run_overview(payload.owner, token)

--- a/apps/api/src/schemas/analytics.py
+++ b/apps/api/src/schemas/analytics.py
@@ -3,7 +3,9 @@ from pydantic import BaseModel, SecretStr
 
 class AnalyticsInput(BaseModel):
     owner: str
-    token: SecretStr
+    # Optional: falls back to a GitHub App installation token when one is connected
+    # for this owner (see src.services.token_resolution).
+    token: SecretStr | None = None
 
 
 class AnalyticsResponse(BaseModel):

--- a/apps/api/src/schemas/cache.py
+++ b/apps/api/src/schemas/cache.py
@@ -2,11 +2,13 @@ from pydantic import BaseModel, SecretStr
 
 
 class CacheListInput(BaseModel):
-    token: SecretStr
+    # Optional: falls back to a GitHub App installation token when one is connected
+    # for this owner (see src.services.token_resolution).
+    token: SecretStr | None = None
 
 
 class CacheClearInput(BaseModel):
-    token: SecretStr
+    token: SecretStr | None = None
     key: str | None = None
     ref: str | None = None
     dry_run: bool = True

--- a/apps/api/src/services/cache_service.py
+++ b/apps/api/src/services/cache_service.py
@@ -6,14 +6,14 @@ from src.repositories import audit_repo, job_repo
 from src.schemas.cache import CacheClearInput
 
 
-def clear(db: Session, owner: str, repo: str, payload: CacheClearInput, actor: str) -> dict:
+def clear(db: Session, owner: str, repo: str, payload: CacheClearInput, actor: str, token: str) -> dict:
     target = f"{owner}/{repo}"
     if payload.dry_run:
         audit_repo.write(db, actor, "cache.clear.dry_run", target, payload.model_dump(exclude={"token"}))
         return {"queued": False, "dry_run": True, "message": "Dry run completed."}
 
     encrypted_token = encrypt_job_token(
-        payload.token.get_secret_value(),
+        token,
         settings.job_secret_key.get_secret_value(),
     )
     job_id = job_repo.enqueue(db, "github.clear_actions_cache", {

--- a/apps/api/src/services/token_resolution.py
+++ b/apps/api/src/services/token_resolution.py
@@ -1,0 +1,83 @@
+"""Resolve a GitHub API token for a request, preferring a connected GitHub App
+installation over a client-supplied personal access token.
+
+If the target org/account has a `github_installations` row with an `installation_id`,
+mint a short-lived installation token via `github_app.get_installation_token()`. Otherwise
+fall back to whatever token the caller supplied (the legacy PAT path). Raises
+`NoGitHubTokenAvailable` when neither is available.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import GitHubInstallation
+from src.repositories import installation_repo
+from src.services import github_app
+
+logger = logging.getLogger(__name__)
+
+
+class NoGitHubTokenAvailable(RuntimeError):
+    """Raised when no GitHub App installation and no client-supplied token are available."""
+
+
+def _from_installation(installation: GitHubInstallation | None) -> str | None:
+    if installation is None or installation.installation_id is None:
+        return None
+    try:
+        return github_app.get_installation_token(installation.installation_id)
+    except github_app.GitHubAppNotConfigured:
+        # Deployment-wide: the App isn't set up at all. Distinct from "no installation for
+        # this account" — worth a log line since every installation-backed request will hit
+        # this until an operator configures GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY.
+        logger.warning("GitHub App installation %s exists but the App is not configured", installation.installation_id)
+        return None
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        # The installation row is stale (App uninstalled/suspended on GitHub's side) or
+        # GitHub's token-minting endpoint is briefly unreachable. Don't let this become an
+        # unhandled 500 — fall back to a client-supplied token same as "no installation".
+        logger.warning("Failed to mint an installation token for installation %s", installation.installation_id, exc_info=True)
+        return None
+
+
+def _github_app_configured() -> bool:
+    return settings.github_app_id is not None and settings.github_app_private_key is not None
+
+
+def resolve_org_token(db: Session, *, org_id: int, account_login: str, client_token: str | None) -> str:
+    installation = (
+        installation_repo.get_for_org(db, org_id=org_id, account_login=account_login)
+        if _github_app_configured()
+        else None
+    )
+    token = _from_installation(installation)
+    if token:
+        return token
+    if client_token:
+        return client_token
+    raise NoGitHubTokenAvailable(
+        f"No GitHub App installation found for '{account_login}' and no token was provided. "
+        "Install the GitHub App for this organization, or add a personal access token in Settings."
+    )
+
+
+def resolve_personal_token(db: Session, *, owner_user_id: int, account_login: str, client_token: str | None) -> str:
+    installation = (
+        installation_repo.get_for_user(db, owner_user_id=owner_user_id, account_login=account_login)
+        if _github_app_configured()
+        else None
+    )
+    token = _from_installation(installation)
+    if token:
+        return token
+    if client_token:
+        return client_token
+    raise NoGitHubTokenAvailable(
+        f"No GitHub App installation found for '{account_login}' and no token was provided. "
+        "Install the GitHub App, or add a personal access token in Settings."
+    )

--- a/apps/api/tests/test_actions_cache.py
+++ b/apps/api/tests/test_actions_cache.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import installation_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.actions_cache import router as cache_router
 
 _USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
@@ -73,3 +73,99 @@ def test_clear_caches_dry_run_does_not_require_a_token(cache_client):
     )
     assert resp.status_code == 200
     assert resp.json()["dry_run"] is True
+
+
+def test_personal_clear_caches_non_dry_run_uses_client_token(cache_client, db):
+    db.add(User(id=_USER.id, email=_USER.email, name=None, password_hash=None, is_workspace_admin=False))
+    db.commit()
+    resp = cache_client.post(
+        "/me/repos/acme/demo/actions-caches/clear",
+        json={"dry_run": False, "token": "ghp_testtoken123456789012345678901234"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["queued"] is True
+
+
+def test_personal_clear_caches_non_dry_run_no_token_returns_400(cache_client):
+    resp = cache_client.post(
+        "/me/repos/acme/demo/actions-caches/clear",
+        json={"dry_run": False},
+    )
+    assert resp.status_code == 400
+
+
+# ── org-scoped ────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def acme_org(db):
+    admin = User(email="admin@e.com", name=None, password_hash=None, is_workspace_admin=False)
+    member = User(email="member@e.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add_all([admin, member])
+    db.commit()
+    db.refresh(admin)
+    db.refresh(member)
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return {"org": org, "admin": admin, "member": member}
+
+
+def _org_client(db, user_id):
+    app = FastAPI()
+    app.include_router(cache_router)
+    app.dependency_overrides[require_auth] = lambda: UserOut(
+        id=user_id, email="u@example.com", name=None, is_workspace_admin=False
+    )
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app)
+
+
+def test_org_list_caches_member_ok(db, acme_org):
+    client = _org_client(db, acme_org["member"].id)
+    with patch("src.routers.actions_cache.GitHubClient") as mock_client:
+        mock_client.return_value.request.return_value = {"total_count": 0, "actions_caches": []}
+        resp = client.post(
+            "/orgs/acme/repos/acme/demo/actions-caches",
+            json={"token": "ghp_testtoken123456789012345678901234"},
+        )
+    assert resp.status_code == 200
+
+
+def test_org_list_caches_no_installation_and_no_token_returns_400(db, acme_org):
+    client = _org_client(db, acme_org["member"].id)
+    resp = client.post("/orgs/acme/repos/acme/demo/actions-caches", json={})
+    assert resp.status_code == 400
+
+
+def test_org_clear_caches_non_dry_run_no_installation_and_no_token_returns_400(db, acme_org):
+    client = _org_client(db, acme_org["admin"].id)
+    resp = client.post("/orgs/acme/repos/acme/demo/actions-caches/clear", json={"dry_run": False})
+    assert resp.status_code == 400
+
+
+def test_org_list_caches_outsider_forbidden(db, acme_org):
+    client = _org_client(db, 999999)
+    resp = client.post(
+        "/orgs/acme/repos/acme/demo/actions-caches",
+        json={"token": "ghp_testtoken123456789012345678901234"},
+    )
+    assert resp.status_code == 403
+
+
+def test_org_clear_caches_non_dry_run_uses_client_token(db, acme_org):
+    client = _org_client(db, acme_org["admin"].id)
+    resp = client.post(
+        "/orgs/acme/repos/acme/demo/actions-caches/clear",
+        json={"dry_run": False, "token": "ghp_testtoken123456789012345678901234"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["queued"] is True
+
+
+def test_org_clear_caches_requires_admin(db, acme_org):
+    client = _org_client(db, acme_org["member"].id)
+    resp = client.post(
+        "/orgs/acme/repos/acme/demo/actions-caches/clear",
+        json={"dry_run": True},
+    )
+    assert resp.status_code == 403

--- a/apps/api/tests/test_actions_cache.py
+++ b/apps/api/tests/test_actions_cache.py
@@ -8,16 +8,19 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.repositories import installation_repo
 from src.routers.actions_cache import router as cache_router
 
 _USER = UserOut(id=1, email="u@example.com", name=None, is_workspace_admin=False)
 
 
 @pytest.fixture()
-def cache_client():
+def cache_client(db):
     app = FastAPI()
     app.include_router(cache_router)
     app.dependency_overrides[require_auth] = lambda: _USER
+    app.dependency_overrides[get_db] = lambda: db
     return TestClient(app)
 
 
@@ -32,3 +35,41 @@ def test_list_caches_maps_github_status_error_to_400(cache_client):
         )
     assert resp.status_code == 400
     assert "404" in resp.json()["detail"]
+
+
+# ── GitHub App installation-token fallback ─────────────────────────────────────
+
+def test_list_caches_uses_installation_token_when_no_client_token(cache_client, db, monkeypatch):
+    from pydantic import SecretStr
+
+    from src.core.config import settings
+
+    monkeypatch.setattr(settings, "github_app_id", "123")
+    monkeypatch.setattr(settings, "github_app_private_key", SecretStr("dummy-pem"))
+    db.add(User(id=_USER.id, email=_USER.email, name=None, password_hash=None, is_workspace_admin=False))
+    db.commit()
+    installation_repo.create(
+        db, account_login="acme", account_type="User", auth_mode="app", installation_id=42, owner_user_id=_USER.id
+    )
+    with (
+        patch("src.routers.actions_cache.GitHubClient") as mock_client,
+        patch("src.services.token_resolution.github_app.get_installation_token", return_value="minted-token"),
+    ):
+        mock_client.return_value.request.return_value = {"total_count": 0, "actions_caches": []}
+        resp = cache_client.post("/me/repos/acme/demo/actions-caches", json={})
+    assert resp.status_code == 200
+    mock_client.assert_called_once_with("minted-token")
+
+
+def test_list_caches_no_installation_and_no_token_returns_400(cache_client):
+    resp = cache_client.post("/me/repos/acme/demo/actions-caches", json={})
+    assert resp.status_code == 400
+
+
+def test_clear_caches_dry_run_does_not_require_a_token(cache_client):
+    resp = cache_client.post(
+        "/me/repos/acme/demo/actions-caches/clear",
+        json={"dry_run": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["dry_run"] is True

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.analytics import router
 
 
@@ -149,3 +149,33 @@ def test_org_overview_owner_mismatch_forbidden(http, db, mock_user):
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
     resp = http.post("/orgs/acme/analytics/overview", json={"owner": "someone-else", "token": "ghp_test"})
     assert resp.status_code == 403
+
+
+# ── GitHub App installation-token fallback ─────────────────────────────────────
+
+def test_org_overview_uses_installation_token_when_no_client_token(http, db, mock_user, monkeypatch):
+    from pydantic import SecretStr
+
+    from src.core.config import settings
+
+    monkeypatch.setattr(settings, "github_app_id", "123")
+    monkeypatch.setattr(settings, "github_app_private_key", SecretStr("dummy-pem"))
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    with (
+        patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW) as mock_overview,
+        patch("src.services.token_resolution.github_app.get_installation_token", return_value="minted-token"),
+    ):
+        resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme"})
+    assert resp.status_code == 200
+    assert mock_overview.call_args.kwargs["token"] == "minted-token"
+
+
+def test_org_overview_no_installation_and_no_token_returns_400(http, db, mock_user):
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
+    resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme"})
+    assert resp.status_code == 400

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -179,3 +179,8 @@ def test_org_overview_no_installation_and_no_token_returns_400(http, db, mock_us
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=mock_user.id, role="member")
     resp = http.post("/orgs/acme/analytics/overview", json={"owner": "acme"})
     assert resp.status_code == 400
+
+
+def test_personal_overview_no_installation_and_no_token_returns_400(http):
+    resp = http.post("/me/analytics/overview", json={"owner": "acme"})
+    assert resp.status_code == 400

--- a/apps/api/tests/test_token_resolution.py
+++ b/apps/api/tests/test_token_resolution.py
@@ -1,0 +1,96 @@
+"""Tests for src.services.token_resolution — installation-token-first, PAT-fallback."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from src.core.config import settings
+from src.core.db import User
+from src.repositories import installation_repo, org_repo
+from src.services import github_app
+from src.services.token_resolution import (
+    NoGitHubTokenAvailable,
+    resolve_org_token,
+    resolve_personal_token,
+)
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture()
+def app_configured(monkeypatch):
+    """Installation-token lookup only kicks in when the GitHub App is configured."""
+    monkeypatch.setattr(settings, "github_app_id", "123")
+    monkeypatch.setattr(settings, "github_app_private_key", SecretStr("dummy-pem"))
+
+
+def test_resolve_org_token_uses_installation_when_connected(db, app_configured):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    with patch("src.services.token_resolution.github_app.get_installation_token", return_value="minted-token") as mint:
+        token = resolve_org_token(db, org_id=org.id, account_login="acme", client_token="ghp_client")
+    mint.assert_called_once_with(42)
+    assert token == "minted-token"
+
+
+def test_resolve_org_token_falls_back_to_client_token_when_no_installation(db, app_configured):
+    org = org_repo.get_or_create(db, github_login="acme")
+    token = resolve_org_token(db, org_id=org.id, account_login="acme", client_token="ghp_client")
+    assert token == "ghp_client"
+
+
+def test_resolve_org_token_falls_back_when_app_not_configured(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    token = resolve_org_token(db, org_id=org.id, account_login="acme", client_token="ghp_client")
+    assert token == "ghp_client"
+
+
+def test_resolve_org_token_falls_back_when_installation_token_mint_fails(db, app_configured):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    request = httpx.Request("POST", "https://api.github.com/app/installations/42/access_tokens")
+    response = httpx.Response(404, request=request)
+    with patch(
+        "src.services.token_resolution.github_app.get_installation_token",
+        side_effect=httpx.HTTPStatusError("not found", request=request, response=response),
+    ):
+        token = resolve_org_token(db, org_id=org.id, account_login="acme", client_token="ghp_client")
+    assert token == "ghp_client"
+
+
+def test_resolve_org_token_raises_when_nothing_available(db, app_configured):
+    org = org_repo.get_or_create(db, github_login="acme")
+    with pytest.raises(NoGitHubTokenAvailable):
+        resolve_org_token(db, org_id=org.id, account_login="acme", client_token=None)
+
+
+def test_resolve_personal_token_uses_installation_when_connected(db, app_configured):
+    user = _make_user(db, "shabnam@e.com")
+    installation_repo.create(
+        db, account_login="shabnam", account_type="User", auth_mode="app", installation_id=7, owner_user_id=user.id
+    )
+    with patch("src.services.token_resolution.github_app.get_installation_token", return_value="minted-token") as mint:
+        token = resolve_personal_token(db, owner_user_id=user.id, account_login="shabnam", client_token=None)
+    mint.assert_called_once_with(7)
+    assert token == "minted-token"
+
+
+def test_resolve_personal_token_raises_when_nothing_available(db, app_configured):
+    user = _make_user(db, "shabnam@e.com")
+    with pytest.raises(NoGitHubTokenAvailable):
+        resolve_personal_token(db, owner_user_id=user.id, account_login="shabnam", client_token=None)

--- a/apps/api/tests/test_token_resolution.py
+++ b/apps/api/tests/test_token_resolution.py
@@ -58,6 +58,19 @@ def test_resolve_org_token_falls_back_when_app_not_configured(db):
     assert token == "ghp_client"
 
 
+def test_resolve_org_token_falls_back_when_get_installation_token_raises_not_configured(db, app_configured):
+    org = org_repo.get_or_create(db, github_login="acme")
+    installation_repo.create(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=42, org_id=org.id
+    )
+    with patch(
+        "src.services.token_resolution.github_app.get_installation_token",
+        side_effect=github_app.GitHubAppNotConfigured("nope"),
+    ):
+        token = resolve_org_token(db, org_id=org.id, account_login="acme", client_token="ghp_client")
+    assert token == "ghp_client"
+
+
 def test_resolve_org_token_falls_back_when_installation_token_mint_fails(db, app_configured):
     org = org_repo.get_or_create(db, github_login="acme")
     installation_repo.create(

--- a/apps/ui/app/repos/[repo]/cache/page.tsx
+++ b/apps/ui/app/repos/[repo]/cache/page.tsx
@@ -104,6 +104,9 @@ export default function CachePage() {
             <div>
               <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
+                <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                  optional if the GitHub App is connected for this org
+                </span>
                 {tokenSaved && (
                   <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
                     <Key className="size-3" />saved
@@ -111,7 +114,7 @@ export default function CachePage() {
                 )}
               </label>
               <Input
-                placeholder="ghp_..."
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
                 type="password"
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
@@ -145,7 +148,7 @@ export default function CachePage() {
             </div>
             <Button
               onClick={() => listMutation.mutate()}
-              disabled={isLoading || !token}
+              disabled={isLoading}
               className="mt-1"
             >
               {listMutation.isPending ? (
@@ -164,7 +167,7 @@ export default function CachePage() {
               <Button
                 variant="outline"
                 onClick={() => clearMutation.mutate(true)}
-                disabled={isLoading || !token || !actor}
+                disabled={isLoading || !actor}
               >
                 <Eye className="size-3.5" />
                 Dry run
@@ -172,7 +175,7 @@ export default function CachePage() {
               <Button
                 variant="destructive"
                 onClick={() => clearMutation.mutate(false)}
-                disabled={isLoading || !token || !actor}
+                disabled={isLoading || !actor}
               >
                 <Trash className="size-3.5" />
                 Clear
@@ -241,7 +244,7 @@ export default function CachePage() {
           ) : caches.length === 0 ? (
             <div className="px-4 py-8">
               <p className="text-sm text-muted-foreground font-mono">
-                — enter a token and click &ldquo;Load caches&rdquo; to list entries
+                — click &ldquo;Load caches&rdquo; to list entries
               </p>
             </div>
           ) : (

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -147,12 +147,15 @@ export default function SecurityPage() {
                 placeholder="e.g. octocat"
                 value={owner}
                 onChange={(e) => setOwner(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && owner && token && !scan.isPending && scan.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && scan.mutate()}
               />
             </div>
             <div>
               <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
+                <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                  optional if the GitHub App is connected for this org
+                </span>
                 {tokenSaved && (
                   <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
                     <Key className="size-3" />saved
@@ -160,17 +163,17 @@ export default function SecurityPage() {
                 )}
               </label>
               <Input
-                placeholder="ghp_..."
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
                 type="password"
                 value={token}
                 onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
                 className="font-mono"
-                onKeyDown={(e) => e.key === "Enter" && owner && token && !scan.isPending && scan.mutate()}
+                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && scan.mutate()}
               />
             </div>
             <Button
               onClick={() => scan.mutate()}
-              disabled={scan.isPending || !owner || !token}
+              disabled={scan.isPending || !owner}
               className="mt-1"
             >
               {scan.isPending ? "Scanning…" : "Run scan"}

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -132,9 +132,10 @@ function normalizeCheckValue(id: string, raw: unknown): CheckValue {
 
 export const api = {
   analytics: {
-    // Self-service: the caller brings their own token, scoped to their personal context.
+    // token is optional — the API falls back to a connected GitHub App installation
+    // token when one exists for this owner, so an empty field is fine to send.
     overview: async (owner: string, token: string): Promise<AnalyticsOverviewResponse> => {
-      const data = await post<AnalyticsOverviewResponse>("/me/analytics/overview", { owner, token })
+      const data = await post<AnalyticsOverviewResponse>("/me/analytics/overview", { owner, token: token || undefined })
       return {
         ...data,
         checks: data.checks.map((c) => ({ ...c, value: normalizeCheckValue(c.id, c.value) })),
@@ -145,7 +146,7 @@ export const api = {
     list: (owner: string, repo: string, token: string) =>
       post<CacheListResponse>(
         `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions-caches`,
-        { token },
+        { token: token || undefined },
       ),
     clear: (
       owner: string,
@@ -154,7 +155,7 @@ export const api = {
     ) =>
       post<CacheClearResponse>(
         `/me/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions-caches/clear`,
-        body,
+        { ...body, token: body.token || undefined },
       ),
   },
   jobs: {

--- a/apps/ui/tests/components/cache-page.test.tsx
+++ b/apps/ui/tests/components/cache-page.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const tokensUpsertMock = vi.fn();
+const cacheListMock = vi.fn();
+const cacheClearMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ repo: "acme~demo" }),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: {
+      resolve: (...args: unknown[]) => tokensResolveMock(...args),
+      upsert: (...args: unknown[]) => tokensUpsertMock(...args),
+    },
+    cache: {
+      list: (...args: unknown[]) => cacheListMock(...args),
+      clear: (...args: unknown[]) => cacheClearMock(...args),
+    },
+  },
+}));
+
+import CachePage from "@/app/repos/[repo]/cache/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CachePage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CachePage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    tokensUpsertMock.mockReset();
+    cacheListMock.mockReset();
+    cacheClearMock.mockReset();
+    tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("allows a dry-run clear with an actor but no token entered", async () => {
+    cacheClearMock.mockResolvedValue({ queued: false, dry_run: true });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("actor"), { target: { value: "me@example.com" } });
+
+    const dryRunButton = screen.getByRole("button", { name: /dry run/i });
+    await waitFor(() => expect(dryRunButton).not.toBeDisabled());
+
+    fireEvent.click(dryRunButton);
+
+    await waitFor(() =>
+      expect(cacheClearMock).toHaveBeenCalledWith("acme", "demo", {
+        token: "",
+        actor: "me@example.com",
+        dry_run: true,
+      }),
+    );
+  });
+
+  it("keeps the Clear button disabled until an actor is entered", async () => {
+    renderPage();
+    expect(screen.getByRole("button", { name: /^clear$/i })).toBeDisabled();
+  });
+});

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -71,4 +71,44 @@ describe("SecurityPage", () => {
 
     await waitFor(() => expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", ""));
   });
+
+  it("runs a scan on Enter in the organization field with no token entered", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 100,
+      total_checks: 0,
+      failed_checks: 0,
+      repo_count: 0,
+      checks: [],
+    });
+
+    renderPage();
+
+    const orgInput = screen.getByPlaceholderText("e.g. octocat");
+    fireEvent.change(orgInput, { target: { value: "acme" } });
+    await waitFor(() => expect(screen.getByRole("button", { name: /run scan/i })).not.toBeDisabled());
+
+    fireEvent.keyDown(orgInput, { key: "Enter" });
+    await waitFor(() => expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", ""));
+  });
+
+  it("runs a scan on Enter in the token field", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 100,
+      total_checks: 0,
+      failed_checks: 0,
+      repo_count: 0,
+      checks: [],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    const tokenInput = screen.getByPlaceholderText(/leave blank to use the connected GitHub App/i);
+    fireEvent.change(tokenInput, { target: { value: "ghp_test" } });
+
+    fireEvent.keyDown(tokenInput, { key: "Enter" });
+    await waitFor(() => expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", "ghp_test"));
+  });
 });

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const tokensUpsertMock = vi.fn();
+const analyticsOverviewMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: {
+      resolve: (...args: unknown[]) => tokensResolveMock(...args),
+      upsert: (...args: unknown[]) => tokensUpsertMock(...args),
+    },
+    analytics: {
+      overview: (...args: unknown[]) => analyticsOverviewMock(...args),
+    },
+  },
+}));
+
+import SecurityPage from "@/app/security/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SecurityPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SecurityPage", () => {
+  beforeEach(() => {
+    tokensResolveMock.mockReset();
+    tokensUpsertMock.mockReset();
+    analyticsOverviewMock.mockReset();
+    tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("allows running a scan with no token entered (GitHub App fallback)", async () => {
+    analyticsOverviewMock.mockResolvedValue({
+      owner: "acme",
+      score: 100,
+      total_checks: 0,
+      failed_checks: 0,
+      repo_count: 0,
+      checks: [],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+
+    const scanButton = screen.getByRole("button", { name: /run scan/i });
+    await waitFor(() => expect(scanButton).not.toBeDisabled());
+
+    fireEvent.click(scanButton);
+
+    await waitFor(() => expect(analyticsOverviewMock).toHaveBeenCalledWith("acme", ""));
+  });
+});

--- a/apps/ui/tests/lib/client.test.ts
+++ b/apps/ui/tests/lib/client.test.ts
@@ -43,3 +43,38 @@ describe("del() 401 handling", () => {
     expect(dispatchSpy).not.toHaveBeenCalledWith(expect.objectContaining({ type: "clevis:unauthorized" }));
   });
 });
+
+describe("optional token coercion (GitHub App installation fallback)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function stubOkJson(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))),
+    );
+  }
+
+  it("sends token: undefined for analytics.overview when the token field is empty", async () => {
+    stubOkJson({ owner: "acme", score: 100, total_checks: 0, failed_checks: 0, repo_count: 0, checks: [] });
+    await api.analytics.overview("acme", "");
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body as string)).toEqual({ owner: "acme", token: undefined });
+  });
+
+  it("sends token: undefined for cache.list when the token field is empty", async () => {
+    stubOkJson({ repository: "acme/demo", total: 0, actions_caches: [] });
+    await api.cache.list("acme", "demo", "");
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined });
+  });
+
+  it("sends token: undefined for cache.clear when the token field is empty", async () => {
+    stubOkJson({ queued: false, dry_run: true });
+    await api.cache.clear("acme", "demo", { token: "", actor: "me", dry_run: true });
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(init.body as string)).toEqual({ token: undefined, actor: "me", dry_run: true });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #140. `apps/api/src/services/github_app.py` already implemented a full GitHub App installation-token flow (mint + cache a short-lived token per installation), but nothing called it — Health & Security and Cache required a manually-pasted personal access token even after an org installed the GitHub App, which defeats the point of offering App-based auth at all.

This PR wires that path in as a fallback, not a replacement:

- **New `apps/api/src/services/token_resolution.py`** — `resolve_org_token`/`resolve_personal_token` look up a connected `github_installations` row for the target org/account and mint an installation token via the existing `github_app.get_installation_token()`. If no installation exists (or the App isn't configured for this deployment, or minting fails), it falls back to whatever token the client supplied. Raises `NoGitHubTokenAvailable` only when neither path has anything to offer.
- **`token` is now optional** on `AnalyticsInput`, `CacheListInput`, `CacheClearInput` (previously required `SecretStr`) — the API can now serve these requests without the client sending anything, when an installation covers the request.
- **Routers** (`analytics.py`, `actions_cache.py`) resolve the token server-side before calling the underlying service, instead of trusting `payload.token` directly. `cache_service.clear()` now takes the resolved token as an explicit parameter rather than pulling it off the payload, decoupling it from where the token came from.
- **Frontend**: Security and Cache pages no longer hard-disable their submit buttons on an empty token field — an empty token is sent as `undefined` and the server decides whether a fallback is available. If neither path has a token, the existing error-banner UI surfaces the server's 400 message telling the user to install the App or add a PAT.

## Why these specific changes, not more

An existing open PR (#150, from another contributor) claimed to close #140 but only called `get_installation_token()` once during `/installations/sync` and discarded the result — it never touched the analytics/cache code paths, so it didn't actually fix the user-facing problem. This PR does the real wiring instead.

Scope was deliberately kept to Health & Security + Cache (what #140 describes). Two related gaps were found during implementation and review but intentionally left out to avoid scope creep — noted here rather than silently fixed or silently ignored:
- The homepage overview stat cards still gate entirely on a saved legacy PAT and weren't updated to the new tokenless flow (separate page/concern from #140).
- Installation tokens are always preferred over an explicit client token when an installation row exists, even if that installation is repo-scoped and doesn't cover the requested repo. Changing that precedence would undercut the point of this fix (using the App automatically without needing a PAT), so it's left as a known tradeoff rather than "fixed" unilaterally.

## Self-review findings (fixed before opening this PR)

Ran this repo's multi-angle code-review process against the diff before opening the PR. Two real bugs surfaced and were fixed:
1. `_from_installation()` only caught `GitHubAppNotConfigured`; a stale/uninstalled App installation or a transient GitHub outage during token minting would raise an uncaught `httpx` error → unhandled 500 instead of falling back to the client's PAT. Now caught and logged, with a fallback to the client token.
2. Token resolution can perform a blocking network call to GitHub, but was being called synchronously inside `async def` route handlers in `analytics.py` — capable of stalling the event loop. Now wrapped in `anyio.to_thread.run_sync`, matching the existing pattern already used for `get_overview` in the same file.

Also added a short-circuit to skip the installation DB lookup entirely when the GitHub App isn't configured for the deployment at all, since the outcome is otherwise fully predetermined by static settings.

## Sensitive-file flag

This touches token-handling/auth-adjacent code (how a GitHub API token is resolved for a request) per AGENTS.md's guardrail — flagging explicitly. It does **not** change the Fernet encryption scheme itself (`_crypto.py` untouched), RBAC role checks, or how tokens are stored; it only changes where a token can come from before it reaches the existing encryption/usage paths. No new migration — `github_installations` already had the columns/indexes this needed.

## Test plan

- [x] `pytest -q` — 180 passed (full suite, real Postgres)
- [x] `cd apps/ui && bun run typecheck && bun run lint && bun run build` — clean
- [x] `cd apps/ui && bun run test` — 58 passed (excluding one pre-existing, unrelated flaky font-loading test timeout in `layout.test.tsx`, not touched by this diff)
- [x] New unit tests for `token_resolution.py` covering: installation found → mints token; no installation → falls back to client token; App not configured → falls back; installation-token mint fails (httpx error) → falls back; neither available → raises
- [x] Router-level tests confirming the installation-token path end-to-end for both `/orgs/{org}/analytics/overview` and `/me/repos/.../actions-caches`, and that dry-run cache clears still don't require a token
- [x] New frontend test confirming the Security page allows submitting a scan with no token entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)