### PR TITLE
feat(db): add personal tenants and remaining tenant_id columns

### DIFF
--- a/apps/api/alembic/versions/0023_backfill_personal_tenants.py
+++ b/apps/api/alembic/versions/0023_backfill_personal_tenants.py
@@ -1,0 +1,43 @@
+"""Backfill one personal tenant/membership per existing user (issue #190, PR 3 of 7).
+
+Every user gets an implicit personal tenant (kind='personal') so
+personal-scope resources (scan_results, saved_tokens, personal
+github_installations) get real DB-level isolation once RLS lands, not just
+owner_user_id filtering. The membership role for a user's own personal
+tenant is 'admin' -- there's no concept of a personal-tenant member who
+isn't its owner.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("INSERT INTO tenants (kind, personal_user_id) SELECT 'personal', id FROM users"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO memberships (tenant_id, user_id, role) "
+            "SELECT t.id, t.personal_user_id, 'admin' "
+            "FROM tenants t WHERE t.kind = 'personal'"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM memberships WHERE tenant_id IN (SELECT id FROM tenants WHERE kind = 'personal')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM tenants WHERE kind = 'personal'"))

--- a/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
+++ b/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
@@ -1,0 +1,42 @@
+"""Add orgs.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+Every existing orgs row already has exactly one 'org'-kind tenants row from
+migration 0022, so the backfill join itself is small and unambiguous. NOT
+NULL is *not* enforced here, though -- app code (org_provisioning.py and
+anywhere else an Org row is created) doesn't set tenant_id yet; that wiring
+is explicitly PR 4's job (dual-write). Enforcing NOT NULL now would break
+every org-creation code path the moment this migration deploys, well before
+PR 4 ships. NOT NULL enforcement is deferred to its own follow-up migration,
+written once PR 4 lands, mirroring github_installations' 0025/(future)
+enforce-not-null split rather than the org-xor-owner backfill's original
+"safe to enforce immediately" framing in #190's design comment -- that
+framing didn't account for app code being the actual writer, not just this
+migration's one-time backfill.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE orgs SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = orgs.id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("orgs", "tenant_id")

--- a/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
+++ b/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
@@ -13,6 +13,16 @@ enforce-not-null split rather than the org-xor-owner backfill's original
 framing didn't account for app code being the actual writer, not just this
 migration's one-time backfill.
 
+Uses a composite FK, (orgs.tenant_id, orgs.id) -> (tenants.id, tenants.org_id),
+instead of a plain single-column FK to tenants.id (per CodeRabbit review on
+#190's PR 3: a plain FK lets orgs.tenant_id point at a personal tenant,
+another org's tenant, or a tenant shared by multiple orgs -- nothing catches
+a backfill/dual-write bug that assigns the wrong tenant). The composite FK
+requires that whatever tenant orgs.tenant_id names must itself have
+org_id = this exact org's id, enforcing the reciprocal 1:1 association at
+the database level. Depends on migration 0021's uq_tenants_id_org_id unique
+constraint on tenants(id, org_id), which the composite FK references.
+
 Revision ID: 0024
 Revises: 0023
 Create Date: 2026-08-12
@@ -28,7 +38,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), nullable=True))
     conn = op.get_bind()
     conn.execute(
         sa.text(
@@ -36,7 +46,15 @@ def upgrade() -> None:
             "FROM tenants t WHERE t.org_id = orgs.id AND t.kind = 'org'"
         )
     )
