### PR TITLE
feat(ui): implement the Pull Requests page as an org-wide PR aggregate

### DIFF
--- a/apps/ui/app/pulls/layout.tsx
+++ b/apps/ui/app/pulls/layout.tsx
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic"
+export const metadata = { title: "Pull Requests · clevis" }
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/ui/app/pulls/page.tsx
+++ b/apps/ui/app/pulls/page.tsx
@@ -1,13 +1,145 @@
-export const metadata = { title: "Pull Requests · clevis" }
+"use client"
 
+import { useQuery } from "@tanstack/react-query"
+import Link from "next/link"
 import { PageHeader } from "@/components/page-header"
-import { EmptyStatePage } from "@/components/empty-state"
+import { Skeleton } from "@/components/ui/skeleton"
+import { SectionError } from "@/components/section-error"
+import { GitPullRequest } from "@phosphor-icons/react"
+import { api } from "@/lib/api/client"
+import { useActiveScope } from "@/lib/active-scope"
+import { relativeTime } from "@/lib/format"
+import type { PullSummary } from "@/lib/api/types"
+
+// This is the primary PR view (not a secondary tab like Activity's PR Board), so unlike
+// that tab's MAX_REPOS_FOR_PR_BOARD there's no hard cap on repo count -- instead requests
+// are fanned out in batches so an org with many repos doesn't fire dozens of simultaneous
+// requests at once.
+const REPO_BATCH_SIZE = 10
+
+interface PullRow extends PullSummary {
+  repo: string
+}
 
 export default function PullRequestsPage() {
+  const { scope } = useActiveScope()
+  const org = scope?.login ?? ""
+  const hasOrg = org.trim().length > 0
+
+  const resolveQuery = useQuery({
+    queryKey: ["tokens.resolve", org],
+    queryFn: () => api.tokens.resolve(org),
+    enabled: hasOrg,
+    retry: false,
+  })
+  const token = resolveQuery.data?.token ?? ""
+  // Same reasoning as Activity: queries fire once token resolution has settled either
+  // way, so an org connected purely via GitHub App installation (no saved PAT) isn't
+  // permanently blocked (see #251).
+  const queriesEnabled = hasOrg && !resolveQuery.isLoading
+
+  const reposQuery = useQuery({
+    queryKey: ["repos.list", org],
+    queryFn: () => api.repos.list(org, token),
+    enabled: queriesEnabled,
+    retry: false,
+  })
+
+  const repoNames = reposQuery.data?.repos.map((r) => r.name) ?? []
+
+  const pullsQuery = useQuery({
+    queryKey: ["repos.pulls.all", org, repoNames.join(",")],
+    queryFn: async () => {
+      const rows: PullRow[] = []
+      for (let i = 0; i < repoNames.length; i += REPO_BATCH_SIZE) {
+        const batch = repoNames.slice(i, i + REPO_BATCH_SIZE)
+        const results = await Promise.all(
+          batch.map((repo) =>
+            api.repos
+              .pulls(org, org, repo, token)
+              .then((r) => r.pulls.map((p) => ({ ...p, repo })))
+              .catch(() => [] as PullRow[]),
+          ),
+        )
+        rows.push(...results.flat())
+      }
+      return rows.sort((a, b) => b.created_at.localeCompare(a.created_at))
+    },
+    enabled: queriesEnabled && !!reposQuery.data,
+    retry: false,
+  })
+
+  const pulls = pullsQuery.data ?? []
+  const isLoading = reposQuery.isLoading || (reposQuery.isSuccess && pullsQuery.isLoading)
+
   return (
     <>
       <PageHeader title="Pull Requests" description="Open PRs across your organization." />
-      <EmptyStatePage message="Pull requests — coming soon" />
+      <div className="card">
+        <div className="px-4 py-3 border-b border-border flex items-center justify-between">
+          <span className="section-title">Open Pull Requests</span>
+          {pulls.length > 0 && <span className="stat-chip">{pulls.length} total</span>}
+        </div>
+        {!hasOrg ? (
+          <div className="px-4 py-8">
+            <p className="text-sm text-muted-foreground">
+              No account selected yet. Pick one from the profile menu, or{" "}
+              <Link href="/security" className="text-primary hover:underline">
+                configure →
+              </Link>
+            </p>
+          </div>
+        ) : reposQuery.isError ? (
+          <SectionError
+            message={reposQuery.error instanceof Error ? reposQuery.error.message : "Failed to load repositories."}
+            onRetry={() => reposQuery.refetch()}
+            retrying={reposQuery.isFetching}
+          />
+        ) : isLoading ? (
+          <div className="p-4 flex flex-col gap-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : pulls.length === 0 ? (
+          <p className="px-4 py-8 text-sm text-muted-foreground">No open pull requests</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Repo</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Pull Request</th>
+                  <th className="text-left text-muted-foreground font-medium px-4 py-2">Author</th>
+                  <th className="text-right text-muted-foreground font-medium px-4 py-2">Opened</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {pulls.map((p) => (
+                  <tr key={`${p.repo}-${p.number}`} className="hover:bg-muted/40 transition-colors">
+                    <td className="px-4 py-2.5 text-muted-foreground">{p.repo}</td>
+                    <td className="px-4 py-2.5">
+                      <a
+                        href={p.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1.5 text-foreground/90 hover:text-primary transition-colors"
+                      >
+                        <GitPullRequest className="size-3.5 shrink-0" />
+                        #{p.number} {p.title}
+                      </a>
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">{p.user ?? "unknown"}</td>
+                    <td className="px-4 py-2.5 text-right text-muted-foreground whitespace-nowrap">
+                      {relativeTime(p.created_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
     </>
   )
 }

--- a/apps/ui/components/app-sidebar.tsx
+++ b/apps/ui/components/app-sidebar.tsx
@@ -35,7 +35,7 @@ const groups = [
   [
     { title: "Overview",         href: "/" },
     { title: "Activity",         href: "/activity", showUnreadBadge: true },
-    { title: "Pull Requests",    href: "/pulls", comingSoon: true },
+    { title: "Pull Requests",    href: "/pulls" },
     { title: "Releases",         href: "/releases" },
   ],
   [
@@ -354,11 +354,6 @@ export function AppSidebar() {
                           {"showUnreadBadge" in item && item.showUnreadBadge && unreadCount > 0 && (
                             <span className="ml-auto text-[0.625rem] font-medium bg-primary/20 text-primary rounded-full px-1.5 py-0.5 tabular-nums">
                               {unreadCount}
-                            </span>
-                          )}
-                          {"comingSoon" in item && item.comingSoon && (
-                            <span className="ml-auto text-[0.625rem] font-medium text-sidebar-foreground/40 border border-sidebar-border/60 rounded-full px-1.5 py-0.5">
-                              Soon
                             </span>
                           )}
                         </SidebarMenuButton>

--- a/apps/ui/tests/components/app-sidebar.test.tsx
+++ b/apps/ui/tests/components/app-sidebar.test.tsx
@@ -379,18 +379,10 @@ describe("AppSidebar coming-soon badges", () => {
     vi.restoreAllMocks();
   });
 
-  it.each(["Pull Requests"])(
-    "shows a 'Soon' badge on the unshipped '%s' nav item",
-    async (title) => {
-      renderSidebar();
-      const link = await screen.findByRole("link", { name: new RegExp(title) });
-      expect(link).toHaveTextContent("Soon");
-    },
-  );
-
   it.each([
     "Overview",
     "Activity",
+    "Pull Requests",
     "Releases",
     "Repositories",
     "Health & Security",

--- a/apps/ui/tests/components/pulls-layout.test.tsx
+++ b/apps/ui/tests/components/pulls-layout.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Layout, { metadata } from "@/app/pulls/layout";
+
+describe("Pull Requests layout", () => {
+  it("renders its children through unmodified", () => {
+    render(
+      <Layout>
+        <p>child content</p>
+      </Layout>,
+    );
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  it("sets the page title", () => {
+    expect(metadata.title).toBe("Pull Requests · clevis");
+  });
+});

--- a/apps/ui/tests/components/pulls-page.test.tsx
+++ b/apps/ui/tests/components/pulls-page.test.tsx
@@ -1,0 +1,158 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const tokensResolveMock = vi.fn();
+const reposListMock = vi.fn();
+const reposPullsMock = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tokens: {
+      resolve: (...args: unknown[]) => tokensResolveMock(...args),
+    },
+    repos: {
+      list: (...args: unknown[]) => reposListMock(...args),
+      pulls: (...args: unknown[]) => reposPullsMock(...args),
+    },
+  },
+}));
+
+import PullRequestsPage from "@/app/pulls/page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PullRequestsPage />
+    </QueryClientProvider>,
+  );
+}
+
+function pull(overrides: Partial<{ number: number; title: string; user: string | null; created_at: string; html_url: string }> = {}) {
+  return {
+    number: 1,
+    title: "Fix the thing",
+    user: "octocat",
+    created_at: "2026-07-01T00:00:00Z",
+    html_url: "https://github.com/acme/demo/pull/1",
+    ...overrides,
+  };
+}
+
+describe("PullRequestsPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    tokensResolveMock.mockReset();
+    reposListMock.mockReset();
+    reposPullsMock.mockReset();
+    tokensResolveMock.mockRejectedValue(new Error("no saved token"));
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+    reposPullsMock.mockResolvedValue({ repository: "acme/demo", total: 0, pulls: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows a configure prompt when no org is set", async () => {
+    renderPage();
+    expect(await screen.findByText(/No account selected yet/)).toBeInTheDocument();
+    expect(reposListMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an empty state when the org has repos but no open pull requests", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [{ name: "demo", full_name: "acme/demo", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/demo" }],
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(reposPullsMock).toHaveBeenCalledWith("acme", "acme", "demo", ""));
+    expect(await screen.findByText("No open pull requests")).toBeInTheDocument();
+  });
+
+  it("aggregates pull requests across every repo in the org, sorted newest first", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 2,
+      repos: [
+        { name: "api", full_name: "acme/api", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/api" },
+        { name: "web", full_name: "acme/web", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/web" },
+      ],
+    });
+    reposPullsMock.mockImplementation((_org: string, _owner: string, repo: string) => {
+      if (repo === "api") {
+        return Promise.resolve({
+          repository: "acme/api",
+          total: 1,
+          pulls: [pull({ number: 10, title: "Older PR", created_at: "2026-06-01T00:00:00Z", html_url: "https://github.com/acme/api/pull/10" })],
+        });
+      }
+      return Promise.resolve({
+        repository: "acme/web",
+        total: 1,
+        pulls: [pull({ number: 20, title: "Newer PR", created_at: "2026-07-10T00:00:00Z", html_url: "https://github.com/acme/web/pull/20" })],
+      });
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/2 total/)).toBeInTheDocument());
+    const rows = screen.getAllByRole("row").slice(1).map((r) => r.textContent);
+    // Newest first: "Newer PR" (07-10) before "Older PR" (06-01).
+    expect(rows[0]).toContain("Newer PR");
+    expect(rows[1]).toContain("Older PR");
+  });
+
+  it("still renders other repos' pull requests when one repo's fetch fails", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 2,
+      repos: [
+        { name: "api", full_name: "acme/api", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/api" },
+        { name: "web", full_name: "acme/web", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/web" },
+      ],
+    });
+    reposPullsMock.mockImplementation((_org: string, _owner: string, repo: string) => {
+      if (repo === "api") return Promise.reject(new Error("GitHub API unreachable"));
+      return Promise.resolve({ repository: "acme/web", total: 1, pulls: [pull({ title: "Still shows up" })] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/Still shows up/)).toBeInTheDocument();
+  });
+
+  it("shows an error with retry when the repo list fails to load", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockRejectedValue(new Error("GitHub API unreachable"));
+
+    renderPage();
+
+    expect(await screen.findByText("GitHub API unreachable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("falls back to 'unknown' when a pull request has no author", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockResolvedValue({
+      org: "acme",
+      total: 1,
+      repos: [{ name: "demo", full_name: "acme/demo", private: false, description: null, language: null, stargazers_count: 0, forks_count: 0, watchers_count: 0, open_issues_count: 0, pushed_at: null, default_branch: "main", html_url: "https://github.com/acme/demo" }],
+    });
+    reposPullsMock.mockResolvedValue({ repository: "acme/demo", total: 1, pulls: [pull({ user: null })] });
+
+    renderPage();
+
+    expect(await screen.findByText("unknown")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/tests/components/pulls-page.test.tsx
+++ b/apps/ui/tests/components/pulls-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -139,7 +139,22 @@ describe("PullRequestsPage", () => {
     renderPage();
 
     expect(await screen.findByText("GitHub API unreachable")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: /retry/i });
+    expect(retryButton).toBeInTheDocument();
+
+    reposListMock.mockResolvedValue({ org: "acme", total: 0, repos: [] });
+    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(screen.getByText("No open pull requests")).toBeInTheDocument());
+  });
+
+  it("shows a generic error message when the repo list rejects with a non-Error value", async () => {
+    localStorage.setItem("default_org", "acme");
+    reposListMock.mockRejectedValue("string rejection, not an Error instance");
+
+    renderPage();
+
+    expect(await screen.findByText("Failed to load repositories.")).toBeInTheDocument();
   });
 
   it("falls back to 'unknown' when a pull request has no author", async () => {


### PR DESCRIPTION
## Summary

Fixes #275.

Replaces `apps/ui/app/pulls/page.tsx`'s "coming soon" placeholder with a real page:

- Fetches every repo in the active scope's org (`api.repos.list`), then fans the existing per-repo pulls endpoint (`api.repos.pulls` — already used by `repos/page.tsx`'s `RepoPullsCell` and Activity's PR Board tab) out across all of them.
- Per the issue's confirmed product decision ("this will now be the primary PR view instead of a secondary tab"), there's no hard repo-count cap like Activity's PR Board's `MAX_REPOS_FOR_PR_BOARD=10`. Instead requests are batched in groups of 10 concurrent calls (`REPO_BATCH_SIZE`) so a large org doesn't fire dozens of simultaneous requests at once.
- Results render as a flat, sorted table (repo, PR link, author, opened) rather than the PR Board's per-author grouping, since this is now a primary listing view, not a companion widget.
- A single repo's `pulls` fetch failing falls back to an empty list for that repo (`.catch(...)`) rather than blanking the whole page — same pattern as the existing PR Board tab.
- Drops the sidebar's `comingSoon: true` flag (`apps/ui/components/app-sidebar.tsx`) for this nav item — it was the last remaining user of that flag, so the now-dead "Soon" badge JSX block was also removed (required to keep the file typechecking after no nav item declares `comingSoon` anymore, not unrelated cleanup).
- `apps/ui/app/pulls/layout.tsx` is new — the page needed `"use client"` for hooks, and Next's app router requires `metadata` exports to live in a server component, so the existing page-level `metadata` moved into a sibling layout, matching the pattern already used by `activity/layout.tsx` and others.

No backend/schema change was needed — `POST /orgs/{org_login}/repos/{owner}/{repo}/pulls` already supports everything this page needs.

## Test plan
- [x] `bun run typecheck`, `bun run lint`, `bun run build`, full `bunx vitest run` (359 tests) all pass locally
- [x] New `pulls-page.test.tsx`: configure-prompt empty state, empty-org empty state, cross-repo aggregation + newest-first sort, one-repo-fails-others-still-show, repo-list error + retry, missing-author fallback to "unknown"
- [x] Updated `app-sidebar.test.tsx`: moved "Pull Requests" from the "shows a Soon badge" list to the "shows no Soon badge" (shipped) list
- Not done: a live browser check against a running API/DB — no backend stack was up in this environment (`docker compose ps` showed nothing running). Relying on the unit test suite + a successful production build instead; flagging this explicitly per AGENTS.md rather than claiming a browser check that didn't happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live Pull Requests page showing open pull requests across configured repositories.
  * Added sorting by newest pull request, repository details, authors, relative timestamps, and links to view each pull request.
  * Added loading, empty, configuration, and error states with retry support.
  * Updated sidebar navigation to mark Pull Requests as available.

* **Tests**
  * Added coverage for layout rendering, data loading, sorting, errors, retries, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->