### PR TITLE
feat(db): dual-write tenants/memberships alongside orgs/org_memberships

### DIFF
--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -3,6 +3,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import GitHubInstallation
+from src.repositories import tenant_repo
+
+
+def _resolve_tenant_id(db: Session, org_id: int | None, owner_user_id: int | None) -> int:
+    if org_id is not None:
+        return tenant_repo.get_or_create_org_tenant(db, org_id).id
+    return tenant_repo.ensure_personal_tenant(db, owner_user_id).id
 
 
 def upsert(
@@ -25,11 +32,13 @@ def upsert(
 
     existing = query.first()
     token_ref = f"tok_{account_login}"
+    tenant_id = _resolve_tenant_id(db, org_id, owner_user_id)
     if existing:
         existing.account_type = account_type
         existing.auth_mode = auth_mode
         existing.installation_id = installation_id
         existing.token_ref = token_ref
+        existing.tenant_id = tenant_id
         db.commit()
         db.refresh(existing)
         return existing
@@ -42,6 +51,7 @@ def upsert(
         token_ref=token_ref,
         org_id=org_id,
         owner_user_id=owner_user_id,
+        tenant_id=tenant_id,
     )
     db.add(row)
     try:
@@ -57,6 +67,7 @@ def upsert(
         existing.auth_mode = auth_mode
         existing.installation_id = installation_id
         existing.token_ref = token_ref
+        existing.tenant_id = tenant_id
         db.commit()
         db.refresh(existing)
         return existing

--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -4,11 +4,13 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from src.core.db import Invitation
+from src.repositories import tenant_repo
 
 INVITATION_LIFETIME = timedelta(days=7)
 
 
 def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Invitation:
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     invitation = Invitation(
         org_id=org_id,
         email=email,
@@ -16,6 +18,7 @@ def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Inv
         status="pending",
         invited_by_user_id=invited_by_user_id,
         expires_at=datetime.now(timezone.utc) + INVITATION_LIFETIME,
+        tenant_id=tenant.id,
     )
     db.add(invitation)
     db.commit()

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -2,6 +2,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import OrgMembership
+from src.repositories import tenant_repo
 
 
 def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
@@ -28,6 +29,8 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
             raise
         return membership
     db.refresh(membership)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role=role)
     return membership
 
 
@@ -46,6 +49,8 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
     membership.role = role
     db.commit()
     db.refresh(membership)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user_id, role=role)
     return membership
 
 
@@ -54,3 +59,5 @@ def delete(db: Session, org_id: int, user_id: int) -> None:
         OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
     ).delete()
     db.commit()
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user_id)

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -3,6 +3,17 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import Org
+from src.repositories import tenant_repo
+
+
+def _ensure_tenant_linked(db: Session, org: Org) -> Org:
+    if org.tenant_id is not None:
+        return org
+    tenant = tenant_repo.get_or_create_org_tenant(db, org.id)
+    org.tenant_id = tenant.id
+    db.commit()
+    db.refresh(org)
+    return org
 
 
 def get_by_login(db: Session, github_login: str) -> Org | None:
@@ -33,7 +44,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org.github_org_id = github_org_id
             db.commit()
             db.refresh(org)
-        return org
+        return _ensure_tenant_linked(db, org)
 
     if github_org_id is not None:
         # The org may have been renamed on GitHub since we last saw it -- github_org_id
@@ -45,7 +56,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
                 org.github_login = github_login
                 db.commit()
                 db.refresh(org)
-            return org
+            return _ensure_tenant_linked(db, org)
 
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
@@ -59,6 +70,6 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org = get_by_org_id(db, github_org_id)
         if org is None:
             raise
-        return org
+        return _ensure_tenant_linked(db, org)
     db.refresh(org)
