### PR TITLE
feat(db): add tenants/memberships schema and org-tenant backfill

### DIFF
--- a/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
+++ b/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
@@ -53,6 +53,11 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("personal_user_id IS NOT NULL"),
     )
+    # (id, org_id) as a composite unique constraint -- redundant with id's own PK
+    # uniqueness on its own, but required so a later composite FK from orgs.tenant_id
+    # can reference this exact column pair (see migration 0024's reciprocal-association
+    # fix on orgs.tenant_id).
+    op.create_unique_constraint("uq_tenants_id_org_id", "tenants", ["id", "org_id"])
 
     op.create_table(
         "memberships",
@@ -67,6 +72,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("memberships")
+    op.drop_constraint("uq_tenants_id_org_id", "tenants", type_="unique")
     op.drop_index("uq_tenants_personal_user_id", table_name="tenants")
     op.drop_index("uq_tenants_org_id", table_name="tenants")
     op.drop_table("tenants")

--- a/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
+++ b/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
@@ -1,0 +1,72 @@
+"""Add tenants and memberships tables (issue #190, S2 multi-tenancy PR 2 of 7).
+
+Pure additive schema change, no backfill and no existing table touched --
+zero data-loss risk. See the design comment on #190 for the full plan this
+is one step of: https://github.com/nazarli-shabnam/clevis/issues/190
+
+`tenants` is a new table, not a rename of `orgs` -- every org gets a 1:1
+`tenants` row (kind='org') and every user gets an implicit personal tenant
+(kind='personal', added in a later PR), so personal-scope resources get
+real DB-level isolation once Row-Level Security lands, not just
+`owner_user_id` filtering. `memberships` mirrors `org_memberships`'
+role vocabulary ("admin"|"member") to avoid renaming that concept mid-flight.
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("kind", sa.Text(), nullable=False),  # 'org' | 'personal'
+        sa.Column("org_id", sa.Integer(), sa.ForeignKey("orgs.id"), nullable=True),
+        sa.Column("personal_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint(
+            "(kind = 'org' AND org_id IS NOT NULL AND personal_user_id IS NULL) OR "
+            "(kind = 'personal' AND org_id IS NULL AND personal_user_id IS NOT NULL)",
+            name="ck_tenants_kind_xor",
+        ),
+    )
+    op.create_index(
+        "uq_tenants_org_id",
+        "tenants",
+        ["org_id"],
+        unique=True,
+        postgresql_where=sa.text("org_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_tenants_personal_user_id",
+        "tenants",
+        ["personal_user_id"],
+        unique=True,
+        postgresql_where=sa.text("personal_user_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "memberships",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),  # 'admin' | 'member'
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "user_id", name="uq_memberships_tenant_user"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("memberships")
+    op.drop_index("uq_tenants_personal_user_id", table_name="tenants")
+    op.drop_index("uq_tenants_org_id", table_name="tenants")
+    op.drop_table("tenants")

--- a/apps/api/alembic/versions/0022_backfill_org_tenants.py
+++ b/apps/api/alembic/versions/0022_backfill_org_tenants.py
@@ -1,0 +1,46 @@
+"""Backfill one tenants/memberships row per existing org/org_membership (issue #190, PR 2 of 7).
+
+Zero ambiguity backfill: every `orgs` row gets exactly one `tenants` row
+(kind='org'), and every `org_memberships` row gets exactly one `memberships`
+row pointing at that org's new tenant, carrying the same role. Nothing here
+is read by application code yet (dual-write/cutover are later PRs in the
+#190 plan), so this is safe to run against any existing deployment.
+
+Personal tenants (one per `users` row) are added in a later PR, not here --
+see the design comment on #190.
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0022"
+down_revision = "0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("INSERT INTO tenants (kind, org_id) SELECT 'org', id FROM orgs"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO memberships (tenant_id, user_id, role) "
+            "SELECT t.id, om.user_id, om.role "
+            "FROM org_memberships om "
+            "JOIN tenants t ON t.org_id = om.org_id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM memberships WHERE tenant_id IN (SELECT id FROM tenants WHERE kind = 'org')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM tenants WHERE kind = 'org'"))

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -179,6 +179,12 @@ class Tenant(Base):
             unique=True,
             postgresql_where="personal_user_id IS NOT NULL",
         ),
