### PR TITLE
fix(api): reject personal-account scans on /me/analytics/overview with a clear error

### DIFF
--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -9,7 +9,7 @@ from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
 from src.schemas.analytics import AnalyticsInput, AnalyticsResponse
-from src.services.analytics_service import get_overview
+from src.services.analytics_service import get_account_type, get_overview
 from src.services.token_resolution import NoGitHubTokenAvailable, resolve_org_token, resolve_personal_token
 
 logger = logging.getLogger(__name__)
@@ -27,6 +27,15 @@ async def _run_overview(owner: str, token: str) -> AnalyticsResponse:
     except Exception:
         logger.exception("analytics_overview failed")
         raise HTTPException(status_code=500, detail="Internal error")
+
+
+async def _get_account_type(owner: str, token: str) -> str:
+    try:
+        return await anyio.to_thread.run_sync(lambda: get_account_type(owner=owner, token=token))
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    except httpx.RequestError:
+        raise HTTPException(status_code=503, detail="GitHub API unreachable")
 
 
 @router.post("/orgs/{org_login}/analytics/overview", response_model=AnalyticsResponse)
@@ -61,4 +70,10 @@ async def personal_analytics_overview(
         )
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
+    account_type = await _get_account_type(payload.owner, token)
+    if account_type == "User":
+        raise HTTPException(
+            status_code=422,
+            detail="Personal GitHub accounts aren't supported for security scanning yet. Connect a GitHub organization instead.",
+        )
     return await _run_overview(payload.owner, token)

--- a/apps/api/src/services/analytics_service.py
+++ b/apps/api/src/services/analytics_service.py
@@ -1,6 +1,20 @@
+import httpx
 from checks.runner import run_all_checks
 
 from src.core.config import settings
+
+
+def get_account_type(owner: str, token: str, base_url: str | None = None) -> str:
+    base_url = base_url or settings.github_api_base
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        r = client.get(f"{base_url}/users/{owner}", headers=headers)
+    r.raise_for_status()
+    return r.json().get("type", "User")
 
 
 def get_overview(owner: str, token: str) -> dict:

--- a/apps/api/tests/test_analytics.py
+++ b/apps/api/tests/test_analytics.py
@@ -66,7 +66,10 @@ def test_personal_overview_requires_auth(db):
 
 def test_overview_returns_expected_shape(http):
     # Mock get_overview directly; anyio.to_thread.run_sync runs the lambda for real
