### PR TITLE
fix(checks): security checks misclassify HTTP errors, hiding real results

### DIFF
--- a/packages/checks/src/checks/github_checks.py
+++ b/packages/checks/src/checks/github_checks.py
@@ -25,10 +25,30 @@ def _is_secondary_rate_limit(r: httpx.Response) -> bool:
         return False
     return "Retry-After" in r.headers or r.headers.get("X-RateLimit-Remaining") == "0"
 
+# Cap on honoring a server-supplied Retry-After value, so a single malformed/huge value
+# can't block a scan for an unreasonable amount of time -- GitHub's real rate-limit
+# Retry-After values are ordinarily well under this.
+_MAX_RETRY_AFTER_SECONDS = 60
+
+
+def _retry_delay_seconds(r: httpx.Response, attempt: int) -> float:
+    """Prefer the server's own Retry-After value (GitHub's rate-limit responses include
+    one) over a blind exponential backoff -- retrying before the window it asked for just
+    burns the fixed attempt budget hitting the same limit again."""
+    raw = r.headers.get("Retry-After")
+    if raw is not None:
+        try:
+            return min(float(raw), _MAX_RETRY_AFTER_SECONDS)
+        except ValueError:
+            pass
+    return 2**attempt
+
 
 def _get_with_retry(client: httpx.Client, url: str, headers: dict) -> httpx.Response:
     # Same retry/backoff contract as GitHubClient.request (apps/api/src/services/github_client.py):
-    # 3 attempts, exponential backoff on connection errors, a 429, or a rate-limit-flavored 403.
+    # 3 attempts, exponential backoff on connection errors, a 429, or a rate-limit-flavored 403 --
+    # plus a 5xx, which is presumed transient (GitHub-side issue) same as everywhere else in this
+    # codebase that talks to the GitHub API.
     for attempt in range(3):
         try:
             r = client.get(url, headers=headers)
@@ -37,8 +57,8 @@ def _get_with_retry(client: httpx.Client, url: str, headers: dict) -> httpx.Resp
                 time.sleep(2**attempt)
                 continue
             raise
-        if (r.status_code == 429 or _is_secondary_rate_limit(r)) and attempt < 2:
-            time.sleep(2**attempt)
+        if (r.status_code == 429 or _is_secondary_rate_limit(r) or r.status_code >= 500) and attempt < 2:
+            time.sleep(_retry_delay_seconds(r, attempt))
             continue
         return r
     raise RuntimeError("request loop exhausted without returning")
@@ -91,9 +111,12 @@ def _branch_protection_status(exc: httpx.HTTPStatusError) -> str:
     code = exc.response.status_code
     if code == 404:
         return "unprotected"
-    if code in (403, 429):
-        return "unknown"
-    return "unprotected"
+    # 403/429 (no access / rate-limited) and any other unexpected status (a transient
+    # 5xx, most notably) all mean branch-protection status genuinely can't be evaluated
+    # right now -- falling through to "unprotected" here previously flipped an org's
+    # entire branch-protection check to "fail" on a flaky GitHub 5xx even when every
+    # real repo was protected.
+    return "unknown"
 
 
 class OrgMFARequired(Check):
@@ -238,6 +261,13 @@ class DependabotAlertsCheck(Check):
         if forbidden == len(repos):
             return {"status": "error", "value": counts}
         compliant = counts["critical"] == 0 and counts["high"] == 0
+        if compliant and forbidden > 0:
+            # 403 means unknown, not zero -- a clean result from only the *reachable*
+            # repos must not be reported as "pass" while some repos' real alert counts
+            # are still unknown. A "fail" from repos we could actually see stays valid
+            # regardless (a real problem was found), so only the false-clean case needs
+            # downgrading here.
+            return {"status": "error", "value": counts}
         return {"status": "pass" if compliant else "fail", "value": counts}
 
 
@@ -285,7 +315,13 @@ class CodeScanningCheck(Check):
         value = {"open": open_count, "repos_with_alerts": repos_with_alerts, "total_repos": total_repos}
         if forbidden == total_repos:
             return {"status": "error", "value": value}
-        return {"status": "pass" if open_count == 0 else "fail", "value": value}
+        compliant = open_count == 0
+        if compliant and forbidden > 0:
+            # Same reasoning as DependabotAlertsCheck: a clean result from only the
+            # reachable repos must not be reported as "pass" while some repos' real
+            # alert status is still unknown (403 means unknown, not zero).
+            return {"status": "error", "value": value}
+        return {"status": "pass" if compliant else "fail", "value": value}
 
 
 class DefaultBranchNoForcePushCheck(Check):
@@ -314,10 +350,23 @@ class DefaultBranchNoForcePushCheck(Check):
             branch = repo.get("default_branch")
             try:
                 details = _get(f"{base_url}/repos/{owner}/{repo['name']}/branches/{branch}", token)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    # No branch protection at all -- force pushes are unambiguously