+        # Lets orgs.tenant_id declare a composite FK to (id, org_id), enforcing that an
+        # org's tenant_id can only point at a tenant whose org_id reciprocally points back
+        # at that same org -- not a personal tenant, another org's tenant, or a tenant
+        # shared by multiple orgs. Redundant with id's own PK uniqueness in isolation, but
+        # required for the composite FK to be legal.
+        UniqueConstraint("id", "org_id", name="uq_tenants_id_org_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -164,6 +164,41 @@ class OrgMembership(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+class Tenant(Base):
+    __tablename__ = "tenants"
+    __table_args__ = (
+        CheckConstraint(
+            "(kind = 'org' AND org_id IS NOT NULL AND personal_user_id IS NULL) "
+            "OR (kind = 'personal' AND org_id IS NULL AND personal_user_id IS NOT NULL)",
+            name="ck_tenants_kind_xor",
+        ),
+        Index("uq_tenants_org_id", "org_id", unique=True, postgresql_where="org_id IS NOT NULL"),
+        Index(
+            "uq_tenants_personal_user_id",
+            "personal_user_id",
+            unique=True,
+            postgresql_where="personal_user_id IS NOT NULL",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "org" | "personal"
+    org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
+    personal_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Membership(Base):
+    __tablename__ = "memberships"
+    __table_args__ = (UniqueConstraint("tenant_id", "user_id", name="uq_memberships_tenant_user"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    role: Mapped[str] = mapped_column(String, nullable=False)  # "admin" | "member"
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class Invitation(Base):
     __tablename__ = "invitations"
 

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -213,7 +213,10 @@ describe("OverviewPage cockpit", () => {
         {
           repo: "acme/api",
           title: "v2",
-          due_on: "2026-08-01T00:00:00Z",
+          // relativeTime() renders anything within 60s (or in the future) as "just now" --
+          // computed relative to test execution time so this doesn't go stale as real time
+          // passes (a hardcoded near-future date drifted into "N days ago" here before).
+          due_on: new Date(Date.now() + 60_000).toISOString(),
           open_issues: 2,
           closed_issues: 8,
           progress_pct: 80,


### PR DESCRIPTION
## Summary

Issue #190 (S2 multi-tenancy), PR 2 of the 7-PR breakdown recorded on the issue: adds the `tenants` and `memberships` tables and backfills one row per existing `org`/`org_membership`. Pure schema addition — nothing reads from these tables yet; RLS, dual-write, and cutover are later PRs in the same sequence.

**Base branch note:** targets `190-worker-db-credential-separation` (PR #314), not `main` — this PR's migrations start at `0021`, which requires #314's `0020_grant_worker_role_privileges` to exist first (see the renumbering comment on #190: https://github.com/nazarli-shabnam/clevis/issues/190#issuecomment-5265790097). Retarget to `main` once #314 merges.

**Unrelated commit included:** also carries a cherry-picked test fix (`fix(ui): stop overview-page milestone burndown test date from going stale`, also opened standalone as #319 against `main`) — it was needed to get the pre-push hook green on this branch. Will be a no-op once #319 merges and this branch rebases past it.

## Schema change (per AGENTS.md's migration guardrail)

This PR includes a schema change: migrations `0021_add_tenants_and_memberships` and `0022_backfill_org_tenants`.

- `0021`: creates `tenants` (kind='org'|'personal', 1:1 to an org or user via partial unique indexes, `ck_tenants_kind_xor` check constraint) and `memberships` (tenant_id + user_id + role, unique per tenant/user). Purely additive — no existing table touched.
- `0022`: backfills one `tenants` row per existing `org` and one `memberships` row per existing `org_membership`, carrying the same role. Zero ambiguity — every org gets exactly one tenant.

Both verified against a real Postgres instance: full `alembic upgrade head` / `downgrade` cycle, including a seeded org+membership row to exercise the backfill logic (confirmed the correct tenant/membership row was produced, then cleaned up). `pytest -q` — 606 passed.

## What changed

- `apps/api/alembic/versions/0021_add_tenants_and_memberships.py` (new)
- `apps/api/alembic/versions/0022_backfill_org_tenants.py` (new)
- `apps/api/src/core/db.py`: adds `Tenant` and `Membership` SQLAlchemy models matching the migration schema.

## Test plan

- [x] `alembic upgrade head` / `downgrade` cycle against real Postgres, with seeded org/membership data to exercise the backfill.
- [x] `pytest -q` — 606 passed.
- [x] `bun run check` (typecheck + lint + build) via the pre-commit hook — passed.
- [x] `bun run test` via the pre-push hook — passed.

## Post-review follow-up

- **CI fix:** Docker Build Verification initially failed on this PR due to a transient network error fetching Google Fonts (`next/font/google`) during the container build in the GitHub Actions runner — unrelated to any code change here. Re-ran the job (`gh run rerun --failed`) and it passed cleanly on retry.
- **CodeRabbit finding, fixed:** flagged that a later PR in this stack (#321, which adds `orgs.tenant_id`) would only have a plain FK to `tenants.id`, with no schema-level guarantee it points at the *reciprocal* tenant (i.e. nothing would stop `orgs.tenant_id` from pointing at a personal tenant, another org's tenant, or a tenant shared by multiple orgs). Since the composite-FK fix needs a matching unique constraint on the `tenants` side, this PR was amended to add `uq_tenants_id_org_id` — a composite unique constraint on `tenants(id, org_id)` — in migration `0021`. The corresponding composite FK on `orgs.tenant_id` itself lives in #321's migration `0024`. Re-verified against real Postgres (upgrade/downgrade cycle) and `pytest -q` (606 passed) after the amendment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for organization and personal tenant spaces.
  - Added membership records linking users to tenant spaces with assigned roles.
  - Existing organizations and memberships are automatically represented in the new tenant structure, preserving users and roles.
  - Added safeguards to maintain valid ownership, unique memberships, and consistent tenant data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