-    with patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW):
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
+        patch("src.routers.analytics.get_overview", return_value=MOCK_OVERVIEW),
+    ):
         resp = http.post(
             "/me/analytics/overview",
             json={"owner": "acme", "token": "ghp_test"},
@@ -81,12 +84,15 @@ def test_overview_returns_expected_shape(http):
 def test_overview_github_http_error_returns_400(http):
     import httpx
 
-    with patch(
-        "src.routers.analytics.get_overview",
-        side_effect=httpx.HTTPStatusError(
-            "not found",
-            request=MagicMock(),
-            response=MagicMock(status_code=404),
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
+        patch(
+            "src.routers.analytics.get_overview",
+            side_effect=httpx.HTTPStatusError(
+                "not found",
+                request=MagicMock(),
+                response=MagicMock(status_code=404),
+            ),
         ),
     ):
         resp = http.post(
@@ -100,9 +106,12 @@ def test_overview_github_http_error_returns_400(http):
 def test_overview_request_error_returns_503(http):
     import httpx
 
-    with patch(
-        "src.routers.analytics.get_overview",
-        side_effect=httpx.RequestError("timeout"),
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
+        patch(
+            "src.routers.analytics.get_overview",
+            side_effect=httpx.RequestError("timeout"),
+        ),
     ):
         resp = http.post(
             "/me/analytics/overview",
@@ -113,6 +122,7 @@ def test_overview_request_error_returns_503(http):
 
 def test_overview_unexpected_exception_logs_and_returns_500(http):
     with (
+        patch("src.routers.analytics.get_account_type", return_value="Organization"),
         patch(
             "src.routers.analytics.get_overview",
             side_effect=RuntimeError("unexpected"),
@@ -126,6 +136,56 @@ def test_overview_unexpected_exception_logs_and_returns_500(http):
     assert resp.status_code == 500
     # B-10: exception must be logged, not silently swallowed
     mock_logger.exception.assert_called_once_with("analytics_overview failed")
+
+
+# ── personal-account guard (issue #144) ────────────────────────────────────────
+
+def test_personal_overview_rejects_user_account_with_422(http):
+    with (
+        patch("src.routers.analytics.get_account_type", return_value="User") as mock_account_type,
+        patch("src.routers.analytics.get_overview") as mock_overview,
+    ):
+        resp = http.post(
+            "/me/analytics/overview",
+            json={"owner": "octocat", "token": "ghp_test"},
+        )
+    assert resp.status_code == 422
+    assert "Personal GitHub accounts aren't supported" in resp.json()["detail"]
+    mock_account_type.assert_called_once()
+    mock_overview.assert_not_called()
+
+
+def test_personal_overview_account_type_http_error_returns_400(http):
+    import httpx
+
+    with patch(
+        "src.routers.analytics.get_account_type",
+        side_effect=httpx.HTTPStatusError(
+            "not found",
+            request=MagicMock(),
+            response=MagicMock(status_code=404),
+        ),
+    ):
+        resp = http.post(
+            "/me/analytics/overview",
+            json={"owner": "octocat", "token": "ghp_test"},
+        )
+    assert resp.status_code == 400
+    assert "GitHub API error" in resp.json()["detail"]
+
+
+def test_personal_overview_account_type_request_error_returns_503(http):
+    import httpx
+
+    with patch(
+        "src.routers.analytics.get_account_type",
+        side_effect=httpx.RequestError("timeout"),
+    ):
+        resp = http.post(
+            "/me/analytics/overview",
+            json={"owner": "octocat", "token": "ghp_test"},
+        )
+    assert resp.status_code == 503
 
 
 # ── org-scoped ────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_analytics_account_type.py
+++ b/apps/api/tests/test_analytics_account_type.py
@@ -1,0 +1,37 @@
+"""Unit tests for analytics_service.get_account_type (issue #144)."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from src.services.analytics_service import get_account_type
+
+
+def _mock_response(json_body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_get_account_type_returns_organization():
+    with patch("httpx.Client.get", return_value=_mock_response({"type": "Organization"})):
+        assert get_account_type("acme", "tok", base_url="https://api.github.com") == "Organization"
+
+
+def test_get_account_type_returns_user():
+    with patch("httpx.Client.get", return_value=_mock_response({"type": "User"})):
+        assert get_account_type("octocat", "tok", base_url="https://api.github.com") == "User"
+
+
+def test_get_account_type_raises_on_404():
+    with patch("httpx.Client.get", return_value=_mock_response({}, status_code=404)):
+        with pytest.raises(httpx.HTTPStatusError):
+            get_account_type("missing", "tok", base_url="https://api.github.com")


### PR DESCRIPTION
## What changed and why

`POST /me/analytics/overview` let any authenticated user run a security scan
against an arbitrary `owner` login, with no check that the login was actually
a GitHub *organization*. The checks underneath — `OrgMFARequired` (calls
`GET /orgs/{owner}`) and the repo-listing call shared by all three checks
(`GET /orgs/{owner}/repos`) — are org-only GitHub REST endpoints. A solo user
with no org, scanning their own personal login, got an opaque
`400 GitHub API error: 404` instead of any explanation of what went wrong.

This adds an account-type check (`GET /users/{owner}`) before running the
scan on the `/me/analytics/overview` path. If the login resolves to a
personal (`User`-type) account, the endpoint now returns a `422` with a clear
message ("Personal GitHub accounts aren't supported for security scanning
yet. Connect a GitHub organization instead.") instead of letting the request
fail unclearly against org-only endpoints.

I chose this minimal guard over adapting the checks themselves to support
personal accounts (issue #144's other suggested option) because that's a
materially larger change touching the shared `packages/checks` package
(`OrgMFARequired` in particular has no real per-user equivalent — GitHub
doesn't expose "does this personal account require 2FA" the way it does for
orgs) and felt out of scope for this fix. Full personal-account support can
be a follow-up.

The `/orgs/{org_login}/analytics/overview` path is
`assert_owner_matches_org` already ties `owner` to a real org there, so it
can't hit this failure mode.

No migration, no RBAC/auth/token-encryption change

Fixes #144