-    return org
+    return _ensure_tenant_linked(db, org)

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -1,0 +1,95 @@
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.core.db import Membership, Tenant
+
+
+def get_or_create_org_tenant(db: Session, org_id: int) -> Tenant:
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is not None:
+        return tenant
+    tenant = Tenant(kind="org", org_id=org_id)
+    db.add(tenant)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same org's tenant.
+        db.rollback()
+        tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is None:
+            raise
+        return tenant
+    db.refresh(tenant)
+    return tenant
+
+
+def ensure_personal_tenant(db: Session, user_id: int) -> Tenant:
+    """Get-or-create a user's personal tenant, plus its self-membership (role='admin') --
+    mirrors migration 0023_backfill_personal_tenants.py, which backfilled both rows
+    together for every pre-existing user. There's no concept of a personal tenant with
+    no membership, so both rows are ensured atomically here."""
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    if tenant is None:
+        tenant = Tenant(kind="personal", personal_user_id=user_id)
+        db.add(tenant)
+        try:
+            db.commit()
+        except IntegrityError:
+            # Lost a race with a concurrent insert of the same user's personal tenant.
+            db.rollback()
+            tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+            if tenant is None:
+                raise
+        else:
+            db.refresh(tenant)
+
+    get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role="admin")
+    return tenant
+
+
+def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:
+    membership = (
+        db.query(Membership)
+        .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+        .first()
+    )
+    if membership is not None:
+        return membership
+    membership = Membership(tenant_id=tenant_id, user_id=user_id, role=role)
+    db.add(membership)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same (tenant_id, user_id) pair.
+        db.rollback()
+        membership = (
+            db.query(Membership)
+            .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+            .first()
+        )
+        if membership is None:
+            raise
+        return membership
+    db.refresh(membership)
+    return membership
+
+
+def update_membership_role(db: Session, tenant_id: int, user_id: int, role: str) -> Membership | None:
+    membership = (
+        db.query(Membership)
+        .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+        .first()
+    )
+    if membership is None:
+        return None
+    membership.role = role
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def delete_membership(db: Session, tenant_id: int, user_id: int) -> None:
+    db.query(Membership).filter(
+        Membership.tenant_id == tenant_id, Membership.user_id == user_id
+    ).delete()
+    db.commit()

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -40,7 +40,7 @@ from src.core.auth import UserOut, clear_session_cookie, create_access_token, re
 from src.core.config import settings
 from src.core.db import Org, User, get_db
 from src.core.rate_limit import check_account_rate_limit, rate_limit
-from src.repositories import invitation_repo
+from src.repositories import invitation_repo, tenant_repo
 from src.services.email import EmailNotConfigured, send_verification_email
 
 logger = logging.getLogger(__name__)
