### PR TITLE
fix(api): verify installation_id against GitHub before persisting sync rows (#141)

### DIFF
--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -12,6 +12,7 @@
   POST /me/installations/sync                connect a personal (User-type) GitHub installation
 """
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -24,8 +25,42 @@ from src.schemas.installation import (
     SyncInstallationsInput,
     SyncInstallationsResponse,
 )
+from src.services import github_app
 
 router = APIRouter()
+
+
+def _verify_installation(installation_id: int | None, account_login: str, account_type: str) -> None:
+    """Confirm a client-supplied installation_id genuinely belongs to the claimed
+    account before it's persisted as trusted data. No-op if installation_id wasn't
+    supplied — there's nothing to verify in that case."""
+    if installation_id is None:
+        return
+    try:
+        installation = github_app.get_installation(installation_id)
+    except github_app.GitHubAppNotConfigured:
+        raise HTTPException(
+            status_code=503,
+            detail="GitHub App is not configured; cannot verify installation_id",
+        )
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            raise HTTPException(status_code=422, detail=f"installation_id {installation_id} does not exist")
+        raise HTTPException(status_code=400, detail=f"GitHub API error: {exc.response.status_code}")
+    except httpx.RequestError:
+        raise HTTPException(status_code=503, detail="GitHub API unreachable")
+
+    account = installation.get("account") or {}
+    actual_login = account.get("login", "")
+    actual_type = account.get("type", "")
+    if actual_login.lower() != account_login.lower() or actual_type != account_type:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"installation_id {installation_id} belongs to {actual_type} "
+                f"'{actual_login}', not {account_type} '{account_login}'"
+            ),
+        )
 
 
 @router.get("/orgs/{org_login}/installations", response_model=list[InstallationOut])
@@ -43,6 +78,7 @@ def sync_org_installation(
     db: Session = Depends(get_db),
 ):
     assert_owner_matches_org(payload.account_login, ctx)
+    _verify_installation(payload.installation_id, payload.account_login, payload.account_type)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,
@@ -84,6 +120,7 @@ def sync_personal_installation(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="account_login must match your own GitHub account",
         )
+    _verify_installation(payload.installation_id, payload.account_login, payload.account_type)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,

--- a/apps/api/src/services/github_app.py
+++ b/apps/api/src/services/github_app.py
@@ -84,6 +84,25 @@ def _request_installation_token(installation_id: int) -> _CachedToken:
     return _CachedToken(token=data["token"], expires_at=expires_at.timestamp())
 
 
+def get_installation(installation_id: int) -> dict:
+    """Look up an installation by ID using the App's own JWT (not an installation
+    token) — used to verify a client-supplied installation_id is real and confirm
+    which account it actually belongs to, before trusting it. Raises
+    httpx.HTTPStatusError (404 if the installation doesn't exist) or
+    GitHubAppNotConfigured."""
+    app_jwt = generate_app_jwt()
+    url = f"{settings.github_api_base}/app/installations/{installation_id}"
+    headers = {
+        "Authorization": f"Bearer {app_jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    with httpx.Client(timeout=20) as client:
+        resp = client.get(url, headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
 def get_installation_token(installation_id: int) -> str:
     """Return a valid installation access token, minting and caching it as needed."""
     with _lock:

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import httpx
 import jwt
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -100,3 +101,46 @@ def test_not_configured_raises(monkeypatch):
     monkeypatch.setattr(settings, "github_app_private_key", None)
     with pytest.raises(github_app.GitHubAppNotConfigured):
         github_app.generate_app_jwt()
+
+
+def test_get_installation_uses_app_jwt_not_installation_token(app_configured):
+    with patch("src.services.github_app.httpx.Client") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.json = MagicMock(return_value={"id": 99, "account": {"login": "acme", "type": "Organization"}})
+        mock_client.get = MagicMock(return_value=mock_resp)
+        mock_cls.return_value = mock_client
+
+        result = github_app.get_installation(99)
+
+    assert result["account"]["login"] == "acme"
+    url = mock_client.get.call_args.args[0]
+    assert url.endswith("/app/installations/99")
+    auth_header = mock_client.get.call_args.kwargs["headers"]["Authorization"]
+    # Distinct from an installation access token (which get_installation_token would mint) —
+    # this must be the App's own JWT, decodable with the App's public key.
+    token = auth_header.removeprefix("Bearer ")
+    decoded = jwt.decode(token, app_configured, algorithms=["RS256"], options={"verify_exp": False})
+    assert decoded["iss"] == _APP_ID
+
+
+def test_get_installation_raises_on_404(app_configured):
+    with patch("src.services.github_app.httpx.Client") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "not found",
+                request=httpx.Request("GET", "https://api.github.com/app/installations/404"),
+                response=httpx.Response(404),
+            )
+        )
+        mock_client.get = MagicMock(return_value=mock_resp)
+        mock_cls.return_value = mock_client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            github_app.get_installation(404)

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -1,5 +1,8 @@
 """Tests for org-scoped and personal installation endpoints."""
 
