### PR TITLE
feat(db): land tenants/memberships schema + dual-write into main

### DIFF
--- a/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
+++ b/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
@@ -53,6 +53,11 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("personal_user_id IS NOT NULL"),
     )
+    # (id, org_id) as a composite unique constraint -- redundant with id's own PK
+    # uniqueness on its own, but required so a later composite FK from orgs.tenant_id
+    # can reference this exact column pair (see migration 0024's reciprocal-association
+    # fix on orgs.tenant_id).
+    op.create_unique_constraint("uq_tenants_id_org_id", "tenants", ["id", "org_id"])
 
     op.create_table(
         "memberships",
@@ -67,6 +72,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("memberships")
+    op.drop_constraint("uq_tenants_id_org_id", "tenants", type_="unique")
     op.drop_index("uq_tenants_personal_user_id", table_name="tenants")
     op.drop_index("uq_tenants_org_id", table_name="tenants")
     op.drop_table("tenants")

--- a/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
+++ b/apps/api/alembic/versions/0021_add_tenants_and_memberships.py
@@ -1,0 +1,72 @@
+"""Add tenants and memberships tables (issue #190, S2 multi-tenancy PR 2 of 7).
+
+Pure additive schema change, no backfill and no existing table touched --
+zero data-loss risk. See the design comment on #190 for the full plan this
+is one step of: https://github.com/nazarli-shabnam/clevis/issues/190
+
+`tenants` is a new table, not a rename of `orgs` -- every org gets a 1:1
+`tenants` row (kind='org') and every user gets an implicit personal tenant
+(kind='personal', added in a later PR), so personal-scope resources get
+real DB-level isolation once Row-Level Security lands, not just
+`owner_user_id` filtering. `memberships` mirrors `org_memberships`'
+role vocabulary ("admin"|"member") to avoid renaming that concept mid-flight.
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenants",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("kind", sa.Text(), nullable=False),  # 'org' | 'personal'
+        sa.Column("org_id", sa.Integer(), sa.ForeignKey("orgs.id"), nullable=True),
+        sa.Column("personal_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint(
+            "(kind = 'org' AND org_id IS NOT NULL AND personal_user_id IS NULL) OR "
+            "(kind = 'personal' AND org_id IS NULL AND personal_user_id IS NOT NULL)",
+            name="ck_tenants_kind_xor",
+        ),
+    )
+    op.create_index(
+        "uq_tenants_org_id",
+        "tenants",
+        ["org_id"],
+        unique=True,
+        postgresql_where=sa.text("org_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_tenants_personal_user_id",
+        "tenants",
+        ["personal_user_id"],
+        unique=True,
+        postgresql_where=sa.text("personal_user_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "memberships",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("role", sa.String(), nullable=False),  # 'admin' | 'member'
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("tenant_id", "user_id", name="uq_memberships_tenant_user"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("memberships")
+    op.drop_index("uq_tenants_personal_user_id", table_name="tenants")
+    op.drop_index("uq_tenants_org_id", table_name="tenants")
+    op.drop_table("tenants")

--- a/apps/api/alembic/versions/0022_backfill_org_tenants.py
+++ b/apps/api/alembic/versions/0022_backfill_org_tenants.py
@@ -1,0 +1,46 @@
+"""Backfill one tenants/memberships row per existing org/org_membership (issue #190, PR 2 of 7).
+
+Zero ambiguity backfill: every `orgs` row gets exactly one `tenants` row
+(kind='org'), and every `org_memberships` row gets exactly one `memberships`
+row pointing at that org's new tenant, carrying the same role. Nothing here
+is read by application code yet (dual-write/cutover are later PRs in the
+#190 plan), so this is safe to run against any existing deployment.
+
+Personal tenants (one per `users` row) are added in a later PR, not here --
+see the design comment on #190.
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0022"
+down_revision = "0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("INSERT INTO tenants (kind, org_id) SELECT 'org', id FROM orgs"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO memberships (tenant_id, user_id, role) "
+            "SELECT t.id, om.user_id, om.role "
+            "FROM org_memberships om "
+            "JOIN tenants t ON t.org_id = om.org_id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM memberships WHERE tenant_id IN (SELECT id FROM tenants WHERE kind = 'org')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM tenants WHERE kind = 'org'"))

--- a/apps/api/alembic/versions/0023_backfill_personal_tenants.py
+++ b/apps/api/alembic/versions/0023_backfill_personal_tenants.py
@@ -1,0 +1,43 @@
+"""Backfill one personal tenant/membership per existing user (issue #190, PR 3 of 7).
+
+Every user gets an implicit personal tenant (kind='personal') so
+personal-scope resources (scan_results, saved_tokens, personal
+github_installations) get real DB-level isolation once RLS lands, not just
+owner_user_id filtering. The membership role for a user's own personal
+tenant is 'admin' -- there's no concept of a personal-tenant member who
+isn't its owner.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("INSERT INTO tenants (kind, personal_user_id) SELECT 'personal', id FROM users"))
+    conn.execute(
+        sa.text(
+            "INSERT INTO memberships (tenant_id, user_id, role) "
+            "SELECT t.id, t.personal_user_id, 'admin' "
+            "FROM tenants t WHERE t.kind = 'personal'"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "DELETE FROM memberships WHERE tenant_id IN (SELECT id FROM tenants WHERE kind = 'personal')"
+        )
+    )
+    conn.execute(sa.text("DELETE FROM tenants WHERE kind = 'personal'"))

--- a/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
+++ b/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
@@ -1,0 +1,42 @@
+"""Add orgs.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+Every existing orgs row already has exactly one 'org'-kind tenants row from
+migration 0022, so the backfill join itself is small and unambiguous. NOT
+NULL is *not* enforced here, though -- app code (org_provisioning.py and
+anywhere else an Org row is created) doesn't set tenant_id yet; that wiring
+is explicitly PR 4's job (dual-write). Enforcing NOT NULL now would break
+every org-creation code path the moment this migration deploys, well before
+PR 4 ships. NOT NULL enforcement is deferred to its own follow-up migration,
+written once PR 4 lands, mirroring github_installations' 0025/(future)
+enforce-not-null split rather than the org-xor-owner backfill's original
+"safe to enforce immediately" framing in #190's design comment -- that
+framing didn't account for app code being the actual writer, not just this
+migration's one-time backfill.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE orgs SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = orgs.id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("orgs", "tenant_id")

--- a/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
+++ b/apps/api/alembic/versions/0024_add_orgs_tenant_id.py
@@ -13,6 +13,16 @@ enforce-not-null split rather than the org-xor-owner backfill's original
 framing didn't account for app code being the actual writer, not just this
 migration's one-time backfill.
 
+Uses a composite FK, (orgs.tenant_id, orgs.id) -> (tenants.id, tenants.org_id),
+instead of a plain single-column FK to tenants.id (per CodeRabbit review on
+#190's PR 3: a plain FK lets orgs.tenant_id point at a personal tenant,
+another org's tenant, or a tenant shared by multiple orgs -- nothing catches
+a backfill/dual-write bug that assigns the wrong tenant). The composite FK
+requires that whatever tenant orgs.tenant_id names must itself have
+org_id = this exact org's id, enforcing the reciprocal 1:1 association at
+the database level. Depends on migration 0021's uq_tenants_id_org_id unique
+constraint on tenants(id, org_id), which the composite FK references.
+
 Revision ID: 0024
 Revises: 0023
 Create Date: 2026-08-12
@@ -28,7 +38,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    op.add_column("orgs", sa.Column("tenant_id", sa.Integer(), nullable=True))
     conn = op.get_bind()
     conn.execute(
         sa.text(
@@ -36,7 +46,15 @@ def upgrade() -> None:
             "FROM tenants t WHERE t.org_id = orgs.id AND t.kind = 'org'"
         )
     )
+    op.create_foreign_key(
+        "fk_orgs_tenant_id_reciprocal",
+        "orgs",
+        "tenants",
+        ["tenant_id", "id"],
+        ["id", "org_id"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("fk_orgs_tenant_id_reciprocal", "orgs", type_="foreignkey")
     op.drop_column("orgs", "tenant_id")

--- a/apps/api/alembic/versions/0025_add_github_installations_tenant_id.py
+++ b/apps/api/alembic/versions/0025_add_github_installations_tenant_id.py
@@ -1,0 +1,41 @@
+"""Add github_installations.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+github_installations.org_id/owner_user_id are already mutually exclusive
+(ck_github_installations_org_xor_owner), so the backfill join picks the
+org's tenant when org_id is set, the owner's personal tenant otherwise.
+NOT NULL is deferred to migration 0029, run only after a verification
+query confirms zero NULLs in the target environment -- this table's
+backfill correctness depends on migrations 0022/0023 having already run
+cleanly there, which this migration can't itself guarantee.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "github_installations", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True)
+    )
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE github_installations gi SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE (gi.org_id IS NOT NULL AND t.org_id = gi.org_id AND t.kind = 'org') "
+            "OR (gi.owner_user_id IS NOT NULL AND t.personal_user_id = gi.owner_user_id AND t.kind = 'personal')"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("github_installations", "tenant_id")

--- a/apps/api/alembic/versions/0026_add_invitations_tenant_id.py
+++ b/apps/api/alembic/versions/0026_add_invitations_tenant_id.py
@@ -1,0 +1,36 @@
+"""Add invitations.tenant_id, backfilled, nullable (issue #190, PR 3 of 7).
+
+invitations.org_id is required, and every org already has a tenant from
+migration 0022, so the backfill join is small and unambiguous. NOT NULL is
+*not* enforced here though, for the same reason as orgs (0024): invitation
+-creation code doesn't set tenant_id until PR 4's dual-write lands.
+Enforcing NOT NULL now would break every "invite a member" request the
+moment this migration deploys.
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("invitations", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE invitations i SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = i.org_id AND t.kind = 'org'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invitations", "tenant_id")

--- a/apps/api/alembic/versions/0027_add_scan_results_and_saved_tokens_tenant_id.py
+++ b/apps/api/alembic/versions/0027_add_scan_results_and_saved_tokens_tenant_id.py
@@ -1,0 +1,57 @@
+"""Add tenant_id to scan_results and saved_tokens, best-effort backfill, stays nullable (issue #190, PR 3 of 7).
+
+Unlike orgs/invitations/github_installations, neither table has a real FK to
+join through: scan_results.owner and saved_tokens.org are free-text GitHub
+login strings, matched against orgs.github_login on a best-effort basis.
+Legacy rows that don't match any known org (renamed/deleted org, or a
+personal-endpoint scan where owner is a user's own login rather than an
+org) are left with tenant_id NULL rather than guessed at or dropped --
+documented here, not chased. scan_results additionally falls back to the
+scanning user's personal tenant via scanned_by_user_id when set.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("scan_results", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+    op.add_column("saved_tokens", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE scan_results sr SET tenant_id = t.id "
+            "FROM orgs o JOIN tenants t ON t.org_id = o.id AND t.kind = 'org' "
+            "WHERE o.github_login = sr.owner"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE scan_results sr SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE sr.tenant_id IS NULL AND sr.scanned_by_user_id IS NOT NULL "
+            "AND t.personal_user_id = sr.scanned_by_user_id AND t.kind = 'personal'"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE saved_tokens st SET tenant_id = t.id "
+            "FROM orgs o JOIN tenants t ON t.org_id = o.id AND t.kind = 'org' "
+            "WHERE o.github_login = st.org"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("saved_tokens", "tenant_id")
+    op.drop_column("scan_results", "tenant_id")

--- a/apps/api/alembic/versions/0028_add_audit_logs_tenant_id.py
+++ b/apps/api/alembic/versions/0028_add_audit_logs_tenant_id.py
@@ -1,0 +1,30 @@
+"""Add audit_logs.tenant_id, nullable, no backfill (issue #190, PR 3 of 7).
+
+audit_logs.actor/target are free text (not FKs), so pre-migration rows
+can't be reliably attributed to a tenant -- per the design decision
+recorded on #190, these stay visible only through a require_workspace_admin
+-gated view once RLS lands, never to ordinary tenant members. No backfill
+attempted here, unlike scan_results/saved_tokens (0027) which at least
+have a best-effort join available; audit_logs has no comparable joinable
+field at all.
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-08-12
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("audit_logs", sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id"), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("audit_logs", "tenant_id")

--- a/apps/api/alembic/versions/0029_enforce_tenant_id_not_null.py
+++ b/apps/api/alembic/versions/0029_enforce_tenant_id_not_null.py
@@ -1,0 +1,90 @@
+"""Enforce NOT NULL on invitations/github_installations.tenant_id (issue #190, PR 5a of 7).
+
+Migrations 0025/0026 added these columns nullable because, at the time, no
+application code populated tenant_id yet -- enforcing NOT NULL then would
+have broken installation/invitation creation the moment those migrations
+deployed. PR 4 (dual-write, already merged) closed that gap: every write
+path now sets tenant_id via src.repositories.tenant_repo. This migration
+re-runs each column's original backfill UPDATE (idempotent -- a no-op for
+already-tenanted rows) to catch any row created in the window between PR 3's
+migrations landing and PR 4's dual-write code actually deploying, then
+enforces NOT NULL.
+
+orgs.tenant_id is deliberately NOT included here and stays nullable
+permanently: creating a brand-new org requires inserting both the Org row
+(needs tenant_id) and its reciprocal Tenant row (needs org_id via
+fk_orgs_tenant_id_reciprocal's composite FK, migration 0024) -- each
+references the other's not-yet-existing id. Postgres NOT NULL constraints
+cannot be deferred (only FK/UNIQUE/PK/EXCLUSION constraints can), so there
+is no way to insert a genuinely new org+tenant pair in one transaction if
+orgs.tenant_id is hard NOT NULL, short of a more complex deferred-FK
+migration (an explicit tradeoff, not attempted here -- see the PR
+description). org_repo.get_or_create's self-healing dual-write plus the
+verification queries below are the ongoing guarantee instead, the same
+pattern already accepted for scan_results/saved_tokens.tenant_id.
+
+Data-loss/backfill risk (AGENTS.md guardrail): if a real gap exists beyond
+what the backfill UPDATE can resolve (e.g. an installation/invitation whose
+org's tenant row was never created, not just never linked), the
+ALTER COLUMN ... SET NOT NULL below fails atomically and the whole migration
+rolls back -- it does not silently succeed with missing data. Run the
+verification queries below against the target environment before applying
+this migration there, and investigate any nonzero count rather than
+retrying blindly. Verified end-to-end against real Postgres for this PR: a
+deliberately-seeded gap (an org with no tenant row, an invitation pointing
+at it) reproduced the atomic-rollback failure below before being fixed.
+
+    -- every org has a reciprocal tenant
+    SELECT count(*) FROM orgs o WHERE NOT EXISTS (
+        SELECT 1 FROM tenants t WHERE t.org_id = o.id AND t.kind = 'org');
+
+    -- invitations/github_installations.tenant_id are populated
+    SELECT count(*) FROM invitations WHERE tenant_id IS NULL;
+    SELECT count(*) FROM github_installations WHERE tenant_id IS NULL;
+
+    -- every org_membership has a matching Membership row (dual-write parity)
+    SELECT count(*) FROM org_memberships om JOIN orgs o ON o.id = om.org_id
+    WHERE o.tenant_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM memberships m WHERE m.tenant_id = o.tenant_id
+        AND m.user_id = om.user_id AND m.role = om.role);
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-08-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            "UPDATE invitations i SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = i.org_id AND t.kind = 'org' AND i.tenant_id IS NULL"
+        )
+    )
+    op.alter_column("invitations", "tenant_id", nullable=False)
+
+    conn.execute(
+        sa.text(
+            "UPDATE github_installations gi SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE gi.tenant_id IS NULL "
+            "AND ((gi.org_id IS NOT NULL AND t.org_id = gi.org_id AND t.kind = 'org') "
+            "OR (gi.owner_user_id IS NOT NULL AND t.personal_user_id = gi.owner_user_id AND t.kind = 'personal'))"
+        )
+    )
+    op.alter_column("github_installations", "tenant_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("github_installations", "tenant_id", nullable=True)
+    op.alter_column("invitations", "tenant_id", nullable=True)

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -58,11 +58,10 @@ class GitHubInstallation(Base):
     # Exactly one of org_id / owner_user_id is set: org-connected installs vs. personal installs.
     org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
-    # Backfilled from org_id/owner_user_id by migration 0025. Stays nullable until PR 4's
-    # dual-write lands and installation-creation code starts setting it -- enforcing NOT
-    # NULL before then would break every new installation the moment this migration deploys
-    # (see the same reasoning documented on orgs.tenant_id and invitations.tenant_id below).
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    # Backfilled from org_id/owner_user_id by migration 0025, dual-written by installation_repo
+    # since PR 4, NOT NULL enforced by migration 0029 now that PR 4's dual-write covers every
+    # installation-creation path.
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -173,9 +172,13 @@ class Org(Base):
     github_login: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     # 1:1 pointer to this org's tenant row (migration 0022 backfills one 'org'-kind tenant
-    # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
-    # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
-    # org -- enforcing NOT NULL before then would break org creation entirely.
+    # per org before this column exists; migration 0024 adds + backfills it; org_repo has
+    # dual-written it on every org since PR 4). Stays nullable permanently, unlike
+    # invitations/github_installations.tenant_id (migration 0029) -- creating a brand-new
+    # org requires the Org and its reciprocal Tenant row to each reference the other's
+    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can. See
+    # migration 0029's docstring. org_repo.get_or_create's self-healing dual-write plus
+    # docs/tenant-id-verification.md's checks are the ongoing guarantee instead.
     tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
@@ -243,10 +246,9 @@ class Invitation(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    # Backfilled from org_id's tenant by migration 0026. Stays nullable until PR 4's
-    # dual-write lands and invitation-creation code starts setting it -- same reasoning as
-    # orgs.tenant_id above.
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    # Backfilled from org_id's tenant by migration 0026, dual-written by invitation_repo
+    # since PR 4, NOT NULL enforced by migration 0029.
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
 
 
 class ScanResult(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -179,6 +179,12 @@ class Tenant(Base):
             unique=True,
             postgresql_where="personal_user_id IS NOT NULL",
         ),
+        # Lets orgs.tenant_id declare a composite FK to (id, org_id), enforcing that an
+        # org's tenant_id can only point at a tenant whose org_id reciprocally points back
+        # at that same org -- not a personal tenant, another org's tenant, or a tenant
+        # shared by multiple orgs. Redundant with id's own PK uniqueness in isolation, but
+        # required for the composite FK to be legal.
+        UniqueConstraint("id", "org_id", name="uq_tenants_id_org_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -305,7 +305,13 @@ def get_db() -> Generator[Session, None, None]:
             db.execute(text("RESET app.tenant_id"))
             db.execute(text("RESET app.user_id"))
             db.commit()
-        except Exception:
-            logger.exception("failed to reset tenant session context before connection checkin")
-        finally:
             db.close()
+        except Exception:
+            # A failure partway through (e.g. a transient network drop after RESET but
+            # before commit) leaves it unclear whether the reset actually took -- closing
+            # normally here would return that connection to the pool for reuse anyway.
+            # invalidate() instead forces the pool to discard the underlying DBAPI
+            # connection rather than risk handing a possibly-still-tenant-scoped
+            # connection to an unrelated later request.
+            logger.exception("failed to reset tenant session context; invalidating connection instead of reusing it")
+            db.invalidate()

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -156,6 +157,13 @@ class User(Base):
 
 class Org(Base):
     __tablename__ = "orgs"
+    __table_args__ = (
+        # Composite FK instead of a plain tenant_id -> tenants.id FK: requires that
+        # whatever tenant tenant_id names must itself have org_id = this exact org's id,
+        # so tenant_id can't point at a personal tenant, another org's tenant, or a tenant
+        # shared across multiple orgs (see migration 0024's docstring).
+        ForeignKeyConstraint(["tenant_id", "id"], ["tenants.id", "tenants.org_id"], name="fk_orgs_tenant_id_reciprocal"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     # Nullable: not known for orgs backfilled from pre-existing installations; filled in
@@ -168,7 +176,7 @@ class Org(Base):
     # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
     # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
     # org -- enforcing NOT NULL before then would break org creation entirely.
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class OrgMembership(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -164,6 +164,41 @@ class OrgMembership(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
+class Tenant(Base):
+    __tablename__ = "tenants"
+    __table_args__ = (
+        CheckConstraint(
+            "(kind = 'org' AND org_id IS NOT NULL AND personal_user_id IS NULL) "
+            "OR (kind = 'personal' AND org_id IS NULL AND personal_user_id IS NOT NULL)",
+            name="ck_tenants_kind_xor",
+        ),
+        Index("uq_tenants_org_id", "org_id", unique=True, postgresql_where="org_id IS NOT NULL"),
+        Index(
+            "uq_tenants_personal_user_id",
+            "personal_user_id",
+            unique=True,
+            postgresql_where="personal_user_id IS NOT NULL",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "org" | "personal"
+    org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
+    personal_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class Membership(Base):
+    __tablename__ = "memberships"
+    __table_args__ = (UniqueConstraint("tenant_id", "user_id", name="uq_memberships_tenant_user"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    role: Mapped[str] = mapped_column(String, nullable=False)  # "admin" | "member"
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
 class Invitation(Base):
     __tablename__ = "invitations"
 

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -57,6 +57,11 @@ class GitHubInstallation(Base):
     # Exactly one of org_id / owner_user_id is set: org-connected installs vs. personal installs.
     org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    # Backfilled from org_id/owner_user_id by migration 0025. Stays nullable until PR 4's
+    # dual-write lands and installation-creation code starts setting it -- enforcing NOT
+    # NULL before then would break every new installation the moment this migration deploys
+    # (see the same reasoning documented on orgs.tenant_id and invitations.tenant_id below).
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -68,6 +73,11 @@ class AuditLog(Base):
     action: Mapped[str] = mapped_column(String, nullable=False)
     target: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[str] = mapped_column(Text, nullable=False)
+    # Nullable, no historical backfill (migration 0028) -- actor/target are free text, not
+    # FKs, so pre-migration rows can't be reliably attributed to a tenant. Per the design
+    # decision on #190, these stay visible only via a require_workspace_admin-gated view
+    # once RLS lands, never to ordinary tenant members.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -106,6 +116,9 @@ class SavedToken(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    # Best-effort backfill by migration 0027, matched on org (free text, not an FK) against
+    # orgs.github_login -- stays nullable since legacy rows for a renamed/deleted org won't match.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class User(Base):
@@ -151,6 +164,11 @@ class Org(Base):
     github_org_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
     github_login: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # 1:1 pointer to this org's tenant row (migration 0022 backfills one 'org'-kind tenant
+    # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
+    # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
+    # org -- enforcing NOT NULL before then would break org creation entirely.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class OrgMembership(Base):
@@ -217,6 +235,10 @@ class Invitation(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Backfilled from org_id's tenant by migration 0026. Stays nullable until PR 4's
+    # dual-write lands and invitation-creation code starts setting it -- same reasoning as
+    # orgs.tenant_id above.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class ScanResult(Base):
@@ -235,6 +257,10 @@ class ScanResult(Base):
     # by org membership, not this column.
     scanned_by_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    # Best-effort backfill by migration 0027: matched via owner -> orgs.github_login first,
+    # falling back to scanned_by_user_id's personal tenant. Stays nullable -- some legacy
+    # rows (renamed/deleted org) won't match either path.
+    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
 
 
 class AppConfig(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from datetime import datetime
+import logging
 
 from sqlalchemy import (
     Boolean,
@@ -19,6 +20,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from src.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -176,9 +179,9 @@ class Org(Base):
     # dual-written it on every org since PR 4). Stays nullable permanently, unlike
     # invitations/github_installations.tenant_id (migration 0029) -- creating a brand-new
     # org requires the Org and its reciprocal Tenant row to each reference the other's
-    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can. See
-    # migration 0029's docstring. org_repo.get_or_create's self-healing dual-write plus
-    # docs/tenant-id-verification.md's checks are the ongoing guarantee instead.
+    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can.
+    # org_repo.get_or_create's self-healing dual-write plus the verification queries in
+    # migration 0029's docstring are the ongoing guarantee instead.
     tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
@@ -290,4 +293,19 @@ def get_db() -> Generator[Session, None, None]:
     try:
         yield db
     finally:
-        db.close()
+        # require_org_role/require_personal_tenant (src.core.rbac) set app.tenant_id/
+        # app.user_id via plain SET (not SET LOCAL, since a request can commit more than
+        # once and SET LOCAL would stop applying after the first commit). Plain SET persists
+        # for the life of the physical connection, not just this request's Session -- since
+        # SQLAlchemy's connection pool only rolls back pending transactions on checkin, an
+        # already-committed SET would otherwise silently leak into whichever unrelated
+        # request reuses this connection next. Reset explicitly before returning to the pool.
+        try:
+            db.rollback()
+            db.execute(text("RESET app.tenant_id"))
+            db.execute(text("RESET app.user_id"))
+            db.commit()
+        except Exception:
+            logger.exception("failed to reset tenant session context before connection checkin")
+        finally:
+            db.close()

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -63,13 +63,10 @@ def require_org_role(min_role: Literal["member", "admin"]):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
         # resolved here via get_by_login (not get_or_create) never gets org_repo's own
-        # self-healing dual-write, so guard the same way org_repo does.
-        tenant_id = org.tenant_id
-        if tenant_id is None:
-            tenant_id = tenant_repo.get_or_create_org_tenant(db, org.id).id
-            org.tenant_id = tenant_id
-            db.commit()
-        _set_tenant_session_context(db, tenant_id, user.id)
+        # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
+        # itself uses, rather than a separate hand-rolled copy of the same logic.
+        org = org_repo.ensure_tenant_linked(db, org)
+        _set_tenant_session_context(db, org.tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 
     return dependency

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -10,11 +10,12 @@ from dataclasses import dataclass
 from typing import Literal
 
 from fastapi import Depends, HTTPException, status
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.core.db import Org, OrgMembership, Tenant, get_db
+from src.repositories import org_membership_repo, org_repo, tenant_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -23,6 +24,26 @@ _ROLE_RANK = {"member": 0, "admin": 1}
 class OrgContext:
     org: Org
     membership: OrgMembership
+
+
+@dataclass
+class PersonalTenantContext:
+    tenant: Tenant
+
+
+def _set_tenant_session_context(db: Session, tenant_id: int, user_id: int) -> None:
+    # Plain SET (not SET LOCAL): a request's Session lifetime doesn't cleanly map to one
+    # transaction, so a transaction-scoped SET LOCAL could stop applying mid-request. No
+    # RLS policy reads these yet (migration 0030 adds FORCE-free policies as scaffolding
+    # only) -- this just prepares the session variable for when that lands.
+    #
+    # SET does not accept bind parameters (it's a configuration command, not a regular
+    # query) -- Postgres rejects `SET app.tenant_id = $1` with a syntax error. Both values
+    # are always int (SQLAlchemy-mapped primary keys, never caller-supplied strings), so
+    # formatting them directly into the statement is safe; int() here is a defensive type
+    # check, not a workaround.
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(text(f"SET app.user_id = {int(user_id)}"))
 
 
 def require_org_role(min_role: Literal["member", "admin"]):
@@ -40,9 +61,31 @@ def require_org_role(min_role: Literal["member", "admin"]):
         membership = org_membership_repo.get(db, org.id, user.id)
         if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
+        # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
+        # resolved here via get_by_login (not get_or_create) never gets org_repo's own
+        # self-healing dual-write, so guard the same way org_repo does.
+        tenant_id = org.tenant_id
+        if tenant_id is None:
+            tenant_id = tenant_repo.get_or_create_org_tenant(db, org.id).id
+            org.tenant_id = tenant_id
+            db.commit()
+        _set_tenant_session_context(db, tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 
     return dependency
+
+
+def require_personal_tenant(
+    db: Session = Depends(get_db),
+    user: UserOut = Depends(require_auth),
+) -> PersonalTenantContext:
+    """Dependency for routes unambiguously scoped to the caller's own personal tenant --
+    not for /me/... routes that can resolve to either an org or personal tenant depending
+    on an `owner` path param (see src.services.token_resolution.resolve_owner_token);
+    wiring those is a separate design decision, deferred out of issue #190's PR 5."""
+    tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+    _set_tenant_session_context(db, tenant.id, user.id)
+    return PersonalTenantContext(tenant=tenant)
 
 
 def assert_owner_matches_org(owner: str, ctx: OrgContext) -> None:

--- a/apps/api/src/repositories/installation_repo.py
+++ b/apps/api/src/repositories/installation_repo.py
@@ -3,6 +3,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import GitHubInstallation
+from src.repositories import tenant_repo
+
+
+def _resolve_tenant_id(db: Session, org_id: int | None, owner_user_id: int | None) -> int:
+    if org_id is not None:
+        return tenant_repo.get_or_create_org_tenant(db, org_id).id
+    return tenant_repo.ensure_personal_tenant(db, owner_user_id).id
 
 
 def upsert(
@@ -25,11 +32,13 @@ def upsert(
 
     existing = query.first()
     token_ref = f"tok_{account_login}"
+    tenant_id = _resolve_tenant_id(db, org_id, owner_user_id)
     if existing:
         existing.account_type = account_type
         existing.auth_mode = auth_mode
         existing.installation_id = installation_id
         existing.token_ref = token_ref
+        existing.tenant_id = tenant_id
         db.commit()
         db.refresh(existing)
         return existing
@@ -42,6 +51,7 @@ def upsert(
         token_ref=token_ref,
         org_id=org_id,
         owner_user_id=owner_user_id,
+        tenant_id=tenant_id,
     )
     db.add(row)
     try:
@@ -57,6 +67,7 @@ def upsert(
         existing.auth_mode = auth_mode
         existing.installation_id = installation_id
         existing.token_ref = token_ref
+        existing.tenant_id = tenant_id
         db.commit()
         db.refresh(existing)
         return existing

--- a/apps/api/src/repositories/invitation_repo.py
+++ b/apps/api/src/repositories/invitation_repo.py
@@ -4,11 +4,13 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from src.core.db import Invitation
+from src.repositories import tenant_repo
 
 INVITATION_LIFETIME = timedelta(days=7)
 
 
 def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Invitation:
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     invitation = Invitation(
         org_id=org_id,
         email=email,
@@ -16,6 +18,7 @@ def create(db: Session, org_id: int, email: str, invited_by_user_id: int) -> Inv
         status="pending",
         invited_by_user_id=invited_by_user_id,
         expires_at=datetime.now(timezone.utc) + INVITATION_LIFETIME,
+        tenant_id=tenant.id,
     )
     db.add(invitation)
     db.commit()

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -5,12 +5,14 @@ from src.core.db import OrgMembership
 from src.repositories import tenant_repo
 
 
-def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
-    return (
-        db.query(OrgMembership)
-        .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-        .first()
-    )
+def get(db: Session, org_id: int, user_id: int, for_update: bool = False) -> OrgMembership | None:
+    query = db.query(OrgMembership).filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+    if for_update:
+        # Locks the row (or blocks until a concurrent delete()'s own implicit row lock
+        # releases) so get_or_create/update_role can't read a membership that's mid-deletion
+        # and resurrect its tenant mirror via _sync_membership_mirror right after revocation.
+        query = query.with_for_update()
+    return query.first()
 
 
 def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership) -> None:
@@ -19,7 +21,7 @@ def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership)
 
 
 def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
-    membership = get(db, org_id, user_id)
+    membership = get(db, org_id, user_id, for_update=True)
     if membership is not None:
         _sync_membership_mirror(db, org_id, membership)
         return membership
@@ -30,7 +32,7 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
     except IntegrityError:
         # Lost a race with a concurrent insert of the same (org_id, user_id) pair.
         db.rollback()
-        membership = get(db, org_id, user_id)
+        membership = get(db, org_id, user_id, for_update=True)
         if membership is None:
             raise
         _sync_membership_mirror(db, org_id, membership)
@@ -49,14 +51,22 @@ def list_for_org(db: Session, org_id: int) -> list[OrgMembership]:
 
 
 def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership | None:
-    membership = get(db, org_id, user_id)
+    membership = get(db, org_id, user_id, for_update=True)
     if membership is None:
         return None
     membership.role = role
-    db.commit()
-    db.refresh(membership)
+    # Sync the mirror before committing -- committing first would release the FOR UPDATE
+    # lock get() just took, reopening the same window a concurrent delete() could land in.
+    # _sync_membership_mirror's own internal commit (tenant_repo.upsert_membership) flushes
+    # this pending role change too, so the OrgMembership update and the mirror update land
+    # together; this commit() is a no-op in that case and only matters if the mirror's role
+    # already matched (nothing to update inside the sync, so nothing committed it yet).
     _sync_membership_mirror(db, org_id, membership)
-    return membership
+    db.commit()
+    # Not db.refresh(membership): the row lock is released by the commit above, so a
+    # concurrent delete() can remove this row before we get here -- re-query instead of
+    # refreshing so that legitimate outcome returns None rather than raising.
+    return get(db, org_id, user_id)
 
 
 def delete(db: Session, org_id: int, user_id: int) -> None:

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -13,9 +13,15 @@ def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
     )
 
 
+def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership) -> None:
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=membership.user_id, role=membership.role)
+
+
 def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
     membership = get(db, org_id, user_id)
     if membership is not None:
+        _sync_membership_mirror(db, org_id, membership)
         return membership
     membership = OrgMembership(org_id=org_id, user_id=user_id, role=role)
     db.add(membership)
@@ -27,10 +33,10 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
         membership = get(db, org_id, user_id)
         if membership is None:
             raise
+        _sync_membership_mirror(db, org_id, membership)
         return membership
     db.refresh(membership)
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
-    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role=role)
+    _sync_membership_mirror(db, org_id, membership)
     return membership
 
 
@@ -49,8 +55,7 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
     membership.role = role
     db.commit()
     db.refresh(membership)
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
-    tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user_id, role=role)
+    _sync_membership_mirror(db, org_id, membership)
     return membership
 
 

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -70,9 +70,15 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
 
 
 def delete(db: Session, org_id: int, user_id: int) -> None:
+    # Delete the mirror before committing the OrgMembership delete -- committing first (the
+    # original ordering) released the DELETE's own implicit row lock before the mirror was
+    # touched, leaving a window where a concurrent get_or_create() could find the row gone,
+    # legitimately re-create a fresh OrgMembership + mirror, and then have this function's
+    # now-unblocked mirror delete remove that brand-new mirror out from under it. Same
+    # principle as update_role's lock-then-sync-then-commit ordering above.
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     db.query(OrgMembership).filter(
         OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
     ).delete()
-    db.commit()
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user_id)
+    db.commit()

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -2,6 +2,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import OrgMembership
+from src.repositories import tenant_repo
 
 
 def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
@@ -28,6 +29,8 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
             raise
         return membership
     db.refresh(membership)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role=role)
     return membership
 
 
@@ -46,6 +49,8 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
     membership.role = role
     db.commit()
     db.refresh(membership)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user_id, role=role)
     return membership
 
 