+                    # allowed, not merely "unknown". Bucketing this with the genuine
+                    # unknowns below meant an org where every repo's default branch had
+                    # no protection at all reported checked == 0 -> "error", never the
+                    # "fail" this check exists to catch.
+                    checked += 1
+                    force_push_allowed += 1
+                    continue
+                # 403/429 (no access / rate-limited) -- force-push status genuinely
+                # can't be evaluated, so exclude the repo from the denominator rather
+                # than counting it as compliant.
+                unknown += 1
+                continue
             except httpx.HTTPError:
-                # Unprotected (404), rate-limited/no-access (403/429), or a network
-                # error — force-push status can't be evaluated, so exclude the repo
-                # from the denominator rather than counting it as compliant.
+                # Network error -- same reasoning as the 403/429 case above.
                 unknown += 1
                 continue
             checked += 1

--- a/packages/checks/tests/test_github_checks.py
+++ b/packages/checks/tests/test_github_checks.py
@@ -7,6 +7,7 @@ import pytest
 
 from checks.github_checks import (
     _MAX_PAGES,
+    _MAX_RETRY_AFTER_SECONDS,
     BranchProtectionEnabled,
     CodeScanningCheck,
     DefaultBranchNoForcePushCheck,
@@ -60,6 +61,26 @@ def test_branch_protection_rate_limit_counts_as_unknown():
         result = check.run(owner="acme", token="tok", repos=repos)
     assert result["status"] == "error"
     assert result["value"]["unknown"] == 1
+
+
+def test_branch_protection_5xx_counts_as_unknown_not_unprotected():
+    # Regression test for #245: _branch_protection_status previously fell through to
+    # "unprotected" for any status code that wasn't 404/403/429 (e.g. a transient
+    # 500/502), which could flip an org's whole branch-protection check to "fail" even
+    # though every real repo was protected.
+    check = BranchProtectionEnabled()
+    repos = [{"name": "demo", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(500, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("server error", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+    assert result["value"]["unknown"] == 1
+    assert result["value"]["protected"] == 0
 
 
 def test_branch_protection_network_error_counts_as_unknown():
@@ -118,6 +139,47 @@ def test_get_retries_on_secondary_rate_limit_403_then_succeeds():
     with patch("time.sleep"), patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
         result = _get("https://x/y", "tok")
     assert result == {"login": "acme"}
+
+
+def test_get_retries_on_5xx_then_succeeds():
+    # Regression test for #245: a 5xx was previously returned as-is with no retry,
+    # immediately raised via raise_for_status -- presumed transient (GitHub-side issue),
+    # same as every other GitHub-talking client in this codebase.
+    request = httpx.Request("GET", "https://x/y")
+    server_error = httpx.Response(502, request=request)
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([server_error, ok_response])
+
+    with patch("time.sleep"), patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        result = _get("https://x/y", "tok")
+    assert result == {"login": "acme"}
+
+
+def test_get_honors_the_actual_retry_after_value_not_a_blind_backoff():
+    # Regression test for #245: the retry loop detected Retry-After's *presence* but
+    # ignored its value, always sleeping a fixed 2**attempt. If GitHub asks for a 60s
+    # backoff, blindly sleeping 1s/2s just burns the fixed attempt budget hitting the
+    # same limit again.
+    request = httpx.Request("GET", "https://x/y")
+    rate_limited = httpx.Response(429, headers={"Retry-After": "5"}, request=request)
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([rate_limited, ok_response])
+
+    with patch("time.sleep") as mock_sleep, patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        result = _get("https://x/y", "tok")
+    assert result == {"login": "acme"}
+    mock_sleep.assert_called_once_with(5.0)
+
+
+def test_get_caps_an_excessive_retry_after_value():
+    request = httpx.Request("GET", "https://x/y")
+    rate_limited = httpx.Response(429, headers={"Retry-After": "600"}, request=request)
+    ok_response = httpx.Response(200, json={"login": "acme"}, request=request)
+    responses = iter([rate_limited, ok_response])
+
+    with patch("time.sleep") as mock_sleep, patch("httpx.Client.get", side_effect=lambda url, headers: next(responses)):
+        _get("https://x/y", "tok")
+    mock_sleep.assert_called_once_with(_MAX_RETRY_AFTER_SECONDS)
 
 
 def test_get_does_not_retry_a_plain_permission_denied_403():
@@ -260,9 +322,11 @@ def test_dependabot_all_repos_forbidden_returns_error_not_false_pass():
     assert result["status"] == "error"
 
 
-def test_dependabot_mixed_403_and_clean_repos_still_passes():
-    # Only some repos are forbidden -- the rest were genuinely evaluated as clear,
-    # so this should NOT be forced to "error".
+def test_dependabot_mixed_403_and_otherwise_clean_repos_reports_error_not_false_pass():
+    # Regression test for #245: 403 means unknown, not zero. A clean result from only
+    # the *reachable* repos must not be reported as "pass" while some repos' real alert
+    # counts are still unknown -- e.g. a fine-grained PAT missing the security-events
+    # scope for a subset of repos, with real critical/high alerts hiding on those.
     check = DependabotAlertsCheck()
     repos = [{"name": "forbidden"}, {"name": "clean"}]
 
@@ -275,7 +339,25 @@ def test_dependabot_mixed_403_and_clean_repos_still_passes():
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("checks.github_checks._get", fake_get)
         result = check.run(owner="acme", token="tok", repos=repos)
-    assert result["status"] == "pass"
+    assert result["status"] == "error"
+
+
+def test_dependabot_mixed_403_and_a_real_alert_still_fails():
+    # A "fail" from the repos we could actually see stays valid regardless of unknowns
+    # elsewhere -- only the false-clean ("pass") case needs downgrading to "error".
+    check = DependabotAlertsCheck()
+    repos = [{"name": "forbidden"}, {"name": "vulnerable"}]
+
+    def fake_get(url, token):
+        if "/forbidden/" in url:
+            response = httpx.Response(403, request=httpx.Request("GET", url))
+            raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+        return [{"security_advisory": {"severity": "critical"}}]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
 
 
 def test_dependabot_non_404_403_error_propagates():
@@ -347,6 +429,41 @@ def test_code_scanning_all_repos_forbidden_returns_error_not_false_pass():
     assert result["status"] == "error"
 
 
+def test_code_scanning_mixed_403_and_otherwise_clean_repos_reports_error_not_false_pass():
+    # Regression test for #245: same reasoning as the Dependabot equivalent -- 403 means
+    # unknown, not zero, so a clean result from the reachable repos alone must not be
+    # reported as "pass" while some repos' real alert status is still unknown.
+    check = CodeScanningCheck()
+    repos = [{"name": "forbidden"}, {"name": "clean"}]
+
+    def fake_get(url, token):
+        if "/forbidden/" in url:
+            response = httpx.Response(403, request=httpx.Request("GET", url))
+            raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+        return []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "error"
+
+
+def test_code_scanning_mixed_403_and_a_real_alert_still_fails():
+    check = CodeScanningCheck()
+    repos = [{"name": "forbidden"}, {"name": "vulnerable"}]
+
+    def fake_get(url, token):
+        if "/forbidden/" in url:
+            response = httpx.Response(403, request=httpx.Request("GET", url))
+            raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
+        return [{"number": 1}]
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
+
+
 # ── DefaultBranchNoForcePushCheck ────────────────────────────────────────────
 
 
@@ -385,13 +502,36 @@ def test_force_push_fails_when_allowed():
     assert result["value"] == {"repos_checked": 1, "force_push_allowed": 1}
 
 
-def test_force_push_unprotected_branch_excluded_from_denominator():
+def test_force_push_unprotected_branch_404_means_force_push_is_allowed():
+    # Regression test for #245: a 404 from the branches endpoint means the default
+    # branch has NO protection at all -- force pushes are unambiguously allowed, not
+    # merely "unknown". Previously this was excluded from the denominator entirely, so
+    # an org where every repo's default branch was completely unprotected (the exact
+    # worst case this check exists to catch) reported checked == 0 -> "error", never
+    # the "fail" it should.
     check = DefaultBranchNoForcePushCheck()
     repos = [{"name": "api", "default_branch": "main"}]
 
     def fake_get(url, token):
         response = httpx.Response(404, request=httpx.Request("GET", url))
         raise httpx.HTTPStatusError("not found", request=response.request, response=response)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("checks.github_checks._get", fake_get)
+        result = check.run(owner="acme", token="tok", repos=repos)
+    assert result["status"] == "fail"
+    assert result["value"] == {"repos_checked": 1, "force_push_allowed": 1}
+
+
+def test_force_push_rate_limited_branch_excluded_from_denominator():
+    # A 403/429 genuinely can't be evaluated -- distinct from the 404 case above, this
+    # must still be excluded from the denominator rather than counted either way.
+    check = DefaultBranchNoForcePushCheck()
+    repos = [{"name": "api", "default_branch": "main"}]
+
+    def fake_get(url, token):
+        response = httpx.Response(403, request=httpx.Request("GET", url))
+        raise httpx.HTTPStatusError("forbidden", request=response.request, response=response)
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("checks.github_checks._get", fake_get)


### PR DESCRIPTION
## Summary

Closes #245.

Five related bugs in `packages/checks/src/checks/github_checks.py`, all stemming from how the retry loop and per-check exception handlers treat non-2xx responses. Every real-world effect is the same shape: transient GitHub-side hiccups (5xx, rate limits) got reported as real security failures, and partial access-scope problems got reported as "all clear" -- the opposite of what each check's own existing comments say it's trying to guarantee.

## What changed

1. **`DefaultBranchNoForcePushCheck`** -- a 404 from `/repos/{owner}/{repo}/branches/{branch}` means the default branch has **no protection at all**, so force pushes are unambiguously allowed -- not "unknown". It was bucketed with the genuine unknowns (403/429/network), so an org where every repo's default branch was completely unprotected (the exact worst case this check exists to catch) reported `checked == 0` -> `"error"`, never `"fail"`. Now a 404 counts toward `checked` **and** `force_push_allowed`; 403/429/network errors still correctly stay excluded from the denominator.

2. **`_branch_protection_status`** -- fell through to `"unprotected"` for any status code that wasn't 404/403/429 (a transient 500/502, most notably). A flaky GitHub 5xx during a scan could flip an org's entire branch-protection check to `"fail"` even though every real repo was protected. Now anything but 404 maps to `"unknown"`.

3. **`DependabotAlertsCheck` / `CodeScanningCheck`** -- only escalated to `"error"` when *every* repo 403'd. If 9 of 10 repos are forbidden (e.g. a fine-grained PAT missing a scope) and 1 is clean, the check reported `"pass"` based solely on the one reachable repo -- contradicting the code's own comment ("403 means unknown, not zero, so it must not silently count toward clear"). Now a would-be `"pass"` is downgraded to `"error"` whenever any repo was forbidden; a `"fail"` from real findings on the reachable repos stays valid regardless of unknowns elsewhere (a real problem doesn't need corroboration from the inaccessible repos to be real).

4. **`_get_with_retry`** -- only retried on `httpx.RequestError`, a `429`, or a rate-limit-flavored `403`. A `500/502/503` was returned as-is and `_get()` immediately raised via `raise_for_status()` -- no retry, directly feeding bug #2 above. Now retries a 5xx too, presumed transient same as every other GitHub-talking client in this codebase (`apps/api/src/services/github_client.py`).

5. **Retry-After handling** -- the loop detected the header's *presence* but never read its value, always sleeping a fixed `2**attempt` (1s, then 2s). If GitHub asks for a 60s backoff, the loop burned its 3 attempts hitting the same limit again instead of eventually succeeding. Now honors the actual value (capped at 60s as a defensive ceiling against a malformed/huge value) when present, falling back to exponential backoff otherwise.

## A parallel issue not fixed here

`apps/api/src/services/github_client.py` has the same `_is_secondary_rate_limit`/retry-loop pattern (doesn't retry 5xx, ignores Retry-After's value either) -- out of scope for #245, which only covers `packages/checks`, so left untouched here. Worth a separate follow-up if desired.

## What changed in tests

- Replaced `test_dependabot_mixed_403_and_clean_repos_still_passes` and added a `CodeScanningCheck` equivalent -- both directly asserted the old buggy behavior (mixed 403 + otherwise-clean -> `"pass"`). Now split into two tests each: the false-clean case (now `"error"`) and a real-alert-plus-403 case (stays `"fail"`).
- Replaced `test_force_push_unprotected_branch_excluded_from_denominator` (asserted the old bug: 404 -> excluded, `checked == 0`) with `test_force_push_unprotected_branch_404_means_force_push_is_allowed` (404 -> `checked=1, force_push_allowed=1, status="fail"`), plus a new test for the still-correctly-excluded 403/429 case.
- Added `test_branch_protection_5xx_counts_as_unknown_not_unprotected`, `test_get_retries_on_5xx_then_succeeds`, `test_get_honors_the_actual_retry_after_value_not_a_blind_backoff`, `test_get_caps_an_excessive_retry_after_value`.

No RBAC/auth/token-encryption/migration changes -- this is a `packages/checks` library fix only, consumed by `apps/api`'s analytics/security-matrix routes via the editable install; ran the affected `apps/api` test files as a regression check (all pass, none assert on internals this touches).

## Test plan
- [x] `pytest packages/checks/tests/ -v` -- all 43 tests pass (8 new/replaced)
- [x] `pytest apps/api/tests/test_analytics_scoring.py apps/api/tests/test_repos.py apps/api/tests/test_security_matrix.py -q` -- all 40 pass, no regressions
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub API retry handling, including support for server errors and capped retry delays.
  * Prevented unexpected API errors from being incorrectly reported as compliant branch protection.
  * Marked security checks as errors when repository results are incomplete due to access restrictions or rate limits.
  * Correctly evaluates unprotected default branches as allowing force pushes while excluding unavailable, rate-limited results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->