+from unittest.mock import patch
+
+import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -8,8 +11,16 @@ from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
 from src.repositories import installation_repo, org_membership_repo, org_repo
 from src.routers.installations import router as inst_router
+from src.services import github_app
 
 _OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
+
+
+def _mock_installation(account_login: str, account_type: str):
+    return patch(
+        "src.routers.installations.github_app.get_installation",
+        return_value={"account": {"login": account_login, "type": account_type}},
+    )
 
 
 def _make_user(db, email: str, github_login: str | None = None) -> UserOut:
@@ -82,10 +93,11 @@ def test_sync_org_installation_requires_admin(db, acme_org):
 
 
 def test_sync_org_installation_admin_ok(db, acme_org):
-    resp = _client(db, acme_org["admin"]).post(
-        "/orgs/acme/installations/sync",
-        json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
-    )
+    with _mock_installation("acme", "Organization"):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
     assert resp.status_code == 200
     assert resp.json()["synced"] is True
 
@@ -113,10 +125,11 @@ def test_personal_installations_scoped_to_self(db):
 
 def test_sync_personal_installation(db):
     me = _make_user(db, "shabnam@e.com", github_login="shabnam")
-    resp = _client(db, me).post(
-        "/me/installations/sync",
-        json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
-    )
+    with _mock_installation("shabnam", "User"):
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
     assert resp.status_code == 200
     assert resp.json()["synced"] is True
 
@@ -142,9 +155,57 @@ def test_sync_personal_installation_login_mismatch_forbidden(db):
 def test_sync_org_installation_upserts_existing_row(db, acme_org):
     client = _client(db, acme_org["admin"])
     payload = {"account_login": "acme", "account_type": "Organization", "installation_id": 7}
-    assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
-    payload["installation_id"] = 8
-    assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
+    with _mock_installation("acme", "Organization"):
+        assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
+        payload["installation_id"] = 8
+        assert client.post("/orgs/acme/installations/sync", json=payload).status_code == 200
     rows = client.get("/orgs/acme/installations").json()
     assert len(rows) == 1
     assert rows[0]["installation_id"] == 8
+
+
+def test_sync_org_installation_rejects_installation_id_owned_by_a_different_account(db, acme_org):
+    with _mock_installation("someone-else", "Organization"):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 422
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
+
+
+def test_sync_org_installation_rejects_nonexistent_installation_id(db, acme_org):
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/app/installations/7"))
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=httpx.HTTPStatusError("not found", request=response.request, response=response),
+    ):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 422
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
+
+
+def test_sync_org_installation_returns_503_when_app_not_configured(db, acme_org):
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=github_app.GitHubAppNotConfigured("not configured"),
+    ):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 503
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
+
+
+def test_sync_org_installation_skips_verification_when_installation_id_omitted(db, acme_org):
+    with patch("src.routers.installations.github_app.get_installation") as mock_get:
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization"},
+        )
+    assert resp.status_code == 200
+    mock_get.assert_not_called()

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -201,6 +201,33 @@ def test_sync_org_installation_returns_503_when_app_not_configured(db, acme_org)
     assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
 
 