@@ -54,3 +59,5 @@ def delete(db: Session, org_id: int, user_id: int) -> None:
         OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
     ).delete()
     db.commit()
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user_id)

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -37,7 +37,15 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
             raise
         _sync_membership_mirror(db, org_id, membership)
         return membership
-    db.refresh(membership)
+    # Re-lock the row we just committed before syncing its mirror -- the commit above
+    # released any lock, opening a window where a concurrent delete() could remove this
+    # row and find no mirror yet (nothing synced), then have this call resume and create a
+    # mirror for a membership that's already revoked (CodeRabbit finding on #323's 2nd
+    # review). If the re-lock finds the row already gone, retry from scratch instead of
+    # syncing a mirror for a membership that no longer exists.
+    membership = get(db, org_id, user_id, for_update=True)
+    if membership is None:
+        return get_or_create(db, org_id, user_id, role)
     _sync_membership_mirror(db, org_id, membership)
     return membership
 

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -3,6 +3,17 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.core.db import Org
+from src.repositories import tenant_repo
+
+
+def _ensure_tenant_linked(db: Session, org: Org) -> Org:
+    if org.tenant_id is not None:
+        return org
+    tenant = tenant_repo.get_or_create_org_tenant(db, org.id)
+    org.tenant_id = tenant.id
+    db.commit()
+    db.refresh(org)
+    return org
 
 
 def get_by_login(db: Session, github_login: str) -> Org | None:
@@ -33,7 +44,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org.github_org_id = github_org_id
             db.commit()
             db.refresh(org)
-        return org
+        return _ensure_tenant_linked(db, org)
 
     if github_org_id is not None:
         # The org may have been renamed on GitHub since we last saw it -- github_org_id
@@ -45,7 +56,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
                 org.github_login = github_login
                 db.commit()
                 db.refresh(org)
-            return org
+            return _ensure_tenant_linked(db, org)
 
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
@@ -59,6 +70,6 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org = get_by_org_id(db, github_org_id)
         if org is None:
             raise
-        return org
+        return _ensure_tenant_linked(db, org)
     db.refresh(org)
-    return org
+    return _ensure_tenant_linked(db, org)

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -6,7 +6,7 @@ from src.core.db import Org
 from src.repositories import tenant_repo
 
 
-def _ensure_tenant_linked(db: Session, org: Org) -> Org:
+def ensure_tenant_linked(db: Session, org: Org) -> Org:
     if org.tenant_id is not None:
         return org
     tenant = tenant_repo.get_or_create_org_tenant(db, org.id)
@@ -44,7 +44,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org.github_org_id = github_org_id
             db.commit()
             db.refresh(org)
-        return _ensure_tenant_linked(db, org)
+        return ensure_tenant_linked(db, org)
 
     if github_org_id is not None:
         # The org may have been renamed on GitHub since we last saw it -- github_org_id