@@ -237,6 +237,7 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
         db.rollback()
         raise HTTPException(status_code=409, detail="Setup already complete") from None
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
@@ -281,6 +282,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     _send_verification_email_best_effort(user)
     db.commit()
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {
         "access_token": token,

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -29,6 +29,7 @@ from src.core.auth import create_access_token, set_session_cookie
 from src.core.config import settings
 from src.core.db import User, get_db
 from src.core.rate_limit import rate_limit
+from src.repositories import tenant_repo
 from src.services import github_oauth, org_provisioning
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
     db.add(user)
     db.commit()
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     return user
 
 

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -78,6 +78,19 @@ def test_setup_returns_token_and_owner(auth_client):
     assert body["user"]["email"] == "owner@example.com"
 
 
+def test_setup_creates_a_personal_tenant_and_self_membership(auth_client, db):
+    from src.core.db import Membership, Tenant
+
+    body = _setup_owner(auth_client)
+    user_id = body["user"]["id"]
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    assert tenant is not None
+    membership = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+    assert membership is not None
+    assert membership.role == "admin"
+
+
 def test_setup_stores_email_lowercased(auth_client):
     resp = auth_client.post(
         "/auth/setup", json={"email": "Owner@Example.com", "password": "supersecret1234"}
@@ -183,6 +196,23 @@ def test_register_creates_non_owner(auth_client):
     assert "access_token" in body
     assert body["user"]["is_workspace_admin"] is False
     assert body["user"]["email"] == "member@example.com"
+
+
+def test_register_creates_a_personal_tenant_and_self_membership(auth_client, db):
+    from src.core.db import Membership, Tenant
+
+    _setup_owner(auth_client)
+    resp = auth_client.post(
+        "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+    )
+    assert resp.status_code == 201
+    user_id = resp.json()["user"]["id"]
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    assert tenant is not None
+    membership = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+    assert membership is not None
+    assert membership.role == "admin"
 
 
 def test_register_before_setup_rejected(auth_client):

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -70,6 +70,30 @@ def test_second_user_is_member(db):
     assert second.is_workspace_admin is False
 
 
+def test_new_user_gets_a_personal_tenant_and_self_membership(db):
+    from src.core.db import Membership, Tenant
+
+    user = find_or_create_user(db, _identity())
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user.id).first()
+    assert tenant is not None
+    membership = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_returning_user_does_not_duplicate_the_personal_tenant(db):
+    from src.core.db import Tenant
+
+    first = find_or_create_user(db, _identity())
+    find_or_create_user(db, _identity(name="Octo Updated"))  # returning-user branch
+
+    tenants = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == first.id).all()
+    assert len(tenants) == 1
+
+
 def test_refuses_to_auto_link_an_existing_email_registered_account(db):
     # Regression test for the account-takeover fix: self-registration has no email
     # verification anywhere in this app, so silently linking a GitHub identity onto an

--- a/apps/api/tests/test_installation_repo.py
+++ b/apps/api/tests/test_installation_repo.py
@@ -24,6 +24,48 @@ def test_upsert_creates_new_row(db):
     assert row.installation_id == 1
 
 
+def test_upsert_sets_tenant_id_for_org_scoped_installation(db):
+    from src.core.db import Tenant
+
+    org_id = _acme_org_id(db)
+    row = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    assert row.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == row.tenant_id).first()
+    assert tenant.kind == "org"
+    assert tenant.org_id == org_id
+
+
+def test_upsert_sets_tenant_id_for_personal_installation(db):
+    from src.core.db import Tenant, User
+
+    user = User(email="dev2@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    row = installation_repo.upsert(
+        db, account_login="octocat", account_type="User", auth_mode="app", installation_id=7, owner_user_id=user.id
+    )
+
+    assert row.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == row.tenant_id).first()
+    assert tenant.kind == "personal"
+    assert tenant.personal_user_id == user.id
+
+
+def test_upsert_update_branch_backfills_tenant_id(db):
+    org_id = _acme_org_id(db)
+    installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    updated = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=2, org_id=org_id
+    )
+    assert updated.tenant_id is not None
+
+
 def test_upsert_updates_existing_row(db):
     org_id = _acme_org_id(db)
     installation_repo.upsert(

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import invitation_repo, org_membership_repo, org_repo
 from src.routers.invitations import router as invitations_router
 
 
@@ -55,6 +55,21 @@ def test_create_invitation_admin_ok(db, acme_org):
     assert body["invitation"]["email"] == "bob@acme.com"
     assert body["invitation"]["status"] == "pending"
     assert "/invite/" in body["invite_link"]
+
+
+def test_create_invitation_sets_tenant_id(db, acme_org):
+    from src.core.db import Tenant
+
+    resp = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 200
+    token = resp.json()["invite_link"].rsplit("/", 1)[-1]
+
+    invitation = invitation_repo.get_by_token(db, token)
+
+    assert invitation.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == invitation.tenant_id).first()
+    assert tenant.kind == "org"
+    assert tenant.org_id == acme_org["org"].id
 
 
 def test_create_invitation_rejects_duplicate_pending_invite(db, acme_org):

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -1,0 +1,80 @@
+"""Tests for src.repositories.org_membership_repo's Membership dual-write (issue #190 PR 4):
+every OrgMembership create/update/delete must be mirrored onto the tenants/memberships
+tables, keyed off the org's tenant."""
+
+from src.core.db import Membership, Tenant, User
+from src.repositories import org_membership_repo, org_repo
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _membership_row(db, org_id: int, user_id: int) -> Membership | None:
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is None:
+        return None
+    return db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+
+
+def test_get_or_create_mirrors_a_membership_row(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "alice@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_get_or_create_is_idempotent_on_the_mirror_too(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "bob@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    rows = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).all()
+    assert len(rows) == 1
+
+
+def test_update_role_mirrors_onto_membership(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "carol@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_delete_removes_the_membership_mirror_too(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "dave@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+
+    org_membership_repo.delete(db, org_id=org.id, user_id=user.id)
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is None
+
+
+def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    admin = _make_user(db, "erin@example.com")
+    member = _make_user(db, "frank@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+
+    admin_membership = _membership_row(db, org.id, admin.id)
+    member_membership = _membership_row(db, org.id, member.id)
+    assert admin_membership.tenant_id == member_membership.tenant_id

--- a/apps/api/tests/test_org_repo.py
+++ b/apps/api/tests/test_org_repo.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from sqlalchemy.orm import Query
 
+from src.core.db import Tenant
 from src.repositories import org_repo
 
 
@@ -11,6 +12,31 @@ def test_creates_new_org(db):
     org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
     assert org.github_login == "acme"
     assert org.github_org_id == 1
+
+
+def test_creates_new_org_links_a_tenant(db):
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    assert org.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+    assert tenant is not None
+    assert tenant.kind == "org"
+    assert tenant.org_id == org.id
+
+
+def test_existing_org_gets_lazily_backfilled_with_a_tenant(db):
+    # An org row created before dual-write existed (tenant_id NULL) must self-heal the
+    # next time it's resolved through get_or_create, not stay permanently untenanted.
+    from src.core.db import Org
+
+    org = Org(github_login="acme", github_org_id=1)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.tenant_id is None
+
+    resolved = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+
+    assert resolved.tenant_id is not None
 
 
 def test_idempotent_by_login(db):

--- a/apps/api/tests/test_tenant_repo.py
+++ b/apps/api/tests/test_tenant_repo.py
@@ -1,0 +1,177 @@
+"""Tests for src.repositories.tenant_repo."""
+
+from unittest.mock import patch
+
+from sqlalchemy.orm import Query
+
+from src.core.db import Membership, User
+from src.repositories import tenant_repo
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _acme_org_id(db) -> int:
+    # org_repo.get_or_create already dual-writes a tenant -- create the org row directly
+    # instead so these tests exercise tenant_repo's own get-or-create behavior in isolation.
+    from src.core.db import Org
+
+    org = Org(github_login="acme")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org.id
+
+
+# ── get_or_create_org_tenant ─────────────────────────────────────────────────
+
+def test_get_or_create_org_tenant_creates_new(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    assert tenant.kind == "org"
+    assert tenant.org_id == org_id
+
+
+def test_get_or_create_org_tenant_idempotent(db):
+    org_id = _acme_org_id(db)
+    first = tenant_repo.get_or_create_org_tenant(db, org_id)
+    second = tenant_repo.get_or_create_org_tenant(db, org_id)
+    assert second.id == first.id
+
+
+def test_get_or_create_org_tenant_falls_back_on_concurrent_insert_race(db):
+    org_id = _acme_org_id(db)
+    existing = tenant_repo.get_or_create_org_tenant(db, org_id)
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = tenant_repo.get_or_create_org_tenant(db, org_id)
+
+    assert result.id == existing.id
+
+
+# ── ensure_personal_tenant ────────────────────────────────────────────────────
+
+def test_ensure_personal_tenant_creates_tenant_and_self_membership(db):
+    user = _make_user(db, "alice@example.com")
+
+    tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert tenant.kind == "personal"
+    assert tenant.personal_user_id == user.id
+    membership = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_ensure_personal_tenant_idempotent(db):
+    user = _make_user(db, "bob@example.com")
+
+    first = tenant_repo.ensure_personal_tenant(db, user.id)
+    second = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert second.id == first.id
+    memberships = db.query(Membership).filter(Membership.tenant_id == first.id, Membership.user_id == user.id).all()
+    assert len(memberships) == 1
+
+
+def test_ensure_personal_tenant_falls_back_on_concurrent_insert_race(db):
+    user = _make_user(db, "carol@example.com")
+    existing = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert result.id == existing.id
+
+
+# ── get_or_create_membership / update_membership_role / delete_membership ────
+
+def test_get_or_create_membership_creates_new(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "dave@example.com")
+
+    membership = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert membership.tenant_id == tenant.id
+    assert membership.user_id == user.id
+    assert membership.role == "member"
+
+
+def test_get_or_create_membership_idempotent(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "erin@example.com")
+
+    first = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+    second = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert second.id == first.id
+
+
+def test_update_membership_role_updates_existing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "frank@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    updated = tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert updated.role == "admin"
+
+
+def test_update_membership_role_returns_none_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "grace@example.com")
+
+    result = tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert result is None
+
+
+def test_delete_membership_removes_row(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "heidi@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)
+
+    remaining = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert remaining is None
+
+
+def test_delete_membership_is_a_noop_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "ivan@example.com")
+
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)  # must not raise


### PR DESCRIPTION
## Summary

Issue #190 (S2 multi-tenancy), PR 4 of the 7-PR breakdown: dual-write application code. Every place that creates an `Org`, `OrgMembership`, `User`, `GitHubInstallation`, or `Invitation` row now also creates/updates the matching `Tenant`/`Membership` row(s), so the `tenants`/`memberships` tables (added in PRs 2-3) become accurate going forward. Per the design comment on #190: "Phase B (dual-write, no enforcement — app code writes tenants/memberships alongside existing tables, reads unchanged)."

**No schema change in this PR** — no new migration, no column added. All the `tenant_id` columns this PR populates already exist (added nullable in PR 3, migrations `0024`-`0026`). This PR only adds application code that writes to them.

**Base branch note:** targets `190-personal-tenants-remaining-columns` (#321), which is the actual head of the merged PR 1-3 chain — not `190-worker-db-credential-separation`, which only received PR 2's (#320's) commits when it merged; PR 3's (#321's) commits landed on a different branch (`190-tenants-memberships-schema`) and never propagated back. Retarget to `main` once the full chain merges.

## What changed

Every write path in scope was already centralized in a handful of repository functions (not scattered across routers), which is what made this safe to wire without touching callers:

- **New `apps/api/src/repositories/tenant_repo.py`** — centralizes all `Tenant`/`Membership` writes (`get_or_create_org_tenant`, `ensure_personal_tenant`, `get_or_create_membership`, `update_membership_role`, `delete_membership`), following the same get-or-create + `IntegrityError`-retry pattern already used by `org_repo`/`org_membership_repo`/`installation_repo`.
- **`org_repo.get_or_create`** — every return path now ensures `org.tenant_id` is set (self-healing: also lazily backfills orgs created before this PR shipped, not just newly created ones).
- **`org_membership_repo.get_or_create` / `update_role` / `delete`** — each now mirrors the `OrgMembership` write onto `Membership`, resolved via the org's tenant. Covers all 6 real call sites (`org_provisioning.py`'s reconcile loop, `installations.py`'s bootstrap-admin, `invitations.py`'s accept) automatically since they all funnel through these three functions.
- **`installation_repo.upsert`** — sets `tenant_id` on both the insert and update branches: the org's tenant for org-scoped installs, the owner's personal tenant for personal installs.
- **`invitation_repo.create`** — sets `tenant_id` from the inviting org's tenant.
- **`auth.py` `setup()` / `register()`, `github_auth.py` `find_or_create_user()`** — each new user gets a personal `Tenant` + self-`Membership` (role `'admin'`), mirroring exactly what migration `0023_backfill_personal_tenants.py` already does for pre-existing users. Only the new-user branch of `find_or_create_user` is wired — the returning-user branch doesn't create a row, so there's nothing to dual-write there.

Explicitly **out of scope**: `ScanResult`/`SavedToken` writes — their `tenant_id` columns are documented in `db.py` as best-effort-backfilled-by-migration-only, and the design comment doesn't list them under dual-write.

Not wiring lazy backfill on login/read paths for users created between migration `0023`'s backfill and this PR shipping — accepted gap, same pattern as `orgs.tenant_id` in PR 3 (reconciled later via a verification query if needed, not this PR's job).