+def test_sync_org_installation_returns_400_on_other_github_api_error(db, acme_org):
+    response = httpx.Response(500, request=httpx.Request("GET", "https://api.github.com/app/installations/7"))
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=httpx.HTTPStatusError("server error", request=response.request, response=response),
+    ):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 400
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
+
+
+def test_sync_org_installation_returns_503_on_github_network_error(db, acme_org):
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        resp = _client(db, acme_org["admin"]).post(
+            "/orgs/acme/installations/sync",
+            json={"account_login": "acme", "account_type": "Organization", "installation_id": 7},
+        )
+    assert resp.status_code == 503
+    assert installation_repo.list_for_org(db, org_id=acme_org["org"].id) == []
+
+
 def test_sync_org_installation_skips_verification_when_installation_id_omitted(db, acme_org):
     with patch("src.routers.installations.github_app.get_installation") as mock_get:
         resp = _client(db, acme_org["admin"]).post(

--- a/apps/api/tests/test_installations.py
+++ b/apps/api/tests/test_installations.py
@@ -236,3 +236,54 @@ def test_sync_org_installation_skips_verification_when_installation_id_omitted(d
         )
     assert resp.status_code == 200
     mock_get.assert_not_called()
+
+
+def test_sync_personal_installation_rejects_installation_id_owned_by_a_different_account(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    with _mock_installation("someone-else", "User"):
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
+    assert resp.status_code == 422
+    assert installation_repo.list_for_user(db, owner_user_id=me.id) == []
+
+
+def test_sync_personal_installation_rejects_nonexistent_installation_id(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.github.com/app/installations/3"))
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=httpx.HTTPStatusError("not found", request=response.request, response=response),
+    ):
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
+    assert resp.status_code == 422
+    assert installation_repo.list_for_user(db, owner_user_id=me.id) == []
+
+
+def test_sync_personal_installation_returns_503_when_app_not_configured(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    with patch(
+        "src.routers.installations.github_app.get_installation",
+        side_effect=github_app.GitHubAppNotConfigured("not configured"),
+    ):
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User", "installation_id": 3},
+        )
+    assert resp.status_code == 503
+    assert installation_repo.list_for_user(db, owner_user_id=me.id) == []
+
+
+def test_sync_personal_installation_skips_verification_when_installation_id_omitted(db):
+    me = _make_user(db, "shabnam@e.com", github_login="shabnam")
+    with patch("src.routers.installations.github_app.get_installation") as mock_get:
+        resp = _client(db, me).post(
+            "/me/installations/sync",
+            json={"account_login": "shabnam", "account_type": "User"},
+        )
+    assert resp.status_code == 200
+    mock_get.assert_not_called()


### PR DESCRIPTION
## ⚠️ Touches auth/trust-boundary code

This PR changes `apps/api/src/routers/installations.py` and `apps/api/src/services/github_app.py` — the installation-sync auth flow. Flagging per AGENTS.md guardrail #3/#2. No RBAC role requirements changed, no token-encryption logic touched, no migration — this only adds a verification call before data is trusted and persisted; it doesn't relax anything.

## Summary

`POST /orgs/{org_login}/installations/sync` and `POST /me/installations/sync` accepted a client-supplied `installation_id`/`account_login`/`auth_mode` and persisted them directly via `installation_repo.create`/`upsert` — there was no call to GitHub's Installations API to confirm the `installation_id` actually exists or belongs to the claimed account. Today this is low-risk in isolation (nothing downstream reads `token_ref` to mint a real token yet), but any authenticated user/org-admin could register an arbitrary or fabricated `installation_id` for their org/account with zero server-side proof it's real — a real trust-boundary gap that's easy to forget once installation-token auth actually ships and starts consuming this data.

Changes:
- `github_app.py`: new `get_installation(installation_id) -> dict`, calling `GET /app/installations/{id}` with the App's own JWT (not an installation token — we don't have one for an unverified ID, that's the whole point). Raises `httpx.HTTPStatusError` (404 if it doesn't exist) or `GitHubAppNotConfigured`.
- `installations.py`: new `_verify_installation(installation_id, account_login, account_type)`, called from both sync endpoints right after their existing ownership checks (`assert_owner_matches_org` / the `github_login` match) and before `installation_repo.create`. It fetches the installation and compares `account.login` (case-insensitive) and `account.type` against what the client claimed:
  - Mismatch or nonexistent `installation_id` → `422`, nothing persisted.
  - GitHub App not configured → `503` — silently accepting unverified data in this case would defeat the entire point of the fix, so verification is required, not best-effort.
  - Other GitHub API errors → `400`; network errors → `503` (matching the existing pattern in `analytics.py`).
  - `installation_id` omitted entirely → verification is skipped (nothing to verify), matching the schema's existing optional design.

Closes #141

## Checks

Mirrors [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — see [CONTRIBUTING.md](../CONTRIBUTING.md) for full commands.

- [ ] `cd apps/ui && bun run typecheck && bun run build` (if UI changed) — not applicable, no UI changes
- [x] `python -m compileall apps/api/src apps/worker/src`
- [x] Relevant `pytest` tests pass
- [ ] Docker images still build, if `Dockerfile`/deps changed — not applicable, no deps changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Updated existing `test_installations.py` sync tests to mock the new verification call, and added tests for: mismatched account rejected (422, nothing persisted), nonexistent `installation_id` rejected (422), App-not-configured returns 503, and verification skipped when `installation_id` is omitted. Also added `test_get_installation_uses_app_jwt_not_installation_token` (decodes the auth header to confirm it's actually the App JWT, not an installation token) and a 404 test in `test_github_app.py`. Full `pytest -q` suite (202 tests) passes against a real Postgres instance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7RDvvVu5mqC4pybwNqq7A)_