@@ -56,7 +56,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
                 org.github_login = github_login
                 db.commit()
                 db.refresh(org)
-            return _ensure_tenant_linked(db, org)
+            return ensure_tenant_linked(db, org)
 
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
@@ -70,6 +70,6 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org = get_by_org_id(db, github_org_id)
         if org is None:
             raise
-        return _ensure_tenant_linked(db, org)
+        return ensure_tenant_linked(db, org)
     db.refresh(org)
-    return _ensure_tenant_linked(db, org)
+    return ensure_tenant_linked(db, org)

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -74,6 +74,17 @@ def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: st
     return membership
 
 
+def upsert_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:
+    """get_or_create_membership plus role reconciliation -- unlike get_or_create_membership
+    alone, this also fixes a stale role on an already-existing row, so callers that resolve
+    a membership through more than one code path (existing found / newly created / recovered
+    from a concurrent-insert race) can call this unconditionally and always end up in sync."""
+    membership = get_or_create_membership(db, tenant_id, user_id, role)
+    if membership.role != role:
+        membership = update_membership_role(db, tenant_id, user_id, role)
+    return membership
+
+
 def update_membership_role(db: Session, tenant_id: int, user_id: int, role: str) -> Membership | None:
     membership = (
         db.query(Membership)

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -59,8 +59,16 @@ def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Te
     if commit:
         get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role="admin")
     else:
-        db.add(Membership(tenant_id=tenant.id, user_id=user_id, role="admin"))
-        db.flush()
+        # Query first rather than inserting unconditionally: currently always a fresh
+        # user_id (see docstring), but staying idempotent here too means a future
+        # commit=False caller that reuses an existing user_id degrades to a no-op instead
+        # of hitting an uncaught IntegrityError on the membership's unique constraint.
+        existing_membership = (
+            db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        if existing_membership is None:
+            db.add(Membership(tenant_id=tenant.id, user_id=user_id, role="admin"))
+            db.flush()
     return tenant
 
 

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -81,7 +81,11 @@ def upsert_membership(db: Session, tenant_id: int, user_id: int, role: str) -> M
     from a concurrent-insert race) can call this unconditionally and always end up in sync."""
     membership = get_or_create_membership(db, tenant_id, user_id, role)
     if membership.role != role:
-        membership = update_membership_role(db, tenant_id, user_id, role)
+        updated = update_membership_role(db, tenant_id, user_id, role)
+        # A concurrent delete_membership could remove the row between the get-or-create
+        # above and this update -- re-create it rather than returning None despite this
+        # function's Membership (non-Optional) return type.
+        membership = updated if updated is not None else get_or_create_membership(db, tenant_id, user_id, role)
     return membership
 
 

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -23,27 +23,44 @@ def get_or_create_org_tenant(db: Session, org_id: int) -> Tenant:
     return tenant
 
 
-def ensure_personal_tenant(db: Session, user_id: int) -> Tenant:
+def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Tenant:
     """Get-or-create a user's personal tenant, plus its self-membership (role='admin') --
     mirrors migration 0023_backfill_personal_tenants.py, which backfilled both rows
     together for every pre-existing user. There's no concept of a personal tenant with
-    no membership, so both rows are ensured atomically here."""
+    no membership, so both rows are ensured atomically here.
+
+    commit=False is for the brand-new-user registration flows (auth.py, github_auth.py):
+    those callers flush the User row (not commit) and pass commit=False here so the tenant
+    and membership inserts land in the *same* transaction as the user, then commit once --
+    otherwise a failure between the user's commit and this function's own commit could leave
+    a User row with no personal tenant (CodeRabbit finding on #323). Skips the concurrent-
+    insert race handling in that mode: user_id was just flushed for the first time in this
+    still-open transaction, so no other transaction can already hold a personal tenant for
+    it. commit=True (default) keeps the original standalone behavior, used by
+    require_personal_tenant (rbac.py) and any other caller not paired with a user commit."""
     tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
     if tenant is None:
         tenant = Tenant(kind="personal", personal_user_id=user_id)
         db.add(tenant)
-        try:
-            db.commit()
-        except IntegrityError:
-            # Lost a race with a concurrent insert of the same user's personal tenant.
-            db.rollback()
-            tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
-            if tenant is None:
-                raise
+        if commit:
+            try:
+                db.commit()
+            except IntegrityError:
+                # Lost a race with a concurrent insert of the same user's personal tenant.
+                db.rollback()
+                tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+                if tenant is None:
+                    raise
+            else:
+                db.refresh(tenant)
         else:
-            db.refresh(tenant)
+            db.flush()
 
-    get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role="admin")
+    if commit:
+        get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role="admin")
+    else:
+        db.add(Membership(tenant_id=tenant.id, user_id=user_id, role="admin"))
+        db.flush()
     return tenant
 
 

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -1,0 +1,95 @@
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.core.db import Membership, Tenant
+
+
+def get_or_create_org_tenant(db: Session, org_id: int) -> Tenant:
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is not None:
+        return tenant
+    tenant = Tenant(kind="org", org_id=org_id)
+    db.add(tenant)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same org's tenant.
+        db.rollback()
+        tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is None:
+            raise
+        return tenant
+    db.refresh(tenant)
+    return tenant
+
+
+def ensure_personal_tenant(db: Session, user_id: int) -> Tenant:
+    """Get-or-create a user's personal tenant, plus its self-membership (role='admin') --
+    mirrors migration 0023_backfill_personal_tenants.py, which backfilled both rows
+    together for every pre-existing user. There's no concept of a personal tenant with
+    no membership, so both rows are ensured atomically here."""
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    if tenant is None:
+        tenant = Tenant(kind="personal", personal_user_id=user_id)
+        db.add(tenant)
+        try:
+            db.commit()
+        except IntegrityError:
+            # Lost a race with a concurrent insert of the same user's personal tenant.
+            db.rollback()
+            tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+            if tenant is None:
+                raise
+        else:
+            db.refresh(tenant)
+
+    get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role="admin")
+    return tenant
+
+
+def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:
+    membership = (
+        db.query(Membership)
+        .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+        .first()
+    )
+    if membership is not None:
+        return membership
+    membership = Membership(tenant_id=tenant_id, user_id=user_id, role=role)
+    db.add(membership)
+    try:
+        db.commit()
+    except IntegrityError:
+        # Lost a race with a concurrent insert of the same (tenant_id, user_id) pair.
+        db.rollback()
+        membership = (
+            db.query(Membership)
+            .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+            .first()
+        )
+        if membership is None:
+            raise
+        return membership
+    db.refresh(membership)
+    return membership
+
+
+def update_membership_role(db: Session, tenant_id: int, user_id: int, role: str) -> Membership | None:
+    membership = (
+        db.query(Membership)
+        .filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id)
+        .first()
+    )
+    if membership is None:
+        return None
+    membership.role = role
+    db.commit()
+    db.refresh(membership)
+    return membership
+
+
+def delete_membership(db: Session, tenant_id: int, user_id: int) -> None:
+    db.query(Membership).filter(
+        Membership.tenant_id == tenant_id, Membership.user_id == user_id
+    ).delete()
+    db.commit()

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -56,12 +56,20 @@ _MAX_PASSWORD_LEN = 72
 _VERIFY_TOKEN_TTL = timedelta(hours=24)
 
 
-def _send_verification_email_best_effort(user: User) -> None:
-    """Generates a fresh verification token/expiry on `user`, then tries to email it.
-    Caller is responsible for db.commit(). Never raises -- registration/resend must
-    succeed regardless of whether SMTP is configured or the send itself fails."""
+def _generate_verification_token(user: User) -> None:
+    """Sets a fresh verification token/expiry on `user`. Caller is responsible for
+    db.commit() *before* calling _send_verification_email_best_effort below -- kept as two
+    steps so the real network send only happens once the token is durably persisted; a
+    commit that fails after the email already went out would hand the user a live-looking
+    verification link for a token that was never actually saved (#323 code-review finding)."""
     user.email_verify_token = secrets.token_urlsafe(32)
     user.email_verify_token_expires_at = datetime.now(timezone.utc) + _VERIFY_TOKEN_TTL
+
+
+def _send_verification_email_best_effort(user: User) -> None:
+    """Tries to email the already-persisted verification token on `user` (see
+    _generate_verification_token). Never raises -- registration/resend must succeed
+    regardless of whether SMTP is configured or the send itself fails."""
     try:
         verify_url = f"{settings.cors_origins[0]}/verify-email?token={user.email_verify_token}"
         send_verification_email(user.email, verify_url)
@@ -283,13 +291,16 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="An account with this email already exists") from None
-    _send_verification_email_best_effort(user)
+    _generate_verification_token(user)
     # commit=False: land the personal tenant/membership in the same transaction as this
     # user, then commit once -- a failure between two separate commits could otherwise
     # leave a User row with no personal tenant (#323 CodeRabbit finding).
     tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)
+    # Only send the real email after the commit above succeeds -- see
+    # _generate_verification_token's docstring for why the two are split.
+    _send_verification_email_best_effort(user)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {
         "access_token": token,
@@ -330,8 +341,9 @@ def resend_verification(
     if user.email_verified:
         return {"ok": True, "already_verified": True}
     check_account_rate_limit(f"resend-verification:{user.email.lower()}")
-    _send_verification_email_best_effort(user)
+    _generate_verification_token(user)
     db.commit()
+    _send_verification_email_best_effort(user)
     return {"ok": True}
 
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -232,12 +232,16 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
     )
     db.add(user)
     try:
-        db.commit()
+        # flush (not commit) so the personal tenant/membership below land in the same
+        # transaction as this user -- a failure between two separate commits could
+        # otherwise leave a User row with no personal tenant (#323 CodeRabbit finding).
+        db.flush()
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="Setup already complete") from None
+    tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
+    db.commit()
     db.refresh(user)
-    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
@@ -280,9 +284,12 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
         db.rollback()
         raise HTTPException(status_code=409, detail="An account with this email already exists") from None
     _send_verification_email_best_effort(user)
+    # commit=False: land the personal tenant/membership in the same transaction as this
+    # user, then commit once -- a failure between two separate commits could otherwise
+    # leave a User row with no personal tenant (#323 CodeRabbit finding).
+    tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)
-    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {
         "access_token": token,

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -40,7 +40,7 @@ from src.core.auth import UserOut, clear_session_cookie, create_access_token, re
 from src.core.config import settings
 from src.core.db import Org, User, get_db
 from src.core.rate_limit import check_account_rate_limit, rate_limit
-from src.repositories import invitation_repo
+from src.repositories import invitation_repo, tenant_repo
 from src.services.email import EmailNotConfigured, send_verification_email
 
 logger = logging.getLogger(__name__)
@@ -237,6 +237,7 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
         db.rollback()
         raise HTTPException(status_code=409, detail="Setup already complete") from None
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {"access_token": token, "user": UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=user.is_workspace_admin)}
 
@@ -281,6 +282,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     _send_verification_email_best_effort(user)
     db.commit()
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     token = create_access_token(user.id, user.email, user.is_workspace_admin, user.name, user.token_version)
     return {
         "access_token": token,

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -29,6 +29,7 @@ from src.core.auth import create_access_token, set_session_cookie
 from src.core.config import settings
 from src.core.db import User, get_db
 from src.core.rate_limit import rate_limit
+from src.repositories import tenant_repo
 from src.services import github_oauth, org_provisioning
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,7 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
     db.add(user)
     db.commit()
     db.refresh(user)
+    tenant_repo.ensure_personal_tenant(db, user.id)
     return user
 
 

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -86,9 +86,13 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
         email_verified=True,
     )
     db.add(user)