## Test plan

- [x] New `apps/api/tests/test_tenant_repo.py` — unit tests for every `tenant_repo` function (create, idempotent get-or-create, update, delete, concurrent-insert race recovery).
- [x] New `apps/api/tests/test_org_membership_repo.py` — asserts `Membership` rows are created/updated/deleted in lockstep with `OrgMembership` across all three functions, and that every membership in an org shares the same tenant.
- [x] Extended `test_org_repo.py` — asserts `org.tenant_id` is set after `get_or_create`, and that a pre-existing untenanted org self-heals on next resolution.
- [x] Extended `test_installation_repo.py` — asserts `tenant_id` set correctly for org-scoped and personal installations, and on the update branch.
- [x] Extended `test_invitations.py` — asserts `Invitation.tenant_id` set on creation via the router.
- [x] Extended `test_auth.py` and `test_github_auth.py` — assert a personal `Tenant` + self-`Membership` (role='admin') exists after each of the three user-creation paths; confirmed the returning-GitHub-user branch does *not* duplicate the tenant.
- [x] `pytest -q` — 633 passed (up from 606 before this PR).
- [x] Manual spot-check against real Postgres: created an org via `org_repo.get_or_create` and confirmed `orgs.tenant_id` + a matching `tenants` row; created a user via `tenant_repo.ensure_personal_tenant` and confirmed both the personal `tenants` row and its `role='admin'` `memberships` row. Cleaned up afterward.
- [x] `bun run check` (typecheck + lint + build) via the pre-commit hook — passed (no UI files touched by this PR).
- [x] `bun run test` via the pre-push hook — passed (388 UI tests; two earlier push attempts hit unrelated pre-existing flaky UI tests under local resource contention, both unrelated to this PR's files — resolved on retry).
- [x] `ruff check` on all touched Python files — clean.