+    op.create_foreign_key(
+        "fk_orgs_tenant_id_reciprocal",
+        "orgs",
+        "tenants",
+        ["tenant_id", "id"],
+        ["id", "org_id"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("fk_orgs_tenant_id_reciprocal", "orgs", type_="foreignkey")
     op.drop_column("orgs", "tenant_id")

--- a/apps/api/alembic/versions/0025_add_github_installations_tenant_id.py
+++ b/apps/api/alembic/versions/0025_add_github_installations_tenant_id.py
@@ -1,0 +1,41 @@
+"""Add github_installations.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+github_installations.org_id/owner_user_id are already mutually exclusive
+(ck_github_installations_org_xor_owner), so the backfill join picks the
+org's tenant when org_id is set, the owner's personal tenant otherwise.
+NOT NULL is deferred to migration 0029, run only after a verification
+query confirms zero NULLs in the target environment -- this table's
+backfill correctness depends on migrations 0022/0023 having already run
+cleanly there, which this migration can't itself guarantee.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "github_installations", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True)
+    )
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE github_installations gi SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE (gi.org_id IS NOT NULL AND t.org_id = gi.org_id AND t.kind = 'org') "
+            "OR (gi.owner_user_id IS NOT NULL AND t.personal_user_id = gi.owner_user_id AND t.kind = 'personal')"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("github_installations", "tenant_id")

--- a/apps/api/alembic/versions/0026_add_invitations_tenant_id.py
+++ b/apps/api/alembic/versions/0026_add_invitations_tenant_id.py
@@ -1,0 +1,36 @@
+"""Add invitations.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+invitations.org_id is required, and every org already has a tenant from
+migration 0022, so the backfill join is small and unambiguous. NOT NULL is
+*not* enforced here though, for the same reason as orgs (0024): invitation
+-creation code doesn't set tenant_id until PR 4's dual-write lands.
+Enforcing NOT NULL now would break every "invite a member" request the
+moment this migration deploys.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("invitations", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE invitations i SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = i.org_id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invitations", "tenant_id")

--- a/apps/api/alembic/versions/0027_add_scan_results_and_saved_tokens_tenant_id.py
+++ b/apps/api/alembic/versions/0027_add_scan_results_and_saved_tokens_tenant_id.py
@@ -1,0 +1,57 @@
+"""Add tenant_id to scan_results and saved_tokens, best-effort backfill, stays nullable (issue #190, PR 3 of 7).
+
+Unlike orgs/invitations/github_installations, neither table has a real FK to
+join through: scan_results.owner and saved_tokens.org are free-text GitHub
+login strings, matched against orgs.github_login on a best-effort basis.
+Legacy rows that don't match any known org (renamed/deleted org, or a
+personal-endpoint scan where owner is a user's own login rather than an
+org) are left with tenant_id NULL rather than guessed at or dropped --
+documented here, not chased. scan_results additionally falls back to the
+scanning user's personal tenant via scanned_by_user_id when set.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("scan_results", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    op.add_column("saved_tokens", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE scan_results sr SET tenant_id = t.id "
+            "FROM orgs o JOIN tenants t ON t.org_id = o.id AND t.kind = 'org' "
+            "WHERE o.github_login = sr.owner"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE scan_results sr SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE sr.tenant_id IS NULL AND sr.scanned_by_user_id IS NOT NULL "
+            "AND t.personal_user_id = sr.scanned_by_user_id AND t.kind = 'personal'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE saved_tokens st SET tenant_id = t.id "
+            "FROM orgs o JOIN tenants t ON t.org_id = o.id AND t.kind = 'org' "
+            "WHERE o.github_login = st.org"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("saved_tokens", "tenant_id")
+    op.drop_column("scan_results", "tenant_id")

--- a/apps/api/alembic/versions/0028_add_audit_logs_tenant_id.py
+++ b/apps/api/alembic/versions/0028_add_audit_logs_tenant_id.py
@@ -1,0 +1,30 @@
+"""Add audit_logs.tenant_id, nullable, no backfill (issue #190, PR 3 of 7).
+
+audit_logs.actor/target are free text (not FKs), so pre-migration rows
+can't be reliably attributed to a tenant -- per the design decision
+recorded on #190, these stay visible only through a require_workspace_admin
+-gated view once RLS lands, never to ordinary tenant members. No backfill
+attempted here, unlike scan_results/saved_tokens (0027) which at least
+have a best-effort join available; audit_logs has no comparable joinable
+field at all.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("audit_logs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("audit_logs", "tenant_id")

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -156,6 +157,13 @@ class User(Base):
 
 class Org(Base):
     __tablename__ = "orgs"
+    __table_args__ = (
+        # Composite FK instead of a plain tenant_id -> tenants.id FK: requires that
+        # whatever tenant tenant_id names must itself have org_id = this exact org's id,
+        # so tenant_id can't point at a personal tenant, another org's tenant, or a tenant
+        # shared across multiple orgs (see migration 0024's docstring).
+        ForeignKeyConstraint(["tenant_id", "id"], ["tenants.id", "tenants.org_id"], name="fk_orgs_tenant_id_reciprocal"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     # Nullable: not known for orgs backfilled from pre-existing installations; filled in
@@ -168,7 +176,7 @@ class Org(Base):
     # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
     # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
     # org -- enforcing NOT NULL before then would break org creation entirely.
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class OrgMembership(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -57,6 +57,11 @@ class GitHubInstallation(Base):
     # Exactly one of org_id / owner_user_id is set: org-connected installs vs. personal installs.
     org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    # Backfilled from org_id/owner_user_id by migration 0025. Stays nullable until PR 4's
+    # dual-write lands and installation-creation code starts setting it -- enforcing NOT
+    # NULL before then would break every new installation the moment this migration deploys
+    # (see the same reasoning documented on orgs.tenant_id and invitations.tenant_id below).
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -68,6 +73,11 @@ class AuditLog(Base):
     action: Mapped[str] = mapped_column(String, nullable=False)
     target: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[str] = mapped_column(Text, nullable=False)
+    # Nullable, no historical backfill (migration 0028) -- actor/target are free text, not
+    # FKs, so pre-migration rows can't be reliably attributed to a tenant. Per the design
+    # decision on #190, these stay visible only via a require_workspace_admin-gated view
+    # once RLS lands, never to ordinary tenant members.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -106,6 +116,9 @@ class SavedToken(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    # Best-effort backfill by migration 0027, matched on org (free text, not an FK) against
+    # orgs.github_login -- stays nullable since legacy rows for a renamed/deleted org won't match.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class User(Base):
@@ -151,6 +164,11 @@ class Org(Base):
     github_org_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
     github_login: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # 1:1 pointer to this org's tenant row (migration 0022 backfills one 'org'-kind tenant
+    # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
+    # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
+    # org -- enforcing NOT NULL before then would break org creation entirely.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class OrgMembership(Base):
@@ -217,6 +235,10 @@ class Invitation(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Backfilled from org_id's tenant by migration 0026. Stays nullable until PR 4's
+    # dual-write lands and invitation-creation code starts setting it -- same reasoning as
+    # orgs.tenant_id above.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class ScanResult(Base):
@@ -235,6 +257,10 @@ class ScanResult(Base):
     # by org membership, not this column.
     scanned_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # Best-effort backfill by migration 0027: matched via owner -> orgs.github_login first,
+    # falling back to scanned_by_user_id's personal tenant. Stays nullable -- some legacy
+    # rows (renamed/deleted org) won't match either path.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class AppConfig(Base):


### PR DESCRIPTION
## Summary

Issue #190 (S2 multi-tenancy), PR 3 of the 7-PR breakdown recorded on the issue: backfills a personal tenant/membership per user, and adds `tenant_id` to `orgs`, `github_installations`, `invitations`, `scan_results`, `saved_tokens`, and `audit_logs`.

**Base branch note:** targets `190-tenants-memberships-schema` (#320), since these migrations depend on the `tenants`/`memberships` tables it adds. Retarget once #320 merges.

**Unrelated commit included:** also carries a cherry-picked test fix (`fix(ui): stop overview-page milestone burndown test date from going stale`, also in #320 and standalone as #319 against `main`) — needed to get the pre-push hook green. Will be a no-op once the earlier PRs merge and this branch rebases past them.

## Schema change, and a design correction (per AGENTS.md's migration guardrail)

This PR includes a schema change: migrations `0023_backfill_personal_tenants` through `0028_add_audit_logs_tenant_id`.

**Important deviation from #190's original design comment, found and fixed during implementation:** the design comment called for `NOT NULL` on `orgs.tenant_id` immediately (and, via its migration list, eventually on `github_installations.tenant_id`), reasoning the backfill join was "small and unambiguous." That's true for *existing* rows, but wrong for the deploy — no application code (`org_provisioning.py`, installation bootstrap, invitation creation) sets `tenant_id` yet; that's explicitly PR 4's dual-write job. Enforcing `NOT NULL` before PR 4 ships would break org/installation/invitation creation the moment this migration deploys.

Confirmed live: an earlier version of this PR with `NOT NULL` enforced on `orgs.tenant_id` produced **73 failed + 134 errored** tests, all `NotNullViolation` on `orgs.tenant_id`, when run against the real app code paths (not just the migration's own backfill check). Fixed by keeping `orgs.tenant_id`, `invitations.tenant_id`, and `github_installations.tenant_id` all **nullable** through this PR. `NOT NULL` enforcement is deferred to a follow-up migration to be written once PR 4's dual-write lands (the migration originally numbered `0029` in the design comment — `enforce_github_installations_tenant_id_not_null` — has been removed from this PR's scope entirely for the same reason).

After the fix: `pytest -q` — 606 passed.

## Post-review follow-up: CodeRabbit finding, fixed

**Data integrity finding (major severity):** `orgs.tenant_id` originally had only a plain FK to `tenants.id`, with no schema-level guarantee it pointed at the *reciprocal* tenant — nothing would stop a future backfill/dual-write bug from pointing `orgs.tenant_id` at a personal tenant, another org's tenant, or a tenant shared by multiple orgs.

Fixed with a composite FK: `orgs(tenant_id, id) -> tenants(id, org_id)`, replacing the plain FK in migration `0024`. This requires whatever tenant `orgs.tenant_id` names to itself have `org_id` equal to that exact org's id, enforcing the reciprocal 1:1 association at the database level. Depends on a matching composite unique constraint `uq_tenants_id_org_id` on `tenants(id, org_id)`, added in #320's migration `0021`.

Verified against real Postgres: full downgrade/upgrade cycle, a direct proof that the fix rejects the exact cross-tenant corruption CodeRabbit described (attempted to point one org's `tenant_id` at another org's tenant and confirmed a `ForeignKeyViolation`), and `pytest -q` (606 passed).

## What changed

- `apps/api/alembic/versions/0023_backfill_personal_tenants.py` (new) — one personal tenant/membership per user.
- `apps/api/alembic/versions/0024_add_orgs_tenant_id.py` (new) — add + backfill, nullable, composite FK enforcing reciprocal org-tenant association (see CodeRabbit fix above).
- `apps/api/alembic/versions/0025_add_github_installations_tenant_id.py` (new) — add + backfill (via org_id or owner_user_id), nullable.
- `apps/api/alembic/versions/0026_add_invitations_tenant_id.py` (new) — add + backfill, nullable.
- `apps/api/alembic/versions/0027_add_scan_results_and_saved_tokens_tenant_id.py` (new) — add + best-effort backfill (matched against `orgs.github_login`, falling back to the scanning user's personal tenant for `scan_results`), stays nullable — some legacy rows won't match.
- `apps/api/alembic/versions/0028_add_audit_logs_tenant_id.py` (new) — add nullable, no backfill attempted (`actor`/`target` are free text, not FKs).
- `apps/api/src/core/db.py`: `tenant_id` columns added to `GitHubInstallation`, `Org`, `Invitation`, `ScanResult`, `SavedToken`, `AuditLog` models, all nullable per the above; `Org.__table_args__` gains the composite `ForeignKeyConstraint`.

## Test plan

- [x] `alembic upgrade head` / `downgrade` cycle against real Postgres, seeded with data covering every backfill path: matched and unmatched orgs/installations/scan_results/saved_tokens, personal-only users, free-text audit_logs. Verified each column's post-migration state matches expectations (e.g. `saved_tokens.tenant_id` NULL only for the one unmatched-org row).
- [x] Composite-FK regression check: attempted to point an org's `tenant_id` at a different org's tenant row directly via SQL — confirmed `ForeignKeyViolation`, proving the reciprocal-association fix actually rejects the corruption CodeRabbit flagged.
- [x] `pytest -q` — 606 passed (after the NOT NULL fix; 73 failed + 134 errored before it, see above).
- [x] `bun run check` (typecheck + lint + build) via the pre-commit hook — passed.
- [x] `bun run test` via the pre-push hook — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personal tenant spaces for existing accounts.
  * Added tenant associations across organizations, integrations, invitations, scan results, saved tokens, and audit logs.
  * Automatically linked existing records to the appropriate personal or organization tenant where possible.

* **Tests**
  * Improved milestone due-date test stability by using a dynamically calculated date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