+    # flush (not commit): land the personal tenant/membership in the same transaction as
+    # this user, then commit once -- a failure between two separate commits could otherwise
+    # leave a User row with no personal tenant (#323 CodeRabbit finding).
+    db.flush()
+    tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)
-    tenant_repo.ensure_personal_tenant(db, user.id)
     return user
 
 

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -26,3 +26,9 @@ def db(_engine):
         # the same way get_db() does in production, or a leaked value leaks across tests.
         conn.execute(text("RESET app.tenant_id"))
         conn.execute(text("RESET app.user_id"))
+        # RESET is transactional like any other statement -- the execute() calls above
+        # auto-begin a new implicit transaction after rollback() ended the last one, and
+        # closing the connection without committing would roll the resets themselves back,
+        # leaving the leaked value intact on the pooled connection. Must commit for the
+        # reset to actually stick.
+        conn.commit()

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
@@ -20,3 +20,9 @@ def db(_engine):
         with Session(conn, join_transaction_mode="create_savepoint") as session:
             yield session
         conn.rollback()
+        # require_org_role/require_personal_tenant (rbac.py) set app.tenant_id/app.user_id
+        # via plain SET, not SET LOCAL -- rollback() above doesn't clear them. _engine is
+        # session-scoped, so a pooled connection can be reused by a later test; reset here
+        # the same way get_db() does in production, or a leaked value leaks across tests.
+        conn.execute(text("RESET app.tenant_id"))
+        conn.execute(text("RESET app.user_id"))

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -78,6 +78,19 @@ def test_setup_returns_token_and_owner(auth_client):
     assert body["user"]["email"] == "owner@example.com"
 
 
