### PR TITLE
test(e2e): cover Settings org-connect and Security scan paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,9 @@ docker run --rm --entrypoint python \
 
 ### E2E tests
 
-Auth-flow critical paths (login, GitHub OAuth error redirect, logout, mid-session 401 handling) are covered by Playwright tests in `apps/ui/e2e/`, run against the **full docker-compose stack** — the real Docker images, not app code in isolation, so this catches deployment-shaped bugs unit tests can't (it's the same infra that would have caught the worker `packages/checks` gap). CI runs this as a required check (`E2E Tests`).
+Auth-flow critical paths (login, GitHub OAuth error redirect, logout, mid-session 401 handling), the Settings GitHub App install surface, and the Security-scan happy/error paths are covered by Playwright tests in `apps/ui/e2e/`, run against the **full docker-compose stack** — the real Docker images, not app code in isolation, so this catches deployment-shaped bugs unit tests can't (it's the same infra that would have caught the worker `packages/checks` gap). CI runs this as a required check (`E2E Tests`).
+
+Security-scan and org-connection specs that need a live GitHub org use Playwright route mocks against the API host — CI has no real App installation, but the browser still exercises the full UI → API client → render path.
 
 Run locally, from the **repository root**:
 

--- a/apps/ui/e2e/auth.spec.ts
+++ b/apps/ui/e2e/auth.spec.ts
@@ -2,19 +2,12 @@ import { expect, test } from "@playwright/test"
 
 import { E2E_API_BASE } from "../playwright.config"
 import { E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD } from "./constants"
