### PR TITLE
feat(ui): hide GitHub token field when App installation covers owner

### DIFF
--- a/apps/ui/app/automation/page.tsx
+++ b/apps/ui/app/automation/page.tsx
@@ -48,12 +48,28 @@ export default function AutomationPage() {
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
-  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
+  // list() above only covers the caller's *personal* installations -- an org's App
+  // installation requires the separate org-scoped endpoint. Errors (403/404, e.g. the
+  // org isn't a recognized Clevis org yet) are treated as "not installed" rather than
+  // surfaced, matching this query's only purpose here (a soft signal to hide the token
+  // field, not something the user needs an error for).
+  const orgInstallsQuery = useQuery<InstallationMeta[]>({
+    queryKey: ["installations.org", owner.trim()],
+    queryFn: () => api.installations.listForOrg(owner.trim()),
+    enabled: owner.trim().length > 0,
+    retry: false,
+  })
+  const hasInstallationForOwner =
+    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
     onSuccess: (data, org) => {
-      if (shouldApplyResolvedToken(org, owner)) {
+      // Skip applying a legacy saved token once an installation covers this owner --
+      // otherwise it'd be silently used (the token field, and its "saved" indicator,
+      // are hidden in that case) and could override the installation-token path the
+      // hidden field implies is now authoritative.
+      if (shouldApplyResolvedToken(org, owner) && !hasInstallationForOwner) {
         setToken(data.token)
         setTokenSaved(true)
       }

--- a/apps/ui/app/automation/page.tsx
+++ b/apps/ui/app/automation/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -13,7 +13,7 @@ import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
-import type { RunSummary, WorkflowSummary } from "@/lib/api/types"
+import type { InstallationMeta, RunSummary, WorkflowSummary } from "@/lib/api/types"
 
 function runDurationSeconds(run: RunSummary): number | null {
   return run.duration_ms == null ? null : Math.round(run.duration_ms / 1000)
@@ -43,6 +43,12 @@ export default function AutomationPage() {
   useEffect(() => {
     if (scopeLogin) setOwner(scopeLogin)
   }, [scopeLogin])
+
+  const { data: installs = [] } = useQuery<InstallationMeta[]>({
+    queryKey: ["installations"],
+    queryFn: () => api.installations.list(),
+  })
+  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
@@ -135,26 +141,28 @@ export default function AutomationPage() {
                 onKeyDown={(e) => e.key === "Enter" && owner.trim() && repo.trim() && !isLoading && loadMutation.mutate()}
               />
             </div>
-            <div>
-              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
-                GitHub Token
-                <span className="text-[0.6875rem] text-muted-foreground font-normal">
-                  optional if the GitHub App is connected for this org
-                </span>
-                {tokenSaved && (
-                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
-                    <Key className="size-3" />saved
+            {!hasInstallationForOwner && (
+              <div>
+                <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                  GitHub Token
+                  <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                    optional if the GitHub App is connected for this org
                   </span>
-                )}
-              </label>
-              <Input
-                placeholder="ghp_... (leave blank to use the connected GitHub App)"
-                type="password"
-                value={token}
-                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
-                className="font-mono"
-              />
-            </div>
+                  {tokenSaved && (
+                    <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                      <Key className="size-3" />saved
+                    </span>
+                  )}
+                </label>
+                <Input
+                  placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                  type="password"
+                  value={token}
+                  onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
+                  className="font-mono"
+                />
+              </div>
+            )}
             {!tokenSaved && token && owner && (
               <Button variant="outline" onClick={() => saveTokenMutation.mutate()} disabled={saveTokenMutation.isPending}>
                 <Key className="size-3.5" />

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -187,12 +187,28 @@ export default function ReposPage() {
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
-  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
+  // list() above only covers the caller's *personal* installations -- an org's App
+  // installation requires the separate org-scoped endpoint. Errors (403/404, e.g. the
+  // org isn't a recognized Clevis org yet) are treated as "not installed" rather than
+  // surfaced, matching this query's only purpose here (a soft signal to hide the token
+  // field, not something the user needs an error for).
+  const orgInstallsQuery = useQuery<InstallationMeta[]>({
+    queryKey: ["installations.org", owner.trim()],
+    queryFn: () => api.installations.listForOrg(owner.trim()),
+    enabled: owner.trim().length > 0,
+    retry: false,
+  })
+  const hasInstallationForOwner =
+    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
     onSuccess: (data, org) => {
-      if (shouldApplyResolvedToken(org, owner)) {
+      // Skip applying a legacy saved token once an installation covers this owner --
+      // otherwise it'd be silently used (the token field, and its "saved" indicator,
+      // are hidden in that case) and could override the installation-token path the
+      // hidden field implies is now authoritative.
+      if (shouldApplyResolvedToken(org, owner) && !hasInstallationForOwner) {
         setToken(data.token)
         setTokenSaved(true)
       }

--- a/apps/ui/app/repos/page.tsx
+++ b/apps/ui/app/repos/page.tsx
@@ -14,7 +14,7 @@ import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { MiniSparkline } from "@/components/charts/mini-sparkline"
 import { relativeTime } from "@/lib/format"
 import { useInView } from "@/lib/use-in-view"
-import type { RepoSummary } from "@/lib/api/types"
+import type { InstallationMeta, RepoSummary } from "@/lib/api/types"
 
 type SortKey = "pushed" | "stars" | "name"
 
@@ -183,6 +183,12 @@ export default function ReposPage() {
     setOwner(scopeOrgLogin)
   }, [scopeOrgLogin])
 
+  const { data: installs = [] } = useQuery<InstallationMeta[]>({
+    queryKey: ["installations"],
+    queryFn: () => api.installations.list(),
+  })
+  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
+
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
     onSuccess: (data, org) => {
@@ -259,6 +265,7 @@ export default function ReposPage() {
                 onKeyDown={(e) => e.key === "Enter" && owner.trim() && !listMutation.isPending && loadRepos()}
               />
             </div>
+            {!hasInstallationForOwner && (
             <div>
               <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
                 GitHub Token
@@ -280,6 +287,7 @@ export default function ReposPage() {
                 onKeyDown={(e) => e.key === "Enter" && owner.trim() && !listMutation.isPending && loadRepos()}
               />
             </div>
+            )}
             <Button
               onClick={loadRepos}
               disabled={listMutation.isPending || !owner.trim()}

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -17,7 +17,7 @@ import { AreaTimeChart } from "@/components/charts/area-time-chart"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { relativeTime } from "@/lib/format"
-import type { CheckResult } from "@/lib/api/types"
+import type { CheckResult, InstallationMeta } from "@/lib/api/types"
 
 const TABS = [
   { id: "all", label: "All" },
@@ -101,6 +101,12 @@ export default function SecurityPage() {
   useEffect(() => {
     setOwner(scopeOrgLogin)
   }, [scopeOrgLogin])
+
+  const { data: installs = [] } = useQuery<InstallationMeta[]>({
+    queryKey: ["installations"],
+    queryFn: () => api.installations.list(),
+  })
+  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
@@ -222,27 +228,29 @@ export default function SecurityPage() {
                 onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && runScan()}
               />
             </div>
-            <div>
-              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
-                GitHub Token
-                <span className="text-[0.6875rem] text-muted-foreground font-normal">
-                  optional if the GitHub App is connected for this org
-                </span>
-                {tokenSaved && (
-                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
-                    <Key className="size-3" />saved
+            {!hasInstallationForOwner && (
+              <div>
+                <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                  GitHub Token
+                  <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                    optional if the GitHub App is connected for this org
                   </span>
-                )}
-              </label>
-              <Input
-                placeholder="ghp_... (leave blank to use the connected GitHub App)"
-                type="password"
-                value={token}
-                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
-                className="font-mono"
-                onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && runScan()}
-              />
-            </div>
+                  {tokenSaved && (
+                    <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                      <Key className="size-3" />saved
+                    </span>
+                  )}
+                </label>
+                <Input
+                  placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                  type="password"
+                  value={token}
+                  onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
+                  className="font-mono"
+                  onKeyDown={(e) => e.key === "Enter" && owner && !scan.isPending && runScan()}
+                />
+              </div>
+            )}
             <Button
               onClick={() => runScan()}
               disabled={scan.isPending || !owner}

--- a/apps/ui/app/security/page.tsx
+++ b/apps/ui/app/security/page.tsx
@@ -106,12 +106,28 @@ export default function SecurityPage() {
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
-  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
+  // list() above only covers the caller's *personal* installations -- an org's App
+  // installation requires the separate org-scoped endpoint. Errors (403/404, e.g. the
+  // org isn't a recognized Clevis org yet) are treated as "not installed" rather than
+  // surfaced, matching this query's only purpose here (a soft signal to hide the token
+  // field, not something the user needs an error for).
+  const orgInstallsQuery = useQuery<InstallationMeta[]>({
+    queryKey: ["installations.org", owner.trim()],
+    queryFn: () => api.installations.listForOrg(owner.trim()),
+    enabled: owner.trim().length > 0,
+    retry: false,
+  })
+  const hasInstallationForOwner =
+    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
     onSuccess: (data, org) => {
-      if (shouldApplyResolvedToken(org, owner)) {
+      // Skip applying a legacy saved token once an installation covers this owner --
+      // otherwise it'd be silently used (the token field, and its "saved" indicator,
+      // are hidden in that case) and could override the installation-token path the
+      // hidden field implies is now authoritative.
+      if (shouldApplyResolvedToken(org, owner) && !hasInstallationForOwner) {
         setToken(data.token)
         setTokenSaved(true)
       }

--- a/apps/ui/components/repo/cache-panel.tsx
+++ b/apps/ui/components/repo/cache-panel.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import Link from "next/link"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -12,7 +12,7 @@ import { shouldApplyResolvedToken } from "@/lib/token-resolve"
 import { BarGroupChart } from "@/components/charts/bar-group-chart"
 import { CHART_COLORS } from "@/lib/charts/theme"
 import { formatBytes, relativeTime, classifyStaleness, stalenessColor } from "@/lib/format"
-import type { CacheEntry } from "@/lib/api/types"
+import type { CacheEntry, InstallationMeta } from "@/lib/api/types"
 
 interface CachePanelProps {
   owner: string
@@ -32,6 +32,12 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
   const [tokenSaved, setTokenSaved] = useState(false)
   const [actor, setActor] = useState("")
   const [clearArmed, setClearArmed] = useState(false)
+
+  const { data: installs = [] } = useQuery<InstallationMeta[]>({
+    queryKey: ["installations"],
+    queryFn: () => api.installations.list(),
+  })
+  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
 
   // Auto-resolve saved token for this owner
   const resolveMutation = useMutation({
@@ -123,26 +129,28 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
           <span className="section-label">Configuration</span>
         </div>
         <div className="p-4 flex flex-col gap-3">
-          <div>
-            <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
-              GitHub Token
-              <span className="text-[0.6875rem] text-muted-foreground font-normal">
-                optional if the GitHub App is connected for this org
-              </span>
-              {tokenSaved && (
-                <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
-                  <Key className="size-3" />saved
+          {!hasInstallationForOwner && (
+            <div>
+              <label className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                GitHub Token
+                <span className="text-[0.6875rem] text-muted-foreground font-normal">
+                  optional if the GitHub App is connected for this org
                 </span>
-              )}
-            </label>
-            <Input
-              placeholder="ghp_... (leave blank to use the connected GitHub App)"
-              type="password"
-              value={token}
-              onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
-              className="font-mono"
-            />
-          </div>
+                {tokenSaved && (
+                  <span className="inline-flex items-center gap-1 text-[0.6875rem] text-primary">
+                    <Key className="size-3" />saved
+                  </span>
+                )}
+              </label>
+              <Input
+                placeholder="ghp_... (leave blank to use the connected GitHub App)"
+                type="password"
+                value={token}
+                onChange={(e) => { setToken(e.target.value); setTokenSaved(false) }}
+                className="font-mono"
+              />
+            </div>
+          )}
           {!tokenSaved && token && (
             <Button
               variant="outline"

--- a/apps/ui/components/repo/cache-panel.tsx
+++ b/apps/ui/components/repo/cache-panel.tsx
@@ -37,13 +37,29 @@ export function CachePanel({ owner, repo, active = true }: CachePanelProps) {
     queryKey: ["installations"],
     queryFn: () => api.installations.list(),
   })
-  const hasInstallationForOwner = installs.some((i) => i.account_login === owner)
+  // list() above only covers the caller's *personal* installations -- an org's App
+  // installation requires the separate org-scoped endpoint. Errors (403/404, e.g. the
+  // org isn't a recognized Clevis org yet) are treated as "not installed" rather than
+  // surfaced, matching this query's only purpose here (a soft signal to hide the token
+  // field, not something the user needs an error for).
+  const orgInstallsQuery = useQuery<InstallationMeta[]>({
+    queryKey: ["installations.org", owner],
+    queryFn: () => api.installations.listForOrg(owner),
+    enabled: !!owner,
+    retry: false,
+  })
+  const hasInstallationForOwner =
+    installs.some((i) => i.account_login === owner) || (orgInstallsQuery.data?.length ?? 0) > 0
 
   // Auto-resolve saved token for this owner
   const resolveMutation = useMutation({
     mutationFn: (org: string) => api.tokens.resolve(org),
     onSuccess: (data, org) => {
-      if (shouldApplyResolvedToken(org, owner)) {
+      // Skip applying a legacy saved token once an installation covers this owner --
+      // otherwise it'd be silently used (the token field, and its "saved" indicator,
+      // are hidden in that case) and could override the installation-token path the
+      // hidden field implies is now authoritative.
+      if (shouldApplyResolvedToken(org, owner) && !hasInstallationForOwner) {
         setToken(data.token)
         setTokenSaved(true)
       }

--- a/apps/ui/lib/api/client.ts
+++ b/apps/ui/lib/api/client.ts
@@ -312,6 +312,12 @@ export const api = {
   },
   installations: {
     list: () => get<InstallationMeta[]>("/me/installations"),
+    // Org-connected installations, not personal ones -- list() above only ever returns
+    // the caller's personal (User-type) installations (GET /me/installations), never an
+    // org's. Requires the caller to already be a recognized Clevis org member (404 if the
+    // org isn't connected yet, 403 if not a member) -- callers should treat either as
+    // "not installed" rather than surfacing the error.
+    listForOrg: (orgLogin: string) => get<InstallationMeta[]>(`/orgs/${encodeURIComponent(orgLogin)}/installations`),
     lookup: (installationId: number) =>
       get<InstallationLookup>(`/me/installations/lookup/${installationId}`),
     sync: (

--- a/apps/ui/tests/components/automation-page.test.tsx
+++ b/apps/ui/tests/components/automation-page.test.tsx
@@ -6,6 +6,7 @@ const tokensResolveMock = vi.fn();
 const workflowsMock = vi.fn();
 const runsMock = vi.fn();
 const dispatchMock = vi.fn();
+const installationsListMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
@@ -17,6 +18,9 @@ vi.mock("@/lib/api/client", () => ({
       workflows: (...args: unknown[]) => workflowsMock(...args),
       runs: (...args: unknown[]) => runsMock(...args),
       dispatch: (...args: unknown[]) => dispatchMock(...args),
+    },
+    installations: {
+      list: (...args: unknown[]) => installationsListMock(...args),
     },
   },
 }));
@@ -40,6 +44,8 @@ describe("AutomationPage", () => {
     workflowsMock.mockReset();
     runsMock.mockReset();
     dispatchMock.mockReset();
+    installationsListMock.mockReset();
+    installationsListMock.mockResolvedValue([]);
     localStorage.clear();
   });
 
@@ -52,6 +58,26 @@ describe("AutomationPage", () => {
     renderPage();
     expect(screen.queryByText("Workflows")).not.toBeInTheDocument();
     expect(workflowsMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the GitHub Token field when no installation covers the entered owner", async () => {
+    installationsListMock.mockResolvedValue([]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.getByText("GitHub Token")).toBeInTheDocument();
+    });
+  });
+
+  it("hides the GitHub Token field when an installation covers the entered owner", async () => {
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
   });
 
   it("loads workflows and run history for the entered owner/repo", async () => {

--- a/apps/ui/tests/components/automation-page.test.tsx
+++ b/apps/ui/tests/components/automation-page.test.tsx
@@ -7,6 +7,7 @@ const workflowsMock = vi.fn();
 const runsMock = vi.fn();
 const dispatchMock = vi.fn();
 const installationsListMock = vi.fn();
+const installationsListForOrgMock = vi.fn();
 
 vi.mock("@/lib/api/client", () => ({
   api: {
@@ -21,6 +22,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     installations: {
       list: (...args: unknown[]) => installationsListMock(...args),
+      listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
     },
   },
 }));
@@ -46,6 +48,8 @@ describe("AutomationPage", () => {
     dispatchMock.mockReset();
     installationsListMock.mockReset();
     installationsListMock.mockResolvedValue([]);
+    installationsListForOrgMock.mockReset();
+    installationsListForOrgMock.mockResolvedValue([]);
     localStorage.clear();
   });
 
@@ -69,7 +73,7 @@ describe("AutomationPage", () => {
     });
   });
 
-  it("hides the GitHub Token field when an installation covers the entered owner", async () => {
+  it("hides the GitHub Token field when a personal installation covers the entered owner", async () => {
     installationsListMock.mockResolvedValue([
       { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
     ]);
@@ -77,6 +81,30 @@ describe("AutomationPage", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
     await waitFor(() => {
       expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the GitHub Token field when an org-level installation covers the entered owner", async () => {
+    // Regression test: api.installations.list() only ever returns the caller's *personal*
+    // installations -- an org's App installation must be checked via the separate
+    // org-scoped endpoint, or this would never hide the field for the primary (org) case.
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 99, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("still shows the GitHub Token field when the org-installation lookup errors (e.g. not a recognized org member)", async () => {
+    installationsListForOrgMock.mockRejectedValue(new Error("403"));
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.getByText("GitHub Token")).toBeInTheDocument();
     });
   });
 

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -10,6 +10,7 @@ const reposStatsMock = vi.fn();
 const reposPullsMock = vi.fn();
 const reposSecurityMock = vi.fn();
 const installationsListMock = vi.fn();
+const installationsListForOrgMock = vi.fn();
 
 let currentRepoParam = "acme~demo";
 
@@ -34,6 +35,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     installations: {
       list: (...args: unknown[]) => installationsListMock(...args),
+      listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
     },
   },
 }));
@@ -72,6 +74,8 @@ describe("RepoDetailPage", () => {
     reposSecurityMock.mockReset();
     installationsListMock.mockReset();
     installationsListMock.mockResolvedValue([]);
+    installationsListForOrgMock.mockReset();
+    installationsListForOrgMock.mockResolvedValue([]);
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
     reposStatsMock.mockResolvedValue({
       repository: "acme/demo",
@@ -206,6 +210,36 @@ describe("RepoDetailPage", () => {
 
     await waitFor(() => {
       expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the GitHub Token field on the Actions Cache tab when an org-level installation covers the repo's owner", async () => {
+    // Regression test: api.installations.list() only ever returns the caller's *personal*
+    // installations -- an org's App installation must be checked via the separate
+    // org-scoped endpoint, or this would never hide the field for the primary (org) case.
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 99, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    cacheListMock.mockResolvedValue({ repository: "acme/demo", total: 0, actions_caches: [] });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /actions cache/i }));
+
+    await waitFor(() => {
+      expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("still shows the GitHub Token field on the Actions Cache tab when the org-installation lookup errors (e.g. not a recognized org member)", async () => {
+    installationsListForOrgMock.mockRejectedValue(new Error("403"));
+    cacheListMock.mockResolvedValue({ repository: "acme/demo", total: 0, actions_caches: [] });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /actions cache/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub Token")).toBeInTheDocument();
     });
   });
 

--- a/apps/ui/tests/components/repo-detail-page.test.tsx
+++ b/apps/ui/tests/components/repo-detail-page.test.tsx
@@ -9,6 +9,7 @@ const cacheClearMock = vi.fn();
 const reposStatsMock = vi.fn();
 const reposPullsMock = vi.fn();
 const reposSecurityMock = vi.fn();
+const installationsListMock = vi.fn();
 
 let currentRepoParam = "acme~demo";
 
@@ -30,6 +31,9 @@ vi.mock("@/lib/api/client", () => ({
       stats: (...args: unknown[]) => reposStatsMock(...args),
       pulls: (...args: unknown[]) => reposPullsMock(...args),
       security: (...args: unknown[]) => reposSecurityMock(...args),
+    },
+    installations: {
+      list: (...args: unknown[]) => installationsListMock(...args),
     },
   },
 }));
@@ -66,6 +70,8 @@ describe("RepoDetailPage", () => {
     reposStatsMock.mockReset();
     reposPullsMock.mockReset();
     reposSecurityMock.mockReset();
+    installationsListMock.mockReset();
+    installationsListMock.mockResolvedValue([]);
     tokensResolveMock.mockRejectedValue(new Error("no saved token"));
     reposStatsMock.mockResolvedValue({
       repository: "acme/demo",
@@ -187,6 +193,20 @@ describe("RepoDetailPage", () => {
 
     expect(screen.getByRole("button", { name: /load caches/i })).toBeInTheDocument();
     expect(container.querySelector("#repo-tabpanel-cache")).not.toHaveClass("hidden");
+  });
+
+  it("hides the GitHub Token field on the Actions Cache tab when an installation covers the repo's owner", async () => {
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    cacheListMock.mockResolvedValue({ repository: "acme/demo", total: 0, actions_caches: [] });
+
+    renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: /actions cache/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
   });
 
   it("defers the Actions Cache tab's own token-resolve call until the tab is opened", async () => {

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -8,6 +8,7 @@ const reposListMock = vi.fn();
 const reposStatsMock = vi.fn();
 const reposPullsMock = vi.fn();
 const installationsListMock = vi.fn();
+const installationsListForOrgMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({}),
@@ -26,6 +27,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     installations: {
       list: (...args: unknown[]) => installationsListMock(...args),
+      listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
     },
   },
 }));
@@ -67,6 +69,8 @@ describe("ReposPage", () => {
     reposPullsMock.mockResolvedValue({ repository: "acme/demo", total: 0, pulls: [] });
     installationsListMock.mockReset();
     installationsListMock.mockResolvedValue([]);
+    installationsListForOrgMock.mockReset();
+    installationsListForOrgMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -87,6 +91,30 @@ describe("ReposPage", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
     await waitFor(() => {
       expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the GitHub Token field when an org-level installation covers the entered org", async () => {
+    // Regression test: api.installations.list() only ever returns the caller's *personal*
+    // installations -- an org's App installation must be checked via the separate
+    // org-scoped endpoint, or this would never hide the field for the primary (org) case.
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 99, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("still shows the GitHub Token field when the org-installation lookup errors (e.g. not a recognized org member)", async () => {
+    installationsListForOrgMock.mockRejectedValue(new Error("403"));
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.getByText("GitHub Token")).toBeInTheDocument();
     });
   });
 

--- a/apps/ui/tests/components/repos-page.test.tsx
+++ b/apps/ui/tests/components/repos-page.test.tsx
@@ -7,6 +7,7 @@ const tokensUpsertMock = vi.fn();
 const reposListMock = vi.fn();
 const reposStatsMock = vi.fn();
 const reposPullsMock = vi.fn();
+const installationsListMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({}),
@@ -22,6 +23,9 @@ vi.mock("@/lib/api/client", () => ({
       list: (...args: unknown[]) => reposListMock(...args),
       stats: (...args: unknown[]) => reposStatsMock(...args),
       pulls: (...args: unknown[]) => reposPullsMock(...args),
+    },
+    installations: {
+      list: (...args: unknown[]) => installationsListMock(...args),
     },
   },
 }));
@@ -61,6 +65,8 @@ describe("ReposPage", () => {
       latest_release: null,
     });
     reposPullsMock.mockResolvedValue({ repository: "acme/demo", total: 0, pulls: [] });
+    installationsListMock.mockReset();
+    installationsListMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -71,6 +77,17 @@ describe("ReposPage", () => {
   it("keeps Load repositories disabled until an org is entered", () => {
     renderPage();
     expect(screen.getByRole("button", { name: /load repositories/i })).toBeDisabled();
+  });
+
+  it("hides the GitHub Token field when an installation covers the entered org", async () => {
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
   });
 
   it("keeps Load repositories disabled for a whitespace-only organization", () => {

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -10,6 +10,7 @@ const analyticsHistoryMock = vi.fn();
 const securityMatrixMock = vi.fn();
 const secretScanningMock = vi.fn();
 const installationsListMock = vi.fn();
+const installationsListForOrgMock = vi.fn();
 
 // A minimal reactive store standing in for Next's router-driven searchParams so a
 // tab click's router.replace(...) actually triggers a re-render in the test, the
@@ -49,6 +50,7 @@ vi.mock("@/lib/api/client", () => ({
     },
     installations: {
       list: (...args: unknown[]) => installationsListMock(...args),
+      listForOrg: (...args: unknown[]) => installationsListForOrgMock(...args),
     },
   },
 }));
@@ -85,6 +87,8 @@ describe("SecurityPage", () => {
     secretScanningMock.mockResolvedValue({ repository: "acme/demo", alerts: [] });
     installationsListMock.mockReset();
     installationsListMock.mockResolvedValue([]);
+    installationsListForOrgMock.mockReset();
+    installationsListForOrgMock.mockResolvedValue([]);
     mockSearchParams = new URLSearchParams();
     localStorage.clear();
   });
@@ -102,6 +106,30 @@ describe("SecurityPage", () => {
     fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
     await waitFor(() => {
       expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the GitHub Token field when an org-level installation covers the entered org", async () => {
+    // Regression test: api.installations.list() only ever returns the caller's *personal*
+    // installations -- an org's App installation must be checked via the separate
+    // org-scoped endpoint, or this would never hide the field for the primary (org) case.
+    installationsListForOrgMock.mockResolvedValue([
+      { id: 2, account_login: "acme", account_type: "Organization", installation_id: 99, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(installationsListForOrgMock).toHaveBeenCalledWith("acme");
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
+  });
+
+  it("still shows the GitHub Token field when the org-installation lookup errors (e.g. not a recognized org member)", async () => {
+    installationsListForOrgMock.mockRejectedValue(new Error("403"));
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.getByText("GitHub Token")).toBeInTheDocument();
     });
   });
 

--- a/apps/ui/tests/components/security-page.test.tsx
+++ b/apps/ui/tests/components/security-page.test.tsx
@@ -9,6 +9,7 @@ const analyticsOverviewMock = vi.fn();
 const analyticsHistoryMock = vi.fn();
 const securityMatrixMock = vi.fn();
 const secretScanningMock = vi.fn();
+const installationsListMock = vi.fn();
 
 // A minimal reactive store standing in for Next's router-driven searchParams so a
 // tab click's router.replace(...) actually triggers a re-render in the test, the
@@ -46,6 +47,9 @@ vi.mock("@/lib/api/client", () => ({
       matrix: (...args: unknown[]) => securityMatrixMock(...args),
       secretScanning: (...args: unknown[]) => secretScanningMock(...args),
     },
+    installations: {
+      list: (...args: unknown[]) => installationsListMock(...args),
+    },
   },
 }));
 
@@ -79,6 +83,8 @@ describe("SecurityPage", () => {
       summary: { fully_compliant_count: 0, critical_risk_count: 0, secret_hits_count: 0, vuln_by_severity: { critical: 0, high: 0, medium: 0, low: 0 } },
     });
     secretScanningMock.mockResolvedValue({ repository: "acme/demo", alerts: [] });
+    installationsListMock.mockReset();
+    installationsListMock.mockResolvedValue([]);
     mockSearchParams = new URLSearchParams();
     localStorage.clear();
   });
@@ -86,6 +92,17 @@ describe("SecurityPage", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("hides the GitHub Token field when an installation covers the entered org", async () => {
+    installationsListMock.mockResolvedValue([
+      { id: 1, account_login: "acme", account_type: "Organization", installation_id: 42, created_at: "2026-07-20T00:00:00Z" },
+    ]);
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("e.g. octocat"), { target: { value: "acme" } });
+    await waitFor(() => {
+      expect(screen.queryByText("GitHub Token")).not.toBeInTheDocument();
+    });
   });
 
   it("allows running a scan with no token entered (GitHub App fallback)", async () => {


### PR DESCRIPTION
## Summary

Fixes #276. The hint "optional if the GitHub App is connected for this org" was shown alongside a token input on 4 pages regardless of whether an installation actually covers the org/account in view:

- `apps/ui/app/automation/page.tsx`
- `apps/ui/app/repos/page.tsx`
- `apps/ui/app/security/page.tsx`
- `apps/ui/components/repo/cache-panel.tsx`

None of these checked installation state. `api.installations.list()` already exists and is used for this purpose elsewhere (`apps/ui/components/app-sidebar.tsx`, `apps/ui/app/settings/page.tsx`).

## Change

Per the confirmed product decision in the issue: when an installation covers the currently active scope, hide the token field entirely rather than just leaving it visible with a hint.

- Wired the existing `["installations"]` query into all 4 sites (React Query dedupes by key, so this doesn't introduce a duplicate fetch — it reuses whatever `app-sidebar.tsx`/`settings/page.tsx` already fetched).
- Each page compares its own resolved `owner` state (not necessarily the sidebar's active scope — the user can overtype it on automation/repos/security) against `installs.some(i => i.account_login === owner)`.
- `cache-panel.tsx` gets `owner`/`repo` as props rather than from `useActiveScope`, so it wires the same query directly.

## Test plan
- [x] `bun run check` (typecheck + lint + build) — passes
- [x] Added `installations.list` mocks to all 4 affected test files (`automation-page.test.tsx`, `repos-page.test.tsx`, `security-page.test.tsx`, `repo-detail-page.test.tsx`) — **none of them previously mocked this endpoint**, so `api.installations.list()` was silently failing/falling back to an empty array in every existing test run, masking the untested code path entirely.
- [x] Added a regression test per page verifying the token field is hidden when an installation covers the entered owner, and (for automation) that it's still shown when none does.
- [x] `bun run test` — all 4 affected test files pass (72 tests)

No backend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - “GitHub Token” inputs are now hidden when a GitHub App installation exists for the chosen owner, using both personal and org-scoped installation lookups.
  - Updated automation, repos, security, and actions cache views to reflect installation status.

- **Bug Fixes**
  - Token auto-resolution no longer applies resolved legacy/saved tokens when an installation already exists for the current owner.

- **Tests**
  - Added/extended UI tests to verify token visibility across installation present/absent and org-lookup error scenarios.

- **Chores**
  - Added an org-scoped installations API method (`listForOrg`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->