+def test_setup_creates_a_personal_tenant_and_self_membership(auth_client, db):
+    from src.core.db import Membership, Tenant
+
+    body = _setup_owner(auth_client)
+    user_id = body["user"]["id"]
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    assert tenant is not None
+    membership = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+    assert membership is not None
+    assert membership.role == "admin"
+
+
 def test_setup_stores_email_lowercased(auth_client):
     resp = auth_client.post(
         "/auth/setup", json={"email": "Owner@Example.com", "password": "supersecret1234"}
@@ -183,6 +196,23 @@ def test_register_creates_non_owner(auth_client):
     assert "access_token" in body
     assert body["user"]["is_workspace_admin"] is False
     assert body["user"]["email"] == "member@example.com"
+
+
+def test_register_creates_a_personal_tenant_and_self_membership(auth_client, db):
+    from src.core.db import Membership, Tenant
+
+    _setup_owner(auth_client)
+    resp = auth_client.post(
+        "/auth/register", json={"email": "member@example.com", "password": "supersecret1234"}
+    )
+    assert resp.status_code == 201
+    user_id = resp.json()["user"]["id"]
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user_id).first()
+    assert tenant is not None
+    membership = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+    assert membership is not None
+    assert membership.role == "admin"
 
 
 def test_register_before_setup_rejected(auth_client):

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -7,7 +7,10 @@ pooled connection next. Uses the real engine/pool directly (not the savepoint-pe
 `db` fixture), since the bug is specifically about connection *reuse* across separate
 get_db() calls."""
 
+from unittest.mock import patch
+
 from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from src.core.db import get_db
 
@@ -37,3 +40,24 @@ def test_get_db_resets_tenant_context_before_connection_checkin():
     # favor immediate reuse of the just-returned connection in a single-threaded test).
     seen = {_current_setting_via_new_connection() for _ in range(5)}
     assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"
+
+
+def test_get_db_invalidates_the_connection_if_the_reset_itself_fails():
+    # If RESET/commit fails partway through, closing normally would return a connection
+    # to the pool whose reset status is uncertain -- get_db() must invalidate it instead
+    # of risking a dirty connection reaching an unrelated later request.
+    original_commit = Session.commit
+    calls = {"n": 0}
+
+    def failing_commit(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("simulated failure during tenant-context reset")
+        return original_commit(self)
+
+    gen = get_db()
+    next(gen)
+    with patch.object(Session, "commit", failing_commit), patch.object(Session, "invalidate") as mock_invalidate:
+        gen.close()
+
+    mock_invalidate.assert_called_once()

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -1,0 +1,39 @@
+"""Regression test for get_db()'s tenant-session-context reset on connection checkin
+(issue #190, PR 5a). require_org_role/require_personal_tenant set app.tenant_id/
+app.user_id via plain SET (not SET LOCAL, since a request can commit more than once) --
+SET persists for the life of the physical connection, not just one request's Session, so
+without an explicit reset it would leak into whatever unrelated request reuses the same
+pooled connection next. Uses the real engine/pool directly (not the savepoint-per-test
+`db` fixture), since the bug is specifically about connection *reuse* across separate
+get_db() calls."""
+
+from sqlalchemy import text
+
+from src.core.db import get_db
+
+
+def _current_setting_via_new_connection() -> str | None:
+    gen = get_db()
+    db = next(gen)
+    try:
+        value = db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar()
+    finally:
+        gen.close()
+    return value or None
+
+
+def test_get_db_resets_tenant_context_before_connection_checkin():
+    gen = get_db()
+    db = next(gen)
+    db.execute(text("SET app.tenant_id = 555555"))
+    db.execute(text("SET app.user_id = 777777"))
+    db.commit()
+    assert db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar() == "555555"
+    gen.close()  # triggers get_db()'s finally: block
+
+    # A fresh get_db() call may or may not reuse the exact same physical connection
+    # depending on pool state, so poll a handful of connections -- if the reset didn't
+    # happen, the leaked value would show up on at least one of them (LIFO pools strongly
+    # favor immediate reuse of the just-returned connection in a single-threaded test).
+    seen = {_current_setting_via_new_connection() for _ in range(5)}
+    assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -15,14 +15,16 @@ from sqlalchemy.orm import Session
 from src.core.db import get_db
 
 
-def _current_setting_via_new_connection() -> str | None:
+def _session_context_via_new_connection() -> tuple[str | None, str | None]:
     gen = get_db()
     db = next(gen)
     try:
-        value = db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar()
+        tenant, user = db.execute(
+            text("SELECT current_setting('app.tenant_id', true), current_setting('app.user_id', true)")
+        ).one()
     finally:
         gen.close()
-    return value or None
+    return (tenant or None, user or None)
 
 
 def test_get_db_resets_tenant_context_before_connection_checkin():
@@ -38,8 +40,8 @@ def test_get_db_resets_tenant_context_before_connection_checkin():
     # depending on pool state, so poll a handful of connections -- if the reset didn't
     # happen, the leaked value would show up on at least one of them (LIFO pools strongly
     # favor immediate reuse of the just-returned connection in a single-threaded test).
-    seen = {_current_setting_via_new_connection() for _ in range(5)}
-    assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"
+    seen = {_session_context_via_new_connection() for _ in range(5)}
+    assert seen == {(None, None)}, f"session context leaked into a reused connection: {seen}"
 
 
 def test_get_db_invalidates_the_connection_if_the_reset_itself_fails():

--- a/apps/api/tests/test_github_auth.py
+++ b/apps/api/tests/test_github_auth.py
@@ -70,6 +70,30 @@ def test_second_user_is_member(db):
     assert second.is_workspace_admin is False
 
 
+def test_new_user_gets_a_personal_tenant_and_self_membership(db):
+    from src.core.db import Membership, Tenant
+
+    user = find_or_create_user(db, _identity())
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == user.id).first()
+    assert tenant is not None
+    membership = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_returning_user_does_not_duplicate_the_personal_tenant(db):
+    from src.core.db import Tenant
+
+    first = find_or_create_user(db, _identity())
+    find_or_create_user(db, _identity(name="Octo Updated"))  # returning-user branch
+
+    tenants = db.query(Tenant).filter(Tenant.kind == "personal", Tenant.personal_user_id == first.id).all()
+    assert len(tenants) == 1
+
+
 def test_refuses_to_auto_link_an_existing_email_registered_account(db):
     # Regression test for the account-takeover fix: self-registration has no email
     # verification anywhere in this app, so silently linking a GitHub identity onto an

--- a/apps/api/tests/test_installation_repo.py
+++ b/apps/api/tests/test_installation_repo.py
@@ -24,6 +24,48 @@ def test_upsert_creates_new_row(db):
     assert row.installation_id == 1
 
 
+def test_upsert_sets_tenant_id_for_org_scoped_installation(db):
+    from src.core.db import Tenant
+
+    org_id = _acme_org_id(db)
+    row = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    assert row.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == row.tenant_id).first()
+    assert tenant.kind == "org"
+    assert tenant.org_id == org_id
+
+
+def test_upsert_sets_tenant_id_for_personal_installation(db):
+    from src.core.db import Tenant, User
+
+    user = User(email="dev2@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    row = installation_repo.upsert(
+        db, account_login="octocat", account_type="User", auth_mode="app", installation_id=7, owner_user_id=user.id
+    )
+
+    assert row.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == row.tenant_id).first()
+    assert tenant.kind == "personal"
+    assert tenant.personal_user_id == user.id
+
+
+def test_upsert_update_branch_backfills_tenant_id(db):
+    org_id = _acme_org_id(db)
+    installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=1, org_id=org_id
+    )
+    updated = installation_repo.upsert(
+        db, account_login="acme", account_type="Organization", auth_mode="app", installation_id=2, org_id=org_id
+    )
+    assert updated.tenant_id is not None
+
+
 def test_upsert_updates_existing_row(db):
     org_id = _acme_org_id(db)
     installation_repo.upsert(

--- a/apps/api/tests/test_invitations.py
+++ b/apps/api/tests/test_invitations.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import User, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import invitation_repo, org_membership_repo, org_repo
 from src.routers.invitations import router as invitations_router
 
 
@@ -55,6 +55,21 @@ def test_create_invitation_admin_ok(db, acme_org):
     assert body["invitation"]["email"] == "bob@acme.com"
     assert body["invitation"]["status"] == "pending"
     assert "/invite/" in body["invite_link"]
+
+
+def test_create_invitation_sets_tenant_id(db, acme_org):
+    from src.core.db import Tenant
+
+    resp = _client(db, acme_org["admin"]).post("/orgs/acme/invitations", json={"email": "bob@acme.com"})
+    assert resp.status_code == 200
+    token = resp.json()["invite_link"].rsplit("/", 1)[-1]
+
+    invitation = invitation_repo.get_by_token(db, token)
+
+    assert invitation.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == invitation.tenant_id).first()
+    assert tenant.kind == "org"
+    assert tenant.org_id == acme_org["org"].id
 
 
 def test_create_invitation_rejects_duplicate_pending_invite(db, acme_org):

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -296,6 +296,99 @@ def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commit
         session_a.close()
 
 
+def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirror_sync_commits():
+    """Regression test for a CodeRabbit finding on #323's 2nd review: get_or_create's
+    new-row path used to commit the freshly-inserted OrgMembership, then sync its mirror
+    with no lock held across that gap. A concurrent delete() landing in the gap would
+    remove the just-created row and find no mirror yet, then have this call resume and
+    create a mirror for a membership that's already revoked. Fixed by re-locking the row
+    immediately after the insert commits, before syncing -- same lock-then-sync ordering
+    as update_role's fix. Needs two genuinely separate connections, same reasoning as the
+    other concurrency tests in this file (the race only exists across real transactions)."""
+    setup = SessionLocal()
+    org = org_repo.get_or_create(setup, github_login="acme-lock-test-3")
+    user = User(email="judy@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    setup.add(user)
+    setup.commit()
+    setup.refresh(user)
+    org_id, user_id = org.id, user.id
+    setup.close()
+    # No get_or_create() call yet for (org_id, user_id) -- the pair doesn't exist, so the
+    # first call below goes down the new-row insert path, not the early-return path.
+
+    reached_lock = threading.Event()
+    release_lock = threading.Event()
+    original_sync = org_membership_repo._sync_membership_mirror
+
+    def paused_sync(db, org_id, membership):
+        reached_lock.set()
+        assert release_lock.wait(timeout=5), "test setup never released the paused sync"
+        original_sync(db, org_id, membership)
+
+    create_result: dict[str, bool] = {}
+    delete_result: dict[str, bool] = {}
+
+    def run_get_or_create(session_a):
+        org_membership_repo.get_or_create(session_a, org_id=org_id, user_id=user_id, role="member")
+        create_result["finished"] = True
+
+    def run_delete():
+        session_b = SessionLocal()
+        try:
+            assert reached_lock.wait(timeout=5), "get_or_create never reached its locked section"
+            org_membership_repo.delete(session_b, org_id=org_id, user_id=user_id)
+            delete_result["finished"] = True
+        finally:
+            session_b.close()
+
+    session_a = SessionLocal()
+    try:
+        with patch.object(org_membership_repo, "_sync_membership_mirror", paused_sync):
+            create_thread = threading.Thread(target=run_get_or_create, args=(session_a,))
+            create_thread.start()
+            assert reached_lock.wait(timeout=5), "get_or_create never reached its locked section"
+
+            delete_thread = threading.Thread(target=run_delete)
+            delete_thread.start()
+            delete_thread.join(timeout=0.3)
+            assert not delete_result, "delete() must block while get_or_create holds the row lock"
+
+            release_lock.set()
+            create_thread.join(timeout=5)
+            delete_thread.join(timeout=5)
+        assert create_result.get("finished") is True
+        assert delete_result.get("finished") is True
+
+        # The delete landed after get_or_create's sync committed the mirror, so the final
+        # state must reflect the delete -- no leftover membership or mirror.
+        remaining = (
+            session_a.query(OrgMembership)
+            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+            .first()
+        )
+        assert remaining is None
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        mirror = (
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        assert mirror is None
+    finally:
+        session_a.rollback()
+        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is not None:
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+            org_row = session_a.query(Org).filter(Org.id == org_id).first()
+            if org_row is not None:
+                org_row.tenant_id = None
+                session_a.commit()
+            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
+        session_a.query(Org).filter(Org.id == org_id).delete()
+        session_a.query(User).filter(User.id == user_id).delete()
+        session_a.commit()
+        session_a.close()
+
+
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
     org = org_repo.get_or_create(db, github_login="acme")
     admin = _make_user(db, "erin@example.com")

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -317,6 +317,7 @@ def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirr
     # first call below goes down the new-row insert path, not the early-return path.
 
     reached_lock = threading.Event()
+    delete_started = threading.Event()
     release_lock = threading.Event()
     original_sync = org_membership_repo._sync_membership_mirror
 
@@ -336,6 +337,7 @@ def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirr
         session_b = SessionLocal()
         try:
             assert reached_lock.wait(timeout=5), "get_or_create never reached its locked section"
+            delete_started.set()
             org_membership_repo.delete(session_b, org_id=org_id, user_id=user_id)
             delete_result["finished"] = True
         finally:
@@ -350,6 +352,11 @@ def test_get_or_create_blocks_a_concurrent_delete_until_the_new_memberships_mirr
 
             delete_thread = threading.Thread(target=run_delete)
             delete_thread.start()
+            # Wait for the delete thread to actually reach delete() (not just start()) before
+            # checking it's blocked -- otherwise a slow scheduler could let the 0.3s timeout
+            # below expire before run_delete has even called delete(), passing "not
+            # delete_result" for the wrong reason instead of proving the lock blocked it.
+            assert delete_started.wait(timeout=5), "delete thread never reached delete()"
             delete_thread.join(timeout=0.3)
             assert not delete_result, "delete() must block while get_or_create holds the row lock"
 

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -203,6 +203,99 @@ def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
         session_a.close()
 
 
+def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commits():
+    """Regression test for a code-review finding on #324: delete()'s original two-phase
+    commit (commit the OrgMembership delete, *then* delete the mirror) released its row
+    lock before the mirror was touched. A concurrent get_or_create() could see the row
+    already gone, legitimately re-create a fresh OrgMembership + mirror, and then have
+    delete()'s now-unblocked mirror deletion remove that brand-new mirror out from under
+    it -- membership drift from the opposite direction of the get_or_create/update_role
+    race fixed above. Needs two genuinely separate connections, same reasoning as above."""
+    setup = SessionLocal()
+    org = org_repo.get_or_create(setup, github_login="acme-lock-test-2")
+    user = User(email="mallory@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    setup.add(user)
+    setup.commit()
+    setup.refresh(user)
+    org_id, user_id = org.id, user.id
+    org_membership_repo.get_or_create(setup, org_id=org_id, user_id=user_id, role="member")
+    setup.close()
+
+    reached_lock = threading.Event()
+    release_lock = threading.Event()
+    original_delete_membership = org_membership_repo.tenant_repo.delete_membership
+
+    def paused_delete_membership(db, tenant_id, user_id):
+        reached_lock.set()
+        assert release_lock.wait(timeout=5), "test setup never released the paused delete"
+        original_delete_membership(db, tenant_id=tenant_id, user_id=user_id)
+
+    delete_result: dict[str, bool] = {}
+    recreate_result: dict[str, bool] = {}
+
+    def run_delete(session_a):
+        org_membership_repo.delete(session_a, org_id=org_id, user_id=user_id)
+        delete_result["finished"] = True
+
+    def run_get_or_create():
+        session_b = SessionLocal()
+        try:
+            assert reached_lock.wait(timeout=5), "delete() never reached its locked section"
+            org_membership_repo.get_or_create(session_b, org_id=org_id, user_id=user_id, role="member")
+            recreate_result["finished"] = True
+        finally:
+            session_b.close()
+
+    session_a = SessionLocal()
+    try:
+        with patch.object(org_membership_repo.tenant_repo, "delete_membership", paused_delete_membership):
+            delete_thread = threading.Thread(target=run_delete, args=(session_a,))
+            delete_thread.start()
+            assert reached_lock.wait(timeout=5), "delete() never reached its locked section"
+
+            recreate_thread = threading.Thread(target=run_get_or_create)
+            recreate_thread.start()
+            recreate_thread.join(timeout=0.3)
+            assert not recreate_result, "get_or_create() must block while delete() holds the row lock"
+
+            release_lock.set()
+            delete_thread.join(timeout=5)
+            recreate_thread.join(timeout=5)
+        assert delete_result.get("finished") is True
+        assert recreate_result.get("finished") is True
+
+        # get_or_create() ran after delete()'s commit released the lock, legitimately
+        # re-creating the membership -- its mirror must exist and match, not be missing
+        # (which is what the pre-fix ordering would have left behind).
+        remaining = (
+            session_a.query(OrgMembership)
+            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+            .first()
+        )
+        assert remaining is not None
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        mirror = (
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        assert mirror is not None
+        assert mirror.role == remaining.role
+    finally:
+        session_a.rollback()
+        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is not None:
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+            org_row = session_a.query(Org).filter(Org.id == org_id).first()
+            if org_row is not None:
+                org_row.tenant_id = None
+                session_a.commit()
+            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
+        session_a.query(Org).filter(Org.id == org_id).delete()
+        session_a.query(User).filter(User.id == user_id).delete()
+        session_a.commit()
+        session_a.close()
+
+
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
     org = org_repo.get_or_create(db, github_login="acme")
     admin = _make_user(db, "erin@example.com")

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -67,6 +67,44 @@ def test_delete_removes_the_membership_mirror_too(db):
     assert membership is None
 
 
+def test_get_or_create_repairs_a_missing_mirror_on_an_existing_membership(db):
+    # Regression test for a CodeRabbit finding on #323: get_or_create's early-return path
+    # (OrgMembership already exists) used to skip the dual-write entirely, so a Membership
+    # row deleted or never created out-of-band would never get repaired on subsequent calls
+    # -- exactly the pattern org_provisioning.py's reconcile loop hits on every login.
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "grace@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    assert _membership_row(db, org.id, user.id) is not None
+    # Simulate the mirror having gone missing out-of-band.
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).delete()
+    db.commit()
+    assert _membership_row(db, org.id, user.id) is None
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "member"
+
+
+def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "heidi@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    # Simulate the mirror's role having drifted out-of-band from the OrgMembership's role.
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    stale = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    stale.role = "admin"
+    db.commit()
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership.role == "member"
+
+
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
     org = org_repo.get_or_create(db, github_login="acme")
     admin = _make_user(db, "erin@example.com")

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -1,0 +1,80 @@
+"""Tests for src.repositories.org_membership_repo's Membership dual-write (issue #190 PR 4):
+every OrgMembership create/update/delete must be mirrored onto the tenants/memberships
+tables, keyed off the org's tenant."""
+
+from src.core.db import Membership, Tenant, User
+from src.repositories import org_membership_repo, org_repo
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _membership_row(db, org_id: int, user_id: int) -> Membership | None:
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+    if tenant is None:
+        return None
+    return db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+
+
+def test_get_or_create_mirrors_a_membership_row(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "alice@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_get_or_create_is_idempotent_on_the_mirror_too(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "bob@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    rows = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).all()
+    assert len(rows) == 1
+
+
+def test_update_role_mirrors_onto_membership(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "carol@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_delete_removes_the_membership_mirror_too(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "dave@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+
+    org_membership_repo.delete(db, org_id=org.id, user_id=user.id)
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is None
+
+
+def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    admin = _make_user(db, "erin@example.com")
+    member = _make_user(db, "frank@example.com")
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+
+    admin_membership = _membership_row(db, org.id, admin.id)
+    member_membership = _membership_row(db, org.id, member.id)
+    assert admin_membership.tenant_id == member_membership.tenant_id

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -2,7 +2,10 @@
 every OrgMembership create/update/delete must be mirrored onto the tenants/memberships
 tables, keyed off the org's tenant."""
 
-from src.core.db import Membership, Tenant, User
+import threading
+from unittest.mock import patch
+
+from src.core.db import Membership, Org, OrgMembership, SessionLocal, Tenant, User
 from src.repositories import org_membership_repo, org_repo
 
 
@@ -103,6 +106,101 @@ def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
 
     membership = _membership_row(db, org.id, user.id)
     assert membership.role == "member"
+
+
+def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
+    """Regression test for a CodeRabbit finding on #324: without row locking, a concurrent
+    delete() could interleave between update_role's membership lookup and its mirror sync,
+    resurrecting the tenant Membership mirror right after revocation. Needs two genuinely
+    separate connections (not the savepoint-per-test `db` fixture, same reasoning as
+    test_db_get_db.py) since the race only exists across real concurrent transactions."""
+    setup = SessionLocal()
+    org = org_repo.get_or_create(setup, github_login="acme-lock-test")
+    user = User(email="ivy@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    setup.add(user)
+    setup.commit()
+    setup.refresh(user)
+    org_id, user_id = org.id, user.id
+    org_membership_repo.get_or_create(setup, org_id=org_id, user_id=user_id, role="member")
+    setup.close()
+    # org/user are bound to `setup`, now closed -- only org_id/user_id (plain ints) are used
+    # from here on, never the detached ORM objects themselves.
+
+    reached_lock = threading.Event()
+    release_lock = threading.Event()
+    original_sync = org_membership_repo._sync_membership_mirror
+
+    def paused_sync(db, org_id, membership):
+        reached_lock.set()
+        assert release_lock.wait(timeout=5), "test setup never released the paused sync"
+        original_sync(db, org_id, membership)
+
+    update_result: dict[str, bool] = {}
+    delete_result: dict[str, bool] = {}
+
+    def run_update_role(session_a):
+        org_membership_repo.update_role(session_a, org_id=org_id, user_id=user_id, role="admin")
+        update_result["finished"] = True
+
+    def run_delete():
+        session_b = SessionLocal()
+        try:
+            assert reached_lock.wait(timeout=5), "update_role never reached its locked section"
+            org_membership_repo.delete(session_b, org_id=org_id, user_id=user_id)
+            delete_result["finished"] = True
+        finally:
+            session_b.close()
+
+    session_a = SessionLocal()
+    try:
+        with patch.object(org_membership_repo, "_sync_membership_mirror", paused_sync):
+            update_thread = threading.Thread(target=run_update_role, args=(session_a,))
+            update_thread.start()
+            assert reached_lock.wait(timeout=5), "update_role never reached its locked section"
+
+            delete_thread = threading.Thread(target=run_delete)
+            delete_thread.start()
+            delete_thread.join(timeout=0.3)
+            assert not delete_result, "delete() must block while update_role holds the row lock"
+
+            release_lock.set()
+            update_thread.join(timeout=5)
+            delete_thread.join(timeout=5)
+        assert update_result.get("finished") is True
+        assert delete_result.get("finished") is True
+
+        # The delete landed after update_role's commit released the lock, so the final
+        # state must reflect the delete -- no resurrected mirror row.
+        remaining = (
+            session_a.query(OrgMembership)
+            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+            .first()
+        )
+        assert remaining is None
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        mirror = (
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        assert mirror is None
+    finally:
+        # This test uses real committing connections (not the savepoint-per-test `db`
+        # fixture), so the rows it creates persist unless cleaned up explicitly here.
+        session_a.rollback()
+        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is not None:
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+            # orgs.tenant_id and tenants.org_id reference each other (composite reciprocal
+            # FK) -- null the org side first so either row can then be deleted freely.
+            org_row = session_a.query(Org).filter(Org.id == org_id).first()
+            if org_row is not None:
+                org_row.tenant_id = None
+                session_a.commit()
+            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
+        session_a.query(Org).filter(Org.id == org_id).delete()
+        session_a.query(User).filter(User.id == user_id).delete()
+        session_a.commit()
+        session_a.close()
 
 
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):

--- a/apps/api/tests/test_org_repo.py
+++ b/apps/api/tests/test_org_repo.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from sqlalchemy.orm import Query
 
+from src.core.db import Tenant
 from src.repositories import org_repo
 
 
@@ -11,6 +12,31 @@ def test_creates_new_org(db):
     org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
     assert org.github_login == "acme"
     assert org.github_org_id == 1
+
+
+def test_creates_new_org_links_a_tenant(db):
+    org = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+    assert org.tenant_id is not None
+    tenant = db.query(Tenant).filter(Tenant.id == org.tenant_id).first()
+    assert tenant is not None
+    assert tenant.kind == "org"
+    assert tenant.org_id == org.id
+
+
+def test_existing_org_gets_lazily_backfilled_with_a_tenant(db):
+    # An org row created before dual-write existed (tenant_id NULL) must self-heal the
+    # next time it's resolved through get_or_create, not stay permanently untenanted.
+    from src.core.db import Org
+
+    org = Org(github_login="acme", github_org_id=1)
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    assert org.tenant_id is None
+
+    resolved = org_repo.get_or_create(db, github_login="acme", github_org_id=1)
+
+    assert resolved.tenant_id is not None
 
 
 def test_idempotent_by_login(db):

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,115 +1,77 @@
-"""Tests for src.core.rbac's org-role dependency."""
+"""Tests for src.core.rbac's tenant-context session-variable wiring (issue #190, PR 5a).
 
+require_org_role's HTTP-level behavior (404/403 on missing org/membership) is already
+covered by router tests (e.g. test_invitations.py) that exercise it un-mocked through a
+real request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
+router tests never assert on directly."""
+
+from fastapi import HTTPException
+from sqlalchemy import text
 import pytest
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi.testclient import TestClient
 
-from src.core.auth import UserOut, require_auth
-from src.core.db import User, get_db
-from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.core.auth import UserOut
+from src.core.db import User
+from src.core.rbac import require_org_role, require_personal_tenant
 from src.repositories import org_membership_repo, org_repo
 
-_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
 
-
-def _make_user(db, email: str) -> UserOut:
+def _make_user(db, email: str) -> User:
     user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
     db.add(user)
     db.commit()
     db.refresh(user)
-    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+    return user
 
 
-@pytest.fixture()
-def rbac_app(db):
-    app = FastAPI()
-
-    @app.get("/orgs/{org_login}/member-only")
-    def member_route(ctx=Depends(require_org_role(min_role="member"))):
-        return {"org": ctx.org.github_login, "role": ctx.membership.role}
-
-    @app.get("/orgs/{org_login}/admin-only")
-    def admin_route(ctx=Depends(require_org_role(min_role="admin"))):
-        return {"org": ctx.org.github_login, "role": ctx.membership.role}
-
-    app.dependency_overrides[get_db] = lambda: db
-    return app
+def _current_setting(db, name: str) -> str | None:
+    value = db.execute(text("SELECT current_setting(:name, true)"), {"name": name}).scalar()
+    return value or None
 
 
-@pytest.fixture()
-def acme_org(db):
-    admin = _make_user(db, "admin@e.com")
-    member = _make_user(db, "member@e.com")
+def test_require_org_role_sets_tenant_and_user_session_vars(db):
     org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
-    return org, admin, member
+    user = _make_user(db, "alice@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    dependency = require_org_role("member")
+    ctx = dependency(org_login="acme", db=db, user=user_out)
+
+    assert ctx.org.id == org.id
+    assert _current_setting(db, "app.tenant_id") == str(org.tenant_id)
+    assert _current_setting(db, "app.user_id") == str(user.id)
 
 
-def _client(app, user):
-    app.dependency_overrides[require_auth] = lambda: user
-    return TestClient(app)
+def test_require_org_role_does_not_set_session_vars_on_403(db):
+    org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "bob@example.com")  # no membership
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-
-def test_member_route_allows_member(rbac_app, acme_org):
-    _, _admin, member = acme_org
-    resp = _client(rbac_app, member).get("/orgs/acme/member-only")
-    assert resp.status_code == 200
-    assert resp.json() == {"org": "acme", "role": "member"}
-
-
-def test_member_route_allows_admin(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/acme/member-only")
-    assert resp.status_code == 200
-
-
-def test_member_route_rejects_outsider(rbac_app, acme_org):
-    resp = _client(rbac_app, _OUTSIDER).get("/orgs/acme/member-only")
-    assert resp.status_code == 403
-
-
-def test_admin_route_rejects_member(rbac_app, acme_org):
-    _, _admin, member = acme_org
-    resp = _client(rbac_app, member).get("/orgs/acme/admin-only")
-    assert resp.status_code == 403
-
-
-def test_admin_route_allows_admin(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/acme/admin-only")
-    assert resp.status_code == 200
-
-
-def test_route_rejects_unknown_org(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/does-not-exist/member-only")
-    assert resp.status_code == 404
-
-
-def test_route_requires_auth(rbac_app, acme_org):
-    resp = TestClient(rbac_app).get("/orgs/acme/member-only")
-    assert resp.status_code == 401
-
-
-# ── assert_owner_matches_org ────────────────────────────────────────────────────
-
-def test_assert_owner_matches_org_allows_exact_match(db):
-    org = org_repo.get_or_create(db, github_login="acme")
-    assert_owner_matches_org("acme", OrgContext(org=org, membership=None))
-
-
-def test_assert_owner_matches_org_is_case_insensitive(db):
-    # GitHub logins are case-insensitive (Acme and acme are the same account) --
-    # regression test for issue #224 item 1, matching the .lower() comparison already
-    # used in apps/api/src/routers/installations.py for the same class of check.
-    org = org_repo.get_or_create(db, github_login="acme")
-    assert_owner_matches_org("Acme", OrgContext(org=org, membership=None))
-    assert_owner_matches_org("ACME", OrgContext(org=org, membership=None))
-
-
-def test_assert_owner_matches_org_rejects_a_different_org(db):
-    org = org_repo.get_or_create(db, github_login="acme")
+    dependency = require_org_role("member")
     with pytest.raises(HTTPException) as exc_info:
-        assert_owner_matches_org("widgets-inc", OrgContext(org=org, membership=None))
+        dependency(org_login="acme", db=db, user=user_out)
+
     assert exc_info.value.status_code == 403
+    assert _current_setting(db, "app.tenant_id") is None
+
+
+def test_require_personal_tenant_sets_session_vars(db):
+    user = _make_user(db, "carol@example.com")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    ctx = require_personal_tenant(db=db, user=user_out)
+
+    assert ctx.tenant.kind == "personal"
+    assert ctx.tenant.personal_user_id == user.id
+    assert _current_setting(db, "app.tenant_id") == str(ctx.tenant.id)
+    assert _current_setting(db, "app.user_id") == str(user.id)
+
+
+def test_require_personal_tenant_is_idempotent(db):
+    user = _make_user(db, "dave@example.com")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    first = require_personal_tenant(db=db, user=user_out)
+    second = require_personal_tenant(db=db, user=user_out)
+
+    assert second.tenant.id == first.tenant.id

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,27 +1,126 @@
-"""Tests for src.core.rbac's tenant-context session-variable wiring (issue #190, PR 5a).
+"""Tests for src.core.rbac's org-role dependency."""
 
-require_org_role's HTTP-level behavior (404/403 on missing org/membership) is already
-covered by router tests (e.g. test_invitations.py) that exercise it un-mocked through a
-real request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
-router tests never assert on directly."""
-
-from fastapi import HTTPException
-from sqlalchemy import text
 import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import text
 
-from src.core.auth import UserOut
-from src.core.db import User
-from src.core.rbac import require_org_role, require_personal_tenant
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role, require_personal_tenant
 from src.repositories import org_membership_repo, org_repo
 
+_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
 
-def _make_user(db, email: str) -> User:
+
+def _make_user(db, email: str) -> UserOut:
     user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
     db.add(user)
     db.commit()
     db.refresh(user)
-    return user
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
+
+@pytest.fixture()
+def rbac_app(db):
+    app = FastAPI()
+
+    @app.get("/orgs/{org_login}/member-only")
+    def member_route(ctx=Depends(require_org_role(min_role="member"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    @app.get("/orgs/{org_login}/admin-only")
+    def admin_route(ctx=Depends(require_org_role(min_role="admin"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+@pytest.fixture()
+def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    member = _make_user(db, "member@e.com")
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return org, admin, member
+
+
+def _client(app, user):
+    app.dependency_overrides[require_auth] = lambda: user
+    return TestClient(app)
+
+
+def test_member_route_allows_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+    assert resp.json() == {"org": "acme", "role": "member"}
+
+
+def test_member_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+
+
+def test_member_route_rejects_outsider(rbac_app, acme_org):
+    resp = _client(rbac_app, _OUTSIDER).get("/orgs/acme/member-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_rejects_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/admin-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/admin-only")
+    assert resp.status_code == 200
+
+
+def test_route_rejects_unknown_org(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/does-not-exist/member-only")
+    assert resp.status_code == 404
+
+
+def test_route_requires_auth(rbac_app, acme_org):
+    resp = TestClient(rbac_app).get("/orgs/acme/member-only")
+    assert resp.status_code == 401
+
+
+# ── assert_owner_matches_org ────────────────────────────────────────────────────
+
+def test_assert_owner_matches_org_allows_exact_match(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    assert_owner_matches_org("acme", OrgContext(org=org, membership=None))
+
+
+def test_assert_owner_matches_org_is_case_insensitive(db):
+    # GitHub logins are case-insensitive (Acme and acme are the same account) --
+    # regression test for issue #224 item 1, matching the .lower() comparison already
+    # used in apps/api/src/routers/installations.py for the same class of check.
+    org = org_repo.get_or_create(db, github_login="acme")
+    assert_owner_matches_org("Acme", OrgContext(org=org, membership=None))
+    assert_owner_matches_org("ACME", OrgContext(org=org, membership=None))
+
+
+def test_assert_owner_matches_org_rejects_a_different_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    with pytest.raises(HTTPException) as exc_info:
+        assert_owner_matches_org("widgets-inc", OrgContext(org=org, membership=None))
+    assert exc_info.value.status_code == 403
+
+
+# ── tenant-context session-variable wiring (issue #190, PR 5a) ─────────────────────
+#
+# require_org_role's HTTP-level behavior is already covered above through a real
+# request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
+# the HTTP-level tests never assert on directly.
 
 def _current_setting(db, name: str) -> str | None:
     value = db.execute(text("SELECT current_setting(:name, true)"), {"name": name}).scalar()
@@ -29,13 +128,12 @@ def _current_setting(db, name: str) -> str | None:
 
 
 def test_require_org_role_sets_tenant_and_user_session_vars(db):
-    org = org_repo.get_or_create(db, github_login="acme")
+    org = org_repo.get_or_create(db, github_login="widgets")
     user = _make_user(db, "alice@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
     dependency = require_org_role("member")
-    ctx = dependency(org_login="acme", db=db, user=user_out)
+    ctx = dependency(org_login="widgets", db=db, user=user)
 
     assert ctx.org.id == org.id
     assert _current_setting(db, "app.tenant_id") == str(org.tenant_id)
@@ -43,13 +141,12 @@ def test_require_org_role_sets_tenant_and_user_session_vars(db):
 
 
 def test_require_org_role_does_not_set_session_vars_on_403(db):
-    org_repo.get_or_create(db, github_login="acme")
+    org_repo.get_or_create(db, github_login="widgets")
     user = _make_user(db, "bob@example.com")  # no membership
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
     dependency = require_org_role("member")
     with pytest.raises(HTTPException) as exc_info:
-        dependency(org_login="acme", db=db, user=user_out)
+        dependency(org_login="widgets", db=db, user=user)
 
     assert exc_info.value.status_code == 403
     assert _current_setting(db, "app.tenant_id") is None
@@ -57,9 +154,8 @@ def test_require_org_role_does_not_set_session_vars_on_403(db):
 
 def test_require_personal_tenant_sets_session_vars(db):
     user = _make_user(db, "carol@example.com")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-    ctx = require_personal_tenant(db=db, user=user_out)
+    ctx = require_personal_tenant(db=db, user=user)
 
     assert ctx.tenant.kind == "personal"
     assert ctx.tenant.personal_user_id == user.id
@@ -69,9 +165,8 @@ def test_require_personal_tenant_sets_session_vars(db):
 
 def test_require_personal_tenant_is_idempotent(db):
     user = _make_user(db, "dave@example.com")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-    first = require_personal_tenant(db=db, user=user_out)
-    second = require_personal_tenant(db=db, user=user_out)
+    first = require_personal_tenant(db=db, user=user)
+    second = require_personal_tenant(db=db, user=user)
 
     assert second.tenant.id == first.tenant.id

--- a/apps/api/tests/test_tenant_repo.py
+++ b/apps/api/tests/test_tenant_repo.py
@@ -109,6 +109,48 @@ def test_ensure_personal_tenant_falls_back_on_concurrent_insert_race(db):
     assert result.id == existing.id
 
 
+def test_ensure_personal_tenant_commit_false_flushes_without_committing(db):
+    # commit=False is for auth.py/github_auth.py's brand-new-user registration flows: the
+    # tenant/membership must be visible to the still-open transaction (so a caller-side
+    # query against `db` sees them) without db having committed anything yet, so the
+    # caller can commit once, atomically, alongside its own User row.
+    user = _make_user(db, "dawn@example.com")
+
+    tenant = tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
+
+    assert tenant.kind == "personal"
+    membership = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert membership is not None
+    assert membership.role == "admin"
+    assert db.in_transaction()
+
+
+def test_ensure_personal_tenant_commit_false_is_atomic_with_the_caller(db):
+    # Regression test for a CodeRabbit finding on #323: ensure_personal_tenant used to
+    # always commit internally, separately from the caller's own User commit -- a failure
+    # between the two commits could leave a User row with no personal tenant. With
+    # commit=False, a failure before the caller's single commit must roll back the User
+    # row too, not just leave the tenant/membership missing.
+    user = User(email="edith@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.flush()
+    user_id = user.id
+
+    with patch("src.core.db.Membership.__init__", side_effect=RuntimeError("simulated failure")):
+        try:
+            tenant_repo.ensure_personal_tenant(db, user_id, commit=False)
+        except RuntimeError:
+            db.rollback()
+        else:
+            raise AssertionError("expected the simulated failure to propagate")
+
+    # The caller never got to its own db.commit() -- the User row must not be visible
+    # either, proving the two are atomic rather than the tenant failure leaving a stray user.
+    assert db.query(User).filter(User.id == user_id).first() is None
+
+
 # ── get_or_create_membership / update_membership_role / delete_membership ────
 
 def test_get_or_create_membership_creates_new(db):

--- a/apps/api/tests/test_tenant_repo.py
+++ b/apps/api/tests/test_tenant_repo.py
@@ -175,3 +175,49 @@ def test_delete_membership_is_a_noop_when_missing(db):
     user = _make_user(db, "ivan@example.com")
 
     tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)  # must not raise
+
+
+# ── upsert_membership ─────────────────────────────────────────────────────────
+
+def test_upsert_membership_creates_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "judy@example.com")
+
+    membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert membership.role == "member"
+
+
+def test_upsert_membership_fixes_a_stale_role(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "kevin@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert membership.role == "admin"
+
+
+def test_upsert_membership_recreates_a_row_deleted_between_its_two_internal_lookups(db):
+    # Regression test: upsert_membership's internal update_membership_role call can find
+    # nothing if a concurrent delete_membership races in between its get-or-create and its
+    # role-reconciliation step. Must recreate the row rather than returning None despite
+    # the function's non-Optional Membership return type.
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "laura@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    original_update = tenant_repo.update_membership_role
+
+    def racy_update(db, tenant_id, user_id, role):
+        tenant_repo.delete_membership(db, tenant_id=tenant_id, user_id=user_id)
+        return original_update(db, tenant_id=tenant_id, user_id=user_id, role=role)
+
+    with patch.object(tenant_repo, "update_membership_role", racy_update):
+        membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert membership is not None
+    assert membership.role == "admin"

--- a/apps/api/tests/test_tenant_repo.py
+++ b/apps/api/tests/test_tenant_repo.py
@@ -1,0 +1,177 @@
+"""Tests for src.repositories.tenant_repo."""
+
+from unittest.mock import patch
+
+from sqlalchemy.orm import Query
+
+from src.core.db import Membership, User
+from src.repositories import tenant_repo
+
+
+def _make_user(db, email: str) -> User:
+    user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _acme_org_id(db) -> int:
+    # org_repo.get_or_create already dual-writes a tenant -- create the org row directly
+    # instead so these tests exercise tenant_repo's own get-or-create behavior in isolation.
+    from src.core.db import Org
+
+    org = Org(github_login="acme")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org.id
+
+
+# ── get_or_create_org_tenant ─────────────────────────────────────────────────
+
+def test_get_or_create_org_tenant_creates_new(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    assert tenant.kind == "org"
+    assert tenant.org_id == org_id
+
+
+def test_get_or_create_org_tenant_idempotent(db):
+    org_id = _acme_org_id(db)
+    first = tenant_repo.get_or_create_org_tenant(db, org_id)
+    second = tenant_repo.get_or_create_org_tenant(db, org_id)
+    assert second.id == first.id
+
+
+def test_get_or_create_org_tenant_falls_back_on_concurrent_insert_race(db):
+    org_id = _acme_org_id(db)
+    existing = tenant_repo.get_or_create_org_tenant(db, org_id)
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = tenant_repo.get_or_create_org_tenant(db, org_id)
+
+    assert result.id == existing.id
+
+
+# ── ensure_personal_tenant ────────────────────────────────────────────────────
+
+def test_ensure_personal_tenant_creates_tenant_and_self_membership(db):
+    user = _make_user(db, "alice@example.com")
+
+    tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert tenant.kind == "personal"
+    assert tenant.personal_user_id == user.id
+    membership = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert membership is not None
+    assert membership.role == "admin"
+
+
+def test_ensure_personal_tenant_idempotent(db):
+    user = _make_user(db, "bob@example.com")
+
+    first = tenant_repo.ensure_personal_tenant(db, user.id)
+    second = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert second.id == first.id
+    memberships = db.query(Membership).filter(Membership.tenant_id == first.id, Membership.user_id == user.id).all()
+    assert len(memberships) == 1
+
+
+def test_ensure_personal_tenant_falls_back_on_concurrent_insert_race(db):
+    user = _make_user(db, "carol@example.com")
+    existing = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    original_first = Query.first
+    calls = {"n": 0}
+
+    def racy_first(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return original_first(self)
+
+    with patch.object(Query, "first", racy_first):
+        result = tenant_repo.ensure_personal_tenant(db, user.id)
+
+    assert result.id == existing.id
+
+
+# ── get_or_create_membership / update_membership_role / delete_membership ────
+
+def test_get_or_create_membership_creates_new(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "dave@example.com")
+
+    membership = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert membership.tenant_id == tenant.id
+    assert membership.user_id == user.id
+    assert membership.role == "member"
+
+
+def test_get_or_create_membership_idempotent(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "erin@example.com")
+
+    first = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+    second = tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert second.id == first.id
+
+
+def test_update_membership_role_updates_existing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "frank@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    updated = tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert updated.role == "admin"
+
+
+def test_update_membership_role_returns_none_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "grace@example.com")
+
+    result = tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert result is None
+
+
+def test_delete_membership_removes_row(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "heidi@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)
+
+    remaining = (
+        db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    )
+    assert remaining is None
+
+
+def test_delete_membership_is_a_noop_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "ivan@example.com")
+
+    tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)  # must not raise

--- a/apps/ui/tests/components/overview-page.test.tsx
+++ b/apps/ui/tests/components/overview-page.test.tsx
@@ -213,7 +213,10 @@ describe("OverviewPage cockpit", () => {
         {
           repo: "acme/api",
           title: "v2",
-          due_on: "2026-08-01T00:00:00Z",
+          // relativeTime() renders anything within 60s (or in the future) as "just now" --
+          // computed relative to test execution time so this doesn't go stale as real time
+          // passes (a hardcoded near-future date drifted into "N days ago" here before).
+          due_on: new Date(Date.now() + 60_000).toISOString(),
           open_issues: 2,
           closed_issues: 8,
           progress_pct: 80,


### PR DESCRIPTION
## Summary

Issue #190 (S2 multi-tenancy) — lands PRs 2, 3, and 4 of the 7-PR breakdown into `main` in one shot: `tenants`/`memberships` schema + org-tenant backfill, personal-tenant backfill + remaining `tenant_id` columns, and application-code dual-write. These were already reviewed and merged individually (#320, #321, #322) but landed on a chain of intermediate staging branches rather than `main` directly — this PR is the one that actually brings that work into `main`. No new work beyond what those three PRs already contained; this is purely a consolidation merge.

**Why a single consolidating PR instead of three separate ones targeting `main`:** #320 merged into `190-worker-db-credential-separation`, #321 merged into a *different* branch (`190-tenants-memberships-schema`), and #322 merged into yet another (`190-personal-tenants-remaining-columns`) — each was correctly reviewed and merged into its own stated base, but merges don't propagate backward between sibling branches, so no single one of those branches ended up with the full stack except this one (`190-personal-tenants-remaining-columns`, which is `git diff --stat`-confirmed to contain exactly PR2+PR3+PR4's combined 23 files / 997 insertions and nothing else relative to `main`).

## Schema change (per AGENTS.md's migration guardrail)

**Yes, this PR includes schema changes** — migrations `0021` through `0028` (all already reviewed individually in #320/#321):

- `0021_add_tenants_and_memberships` / `0022_backfill_org_tenants` — new `tenants`/`memberships` tables + one row per existing org/org_membership.
- `0023_backfill_personal_tenants` — one personal tenant/membership per existing user.
- `0024_add_orgs_tenant_id` / `0025_add_github_installations_tenant_id` / `0026_add_invitations_tenant_id` — add + backfill, all **nullable** (deliberately — see design-bug note in #321's own description; app code didn't populate these until PR 4).
- `0027_add_scan_results_and_saved_tokens_tenant_id` — add + best-effort backfill, stays nullable (some legacy rows unmatched, documented not chased).
- `0028_add_audit_logs_tenant_id` — add nullable, no backfill (free-text `actor`/`target`, not FK-joinable).

No `NOT NULL` enforcement happens in this PR — that's the next PR (5a) in the sequence, now that dual-write (PR 4, included here) has landed and there's app code actually populating these columns going forward.

## What changed

Application code (PR 4, new since #321's description): `apps/api/src/repositories/tenant_repo.py` (new) centralizes all `Tenant`/`Membership` writes; wired into `org_repo.get_or_create`, `org_membership_repo.get_or_create`/`update_role`/`delete`, `installation_repo.upsert`, `invitation_repo.create`, and all 3 `User`-creation sites (`auth.py` setup/register, `github_auth.py` find_or_create_user) — every write to `orgs`/`org_memberships`/`users`/`github_installations`/`invitations` now also writes the matching `tenants`/`memberships` row. No read-path changes.

Full file list and individual rationale already documented on #320 and #321's PR descriptions (both merged, still viewable).

## Test plan

- [x] `pytest -q` — 633 passed on the source branch before this PR was opened (up from `main`'s current baseline).
- [x] Each of #320/#321/#322 was independently verified against real Postgres (migration upgrade/downgrade cycles, seeded backfill data) and had full pre-commit/pre-push hooks pass before merging.
- [x] `git diff --stat origin/main..190-personal-tenants-remaining-columns` confirmed this PR's diff is exactly the union of #320+#321+#322's changes, nothing more.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-based ownership for organizations and personal accounts.
  * New users automatically receive a personal tenant with administrator access.
  * GitHub installations, invitations, scan results, saved tokens, and audit logs can now be associated with a tenant.
  * Organization membership changes stay synchronized with tenant memberships.
  * Added tenant-aware authorization for organization and personal account access.

* **Bug Fixes**
  * Existing records are automatically linked to the appropriate tenant where possible.
  * Prevented duplicate personal tenants and memberships during repeated operations.
  * Improved cleanup of tenant and user access context between requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->