-
-async function login(page: import("@playwright/test").Page) {
-  await page.goto("/login")
-  await page.getByPlaceholder("you@example.com").fill(E2E_ADMIN_EMAIL)
-  await page.getByPlaceholder("Password").fill(E2E_ADMIN_PASSWORD)
-  await page.getByRole("button", { name: "Sign in", exact: true }).click()
-}
+import { loginAsAdmin } from "./helpers"
 
 test.describe("Login", () => {
   test("valid credentials redirect to the app", async ({ page }) => {
-    await login(page)
+    await loginAsAdmin(page)
 
-    await expect(page).toHaveURL((url) => !url.pathname.startsWith("/login"))
     await expect(page.getByRole("heading", { level: 1, name: "Overview" })).toBeVisible()
   })
 
@@ -41,7 +34,7 @@ test.describe("GitHub OAuth error redirect", () => {
 
 test.describe("Logout", () => {
   test("manual sign-out clears the session and returns to /login", async ({ page }) => {
-    await login(page)
+    await loginAsAdmin(page)
     await expect(page.getByRole("heading", { level: 1, name: "Overview" })).toBeVisible()
 
     // Sidebar header button shows the user's name (see components/app-sidebar.tsx);
@@ -60,7 +53,7 @@ test.describe("Logout", () => {
 
 test.describe("Mid-session 401", () => {
   test("a 401 from the API redirects to /login without a loop", async ({ page }) => {
-    await login(page)
+    await loginAsAdmin(page)
     await expect(page.getByRole("heading", { level: 1, name: "Overview" })).toBeVisible()
 
     // Force the next API call to look like an expired/revoked session. /jobs auto-fetches

--- a/apps/ui/e2e/helpers.ts
+++ b/apps/ui/e2e/helpers.ts
@@ -1,0 +1,12 @@
+import type { Page } from "@playwright/test"
+
+import { E2E_ADMIN_EMAIL, E2E_ADMIN_PASSWORD } from "./constants"
+
+/** Shared login helper for e2e specs — seeds user via global-setup.ts. */
+export async function loginAsAdmin(page: Page): Promise<void> {
+  await page.goto("/login")
+  await page.getByPlaceholder("you@example.com").fill(E2E_ADMIN_EMAIL)
+  await page.getByPlaceholder("Password").fill(E2E_ADMIN_PASSWORD)
+  await page.getByRole("button", { name: "Sign in", exact: true }).click()
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"))
+}

--- a/apps/ui/e2e/security-settings.spec.ts
+++ b/apps/ui/e2e/security-settings.spec.ts
@@ -81,7 +81,7 @@ test.describe("Security scan", () => {
         body: JSON.stringify({
           detail:
             "No GitHub App installation found for 'missing-org' and no token was provided. " +
-            "Install the GitHub App for this organization, or add a personal access token in Settings.",
+            "Install the GitHub App for this organization in Settings → Connected orgs.",
         }),
       })
     })

--- a/apps/ui/e2e/security-settings.spec.ts
+++ b/apps/ui/e2e/security-settings.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test"
+
+import { E2E_API_BASE } from "../playwright.config"
+import { loginAsAdmin } from "./helpers"
+
+test.describe("Settings — org connection surface", () => {
+  test("shows the GitHub App install path after login", async ({ page }) => {
+    await loginAsAdmin(page)
+    await page.goto("/settings")
+
+    // Org-connection UI lives on Settings — real GitHub OAuth can't run in CI,
+    // so this asserts the install surface is reachable and wired (issue #187).
+    await expect(page.getByText("Personal GitHub installs")).toBeVisible()
+    await expect(
+      page.getByText(/No organizations connected yet|Install the Clevis GitHub App/i),
+    ).toBeVisible()
+
+    // Install button is present when NEXT_PUBLIC_GITHUB_APP_SLUG is set in the
+    // stack; otherwise the page explains how to enable it. Either is fine — both
+    // prove the connection section rendered instead of a stub.
+    const installButton = page.getByRole("button", { name: /Install GitHub App/i })
+    const missingSlugHint = page.getByText(/NEXT_PUBLIC_GITHUB_APP_SLUG/i)
+    await expect(installButton.or(missingSlugHint)).toBeVisible()
+  })
+})
+
+test.describe("Security scan", () => {
+  test("runs a scan happy path without a real GitHub org (API mocked)", async ({ page }) => {
+    await loginAsAdmin(page)
+
+    await page.route(`${E2E_API_BASE}/me/analytics/overview`, async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          owner: "acme",
+          score: 100,
+          total_checks: 1,
+          failed_checks: 0,
+          repo_count: 3,
+          checks: [
+            {
+              id: "organization_members_mfa_required",
+              title: "MFA required for org members",
+              status: "pass",
+              severity: "high",
+              value: true,
+              remediation: "Require two-factor authentication for all organization members.",
+            },
+          ],
+        }),
+      })
+    })
+
+    await page.goto("/security")
+    await expect(page.getByRole("heading", { level: 1, name: "Health & Security" })).toBeVisible()
+
+    await page.getByPlaceholder("e.g. octocat").fill("acme")
+    await page.getByRole("button", { name: "Run scan" }).click()
+
+    await expect(page.getByText("Results — acme")).toBeVisible()
+    await expect(page.getByText("MFA required for org members")).toBeVisible()
+    await expect(page.getByLabel(/Security score: 100/i)).toBeVisible()
+  })
+
+  test("surfaces a clear error when the API has no installation token", async ({ page }) => {
+    await loginAsAdmin(page)
+
+    await page.route(`${E2E_API_BASE}/me/analytics/overview`, async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue()
+        return
+      }
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          detail:
+            "No GitHub App installation found for 'missing-org' and no token was provided. " +
+            "Install the GitHub App for this organization, or add a personal access token in Settings.",
+        }),
+      })
+    })
+
+    await page.goto("/security")
+    await page.getByPlaceholder("e.g. octocat").fill("missing-org")
+    await page.getByRole("button", { name: "Run scan" }).click()
+
+    await expect(page.getByText(/No GitHub App installation found for 'missing-org'/i)).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

### Why
Issue #187 asked for Playwright against the full stack covering auth, org connection, and the Security-scan path. Auth + CI Playwright already landed on `main`; this PR finishes the remaining surfaces so the issue can close without leaving “org connect / security scan” uncovered.

### What changed (and why)
- **`e2e/security-settings.spec.ts`** — Settings “Personal GitHub installs” / Install App surface (real OAuth cannot run in CI). Security-scan happy path and no-installation error path via Playwright `route` mocks against `E2E_API_BASE` so CI still exercises UI → client → render without a live GitHub org.
- **`e2e/helpers.ts` + `auth.spec.ts`** — Shared `loginAsAdmin` to avoid duplicated login boilerplate.
- **CONTRIBUTING.md** — Documents the expanded e2e scope and the mock strategy.

### Sensitive surfaces
Tests + docs only. No auth/crypto/migration changes.

Fixes #187

## Test plan
- [x] `cd apps/ui && bun run typecheck`
- [x] CI **E2E Tests** previously green on this branch; re-check after latest push
- [ ] Optional local: docker-compose.ci stack + `bun run test:e2e`