### PR TITLE
feat(db): enforce tenant_id NOT NULL + wire tenant session context (RBAC)

### DIFF
--- a/apps/api/alembic/versions/0029_enforce_tenant_id_not_null.py
+++ b/apps/api/alembic/versions/0029_enforce_tenant_id_not_null.py
@@ -1,0 +1,90 @@
+"""Enforce NOT NULL on invitations/github_installations.tenant_id (issue #190, PR 5a of 7).
+
+Migrations 0025/0026 added these columns nullable because, at the time, no
+application code populated tenant_id yet -- enforcing NOT NULL then would
+have broken installation/invitation creation the moment those migrations
+deployed. PR 4 (dual-write, already merged) closed that gap: every write
+path now sets tenant_id via src.repositories.tenant_repo. This migration
+re-runs each column's original backfill UPDATE (idempotent -- a no-op for
+already-tenanted rows) to catch any row created in the window between PR 3's
+migrations landing and PR 4's dual-write code actually deploying, then
+enforces NOT NULL.
+
+orgs.tenant_id is deliberately NOT included here and stays nullable
+permanently: creating a brand-new org requires inserting both the Org row
+(needs tenant_id) and its reciprocal Tenant row (needs org_id via
+fk_orgs_tenant_id_reciprocal's composite FK, migration 0024) -- each
+references the other's not-yet-existing id. Postgres NOT NULL constraints
+cannot be deferred (only FK/UNIQUE/PK/EXCLUSION constraints can), so there
+is no way to insert a genuinely new org+tenant pair in one transaction if
+orgs.tenant_id is hard NOT NULL, short of a more complex deferred-FK
+migration (an explicit tradeoff, not attempted here -- see the PR
+description). org_repo.get_or_create's self-healing dual-write plus the
+verification queries below are the ongoing guarantee instead, the same
+pattern already accepted for scan_results/saved_tokens.tenant_id.
+
+Data-loss/backfill risk (AGENTS.md guardrail): if a real gap exists beyond
+what the backfill UPDATE can resolve (e.g. an installation/invitation whose
+org's tenant row was never created, not just never linked), the
+ALTER COLUMN ... SET NOT NULL below fails atomically and the whole migration
+rolls back -- it does not silently succeed with missing data. Run the
+verification queries below against the target environment before applying
+this migration there, and investigate any nonzero count rather than
+retrying blindly. Verified end-to-end against real Postgres for this PR: a
+deliberately-seeded gap (an org with no tenant row, an invitation pointing
+at it) reproduced the atomic-rollback failure below before being fixed.
+
+    -- every org has a reciprocal tenant
+    SELECT count(*) FROM orgs o WHERE NOT EXISTS (
+        SELECT 1 FROM tenants t WHERE t.org_id = o.id AND t.kind = 'org');
+
+    -- invitations/github_installations.tenant_id are populated
+    SELECT count(*) FROM invitations WHERE tenant_id IS NULL;
+    SELECT count(*) FROM github_installations WHERE tenant_id IS NULL;
+
+    -- every org_membership has a matching Membership row (dual-write parity)
+    SELECT count(*) FROM org_memberships om JOIN orgs o ON o.id = om.org_id
+    WHERE o.tenant_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM memberships m WHERE m.tenant_id = o.tenant_id
+        AND m.user_id = om.user_id AND m.role = om.role);
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-08-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            "UPDATE invitations i SET tenant_id = t.id "
+            "FROM tenants t WHERE t.org_id = i.org_id AND t.kind = 'org' AND i.tenant_id IS NULL"
+        )
+    )
+    op.alter_column("invitations", "tenant_id", nullable=False)
+
+    conn.execute(
+        sa.text(
+            "UPDATE github_installations gi SET tenant_id = t.id "
+            "FROM tenants t "
+            "WHERE gi.tenant_id IS NULL "
+            "AND ((gi.org_id IS NOT NULL AND t.org_id = gi.org_id AND t.kind = 'org') "
+            "OR (gi.owner_user_id IS NOT NULL AND t.personal_user_id = gi.owner_user_id AND t.kind = 'personal'))"
+        )
+    )
+    op.alter_column("github_installations", "tenant_id", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("github_installations", "tenant_id", nullable=True)
+    op.alter_column("invitations", "tenant_id", nullable=True)

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -58,11 +58,10 @@ class GitHubInstallation(Base):
     # Exactly one of org_id / owner_user_id is set: org-connected installs vs. personal installs.
     org_id: Mapped[int | None] = mapped_column(ForeignKey("orgs.id"), nullable=True)
     owner_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
-    # Backfilled from org_id/owner_user_id by migration 0025. Stays nullable until PR 4's
-    # dual-write lands and installation-creation code starts setting it -- enforcing NOT
-    # NULL before then would break every new installation the moment this migration deploys
-    # (see the same reasoning documented on orgs.tenant_id and invitations.tenant_id below).
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    # Backfilled from org_id/owner_user_id by migration 0025, dual-written by installation_repo
+    # since PR 4, NOT NULL enforced by migration 0029 now that PR 4's dual-write covers every
+    # installation-creation path.
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -173,9 +172,13 @@ class Org(Base):
     github_login: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     # 1:1 pointer to this org's tenant row (migration 0022 backfills one 'org'-kind tenant
-    # per org before this column exists; migration 0024 adds + backfills it). Stays nullable
-    # until PR 4's dual-write lands and org_provisioning.py starts setting it on every new
-    # org -- enforcing NOT NULL before then would break org creation entirely.
+    # per org before this column exists; migration 0024 adds + backfills it; org_repo has
+    # dual-written it on every org since PR 4). Stays nullable permanently, unlike
+    # invitations/github_installations.tenant_id (migration 0029) -- creating a brand-new
+    # org requires the Org and its reciprocal Tenant row to each reference the other's
+    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can. See
+    # migration 0029's docstring. org_repo.get_or_create's self-healing dual-write plus
+    # docs/tenant-id-verification.md's checks are the ongoing guarantee instead.
     tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
@@ -243,10 +246,9 @@ class Invitation(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    # Backfilled from org_id's tenant by migration 0026. Stays nullable until PR 4's
-    # dual-write lands and invitation-creation code starts setting it -- same reasoning as
-    # orgs.tenant_id above.
-    tenant_id: Mapped[int | None] = mapped_column(ForeignKey("tenants.id"), nullable=True)
+    # Backfilled from org_id's tenant by migration 0026, dual-written by invitation_repo
+    # since PR 4, NOT NULL enforced by migration 0029.
+    tenant_id: Mapped[int] = mapped_column(ForeignKey("tenants.id"), nullable=False)
 
 
 class ScanResult(Base):

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -305,7 +305,13 @@ def get_db() -> Generator[Session, None, None]:
             db.execute(text("RESET app.tenant_id"))
             db.execute(text("RESET app.user_id"))
             db.commit()
-        except Exception:
-            logger.exception("failed to reset tenant session context before connection checkin")
-        finally:
             db.close()
+        except Exception:
+            # A failure partway through (e.g. a transient network drop after RESET but
+            # before commit) leaves it unclear whether the reset actually took -- closing
+            # normally here would return that connection to the pool for reuse anyway.
+            # invalidate() instead forces the pool to discard the underlying DBAPI
+            # connection rather than risk handing a possibly-still-tenant-scoped
+            # connection to an unrelated later request.
+            logger.exception("failed to reset tenant session context; invalidating connection instead of reusing it")
+            db.invalidate()

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -1,5 +1,6 @@
 from collections.abc import Generator
 from datetime import datetime
+import logging
 
 from sqlalchemy import (
     Boolean,
@@ -19,6 +20,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 
 from src.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -176,9 +179,9 @@ class Org(Base):
     # dual-written it on every org since PR 4). Stays nullable permanently, unlike
     # invitations/github_installations.tenant_id (migration 0029) -- creating a brand-new
     # org requires the Org and its reciprocal Tenant row to each reference the other's
-    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can. See
-    # migration 0029's docstring. org_repo.get_or_create's self-healing dual-write plus
-    # docs/tenant-id-verification.md's checks are the ongoing guarantee instead.
+    # not-yet-existing id, and Postgres NOT NULL can't be deferred like a FK can.
+    # org_repo.get_or_create's self-healing dual-write plus the verification queries in
+    # migration 0029's docstring are the ongoing guarantee instead.
     tenant_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
@@ -290,4 +293,19 @@ def get_db() -> Generator[Session, None, None]:
     try:
         yield db
     finally:
-        db.close()
+        # require_org_role/require_personal_tenant (src.core.rbac) set app.tenant_id/
+        # app.user_id via plain SET (not SET LOCAL, since a request can commit more than
+        # once and SET LOCAL would stop applying after the first commit). Plain SET persists
+        # for the life of the physical connection, not just this request's Session -- since
+        # SQLAlchemy's connection pool only rolls back pending transactions on checkin, an
+        # already-committed SET would otherwise silently leak into whichever unrelated
+        # request reuses this connection next. Reset explicitly before returning to the pool.
+        try:
+            db.rollback()
+            db.execute(text("RESET app.tenant_id"))
+            db.execute(text("RESET app.user_id"))
+            db.commit()
+        except Exception:
+            logger.exception("failed to reset tenant session context before connection checkin")
+        finally:
+            db.close()

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -63,13 +63,10 @@ def require_org_role(min_role: Literal["member", "admin"]):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
         # resolved here via get_by_login (not get_or_create) never gets org_repo's own
-        # self-healing dual-write, so guard the same way org_repo does.
-        tenant_id = org.tenant_id
-        if tenant_id is None:
-            tenant_id = tenant_repo.get_or_create_org_tenant(db, org.id).id
-            org.tenant_id = tenant_id
-            db.commit()
-        _set_tenant_session_context(db, tenant_id, user.id)
+        # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
+        # itself uses, rather than a separate hand-rolled copy of the same logic.
+        org = org_repo.ensure_tenant_linked(db, org)
+        _set_tenant_session_context(db, org.tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 
     return dependency

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -10,11 +10,12 @@ from dataclasses import dataclass
 from typing import Literal
 
 from fastapi import Depends, HTTPException, status
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, get_db
-from src.repositories import org_membership_repo, org_repo
+from src.core.db import Org, OrgMembership, Tenant, get_db
+from src.repositories import org_membership_repo, org_repo, tenant_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -23,6 +24,26 @@ _ROLE_RANK = {"member": 0, "admin": 1}
 class OrgContext:
     org: Org
     membership: OrgMembership
+
+
+@dataclass
+class PersonalTenantContext:
+    tenant: Tenant
+
+
+def _set_tenant_session_context(db: Session, tenant_id: int, user_id: int) -> None:
+    # Plain SET (not SET LOCAL): a request's Session lifetime doesn't cleanly map to one
+    # transaction, so a transaction-scoped SET LOCAL could stop applying mid-request. No
+    # RLS policy reads these yet (migration 0030 adds FORCE-free policies as scaffolding
+    # only) -- this just prepares the session variable for when that lands.
+    #
+    # SET does not accept bind parameters (it's a configuration command, not a regular
+    # query) -- Postgres rejects `SET app.tenant_id = $1` with a syntax error. Both values
+    # are always int (SQLAlchemy-mapped primary keys, never caller-supplied strings), so
+    # formatting them directly into the statement is safe; int() here is a defensive type
+    # check, not a workaround.
+    db.execute(text(f"SET app.tenant_id = {int(tenant_id)}"))
+    db.execute(text(f"SET app.user_id = {int(user_id)}"))
 
 
 def require_org_role(min_role: Literal["member", "admin"]):
@@ -40,9 +61,31 @@ def require_org_role(min_role: Literal["member", "admin"]):
         membership = org_membership_repo.get(db, org.id, user.id)
         if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
+        # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
+        # resolved here via get_by_login (not get_or_create) never gets org_repo's own
+        # self-healing dual-write, so guard the same way org_repo does.
+        tenant_id = org.tenant_id
+        if tenant_id is None:
+            tenant_id = tenant_repo.get_or_create_org_tenant(db, org.id).id
+            org.tenant_id = tenant_id
+            db.commit()
+        _set_tenant_session_context(db, tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 
     return dependency
+
+
+def require_personal_tenant(
+    db: Session = Depends(get_db),
+    user: UserOut = Depends(require_auth),
+) -> PersonalTenantContext:
+    """Dependency for routes unambiguously scoped to the caller's own personal tenant --
+    not for /me/... routes that can resolve to either an org or personal tenant depending
+    on an `owner` path param (see src.services.token_resolution.resolve_owner_token);
+    wiring those is a separate design decision, deferred out of issue #190's PR 5."""
+    tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+    _set_tenant_session_context(db, tenant.id, user.id)
+    return PersonalTenantContext(tenant=tenant)
 
 
 def assert_owner_matches_org(owner: str, ctx: OrgContext) -> None:

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -5,12 +5,14 @@ from src.core.db import OrgMembership
 from src.repositories import tenant_repo
 
 
-def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
-    return (
-        db.query(OrgMembership)
-        .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
-        .first()
-    )
+def get(db: Session, org_id: int, user_id: int, for_update: bool = False) -> OrgMembership | None:
+    query = db.query(OrgMembership).filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+    if for_update:
+        # Locks the row (or blocks until a concurrent delete()'s own implicit row lock
+        # releases) so get_or_create/update_role can't read a membership that's mid-deletion
+        # and resurrect its tenant mirror via _sync_membership_mirror right after revocation.
+        query = query.with_for_update()
+    return query.first()
 
 
 def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership) -> None:
@@ -19,7 +21,7 @@ def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership)
 
 
 def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
-    membership = get(db, org_id, user_id)
+    membership = get(db, org_id, user_id, for_update=True)
     if membership is not None:
         _sync_membership_mirror(db, org_id, membership)
         return membership
@@ -30,7 +32,7 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
     except IntegrityError:
         # Lost a race with a concurrent insert of the same (org_id, user_id) pair.
         db.rollback()
-        membership = get(db, org_id, user_id)
+        membership = get(db, org_id, user_id, for_update=True)
         if membership is None:
             raise
         _sync_membership_mirror(db, org_id, membership)
@@ -49,14 +51,22 @@ def list_for_org(db: Session, org_id: int) -> list[OrgMembership]:
 
 
 def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership | None:
-    membership = get(db, org_id, user_id)
+    membership = get(db, org_id, user_id, for_update=True)
     if membership is None:
         return None
     membership.role = role
-    db.commit()
-    db.refresh(membership)
+    # Sync the mirror before committing -- committing first would release the FOR UPDATE
+    # lock get() just took, reopening the same window a concurrent delete() could land in.
+    # _sync_membership_mirror's own internal commit (tenant_repo.upsert_membership) flushes
+    # this pending role change too, so the OrgMembership update and the mirror update land
+    # together; this commit() is a no-op in that case and only matters if the mirror's role
+    # already matched (nothing to update inside the sync, so nothing committed it yet).
     _sync_membership_mirror(db, org_id, membership)
-    return membership
+    db.commit()
+    # Not db.refresh(membership): the row lock is released by the commit above, so a
+    # concurrent delete() can remove this row before we get here -- re-query instead of
+    # refreshing so that legitimate outcome returns None rather than raising.
+    return get(db, org_id, user_id)
 
 
 def delete(db: Session, org_id: int, user_id: int) -> None:

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -13,9 +13,15 @@ def get(db: Session, org_id: int, user_id: int) -> OrgMembership | None:
     )
 
 
+def _sync_membership_mirror(db: Session, org_id: int, membership: OrgMembership) -> None:
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=membership.user_id, role=membership.role)
+
+
 def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembership:
     membership = get(db, org_id, user_id)
     if membership is not None:
+        _sync_membership_mirror(db, org_id, membership)
         return membership
     membership = OrgMembership(org_id=org_id, user_id=user_id, role=role)
     db.add(membership)
@@ -27,10 +33,10 @@ def get_or_create(db: Session, org_id: int, user_id: int, role: str) -> OrgMembe
         membership = get(db, org_id, user_id)
         if membership is None:
             raise
+        _sync_membership_mirror(db, org_id, membership)
         return membership
     db.refresh(membership)
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
-    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user_id, role=role)
+    _sync_membership_mirror(db, org_id, membership)
     return membership
 
 
@@ -49,8 +55,7 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
     membership.role = role
     db.commit()
     db.refresh(membership)
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
-    tenant_repo.update_membership_role(db, tenant_id=tenant.id, user_id=user_id, role=role)
+    _sync_membership_mirror(db, org_id, membership)
     return membership
 
 

--- a/apps/api/src/repositories/org_membership_repo.py
+++ b/apps/api/src/repositories/org_membership_repo.py
@@ -70,9 +70,15 @@ def update_role(db: Session, org_id: int, user_id: int, role: str) -> OrgMembers
 
 
 def delete(db: Session, org_id: int, user_id: int) -> None:
+    # Delete the mirror before committing the OrgMembership delete -- committing first (the
+    # original ordering) released the DELETE's own implicit row lock before the mirror was
+    # touched, leaving a window where a concurrent get_or_create() could find the row gone,
+    # legitimately re-create a fresh OrgMembership + mirror, and then have this function's
+    # now-unblocked mirror delete remove that brand-new mirror out from under it. Same
+    # principle as update_role's lock-then-sync-then-commit ordering above.
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     db.query(OrgMembership).filter(
         OrgMembership.org_id == org_id, OrgMembership.user_id == user_id
     ).delete()
-    db.commit()
-    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
     tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user_id)
+    db.commit()

--- a/apps/api/src/repositories/org_repo.py
+++ b/apps/api/src/repositories/org_repo.py
@@ -6,7 +6,7 @@ from src.core.db import Org
 from src.repositories import tenant_repo
 
 
-def _ensure_tenant_linked(db: Session, org: Org) -> Org:
+def ensure_tenant_linked(db: Session, org: Org) -> Org:
     if org.tenant_id is not None:
         return org
     tenant = tenant_repo.get_or_create_org_tenant(db, org.id)
@@ -44,7 +44,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org.github_org_id = github_org_id
             db.commit()
             db.refresh(org)
-        return _ensure_tenant_linked(db, org)
+        return ensure_tenant_linked(db, org)
 
     if github_org_id is not None:
         # The org may have been renamed on GitHub since we last saw it -- github_org_id
@@ -56,7 +56,7 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
                 org.github_login = github_login
                 db.commit()
                 db.refresh(org)
-            return _ensure_tenant_linked(db, org)
+            return ensure_tenant_linked(db, org)
 
     org = Org(github_login=github_login, github_org_id=github_org_id)
     db.add(org)
@@ -70,6 +70,6 @@ def get_or_create(db: Session, github_login: str, github_org_id: int | None = No
             org = get_by_org_id(db, github_org_id)
         if org is None:
             raise
-        return _ensure_tenant_linked(db, org)
+        return ensure_tenant_linked(db, org)
     db.refresh(org)
-    return _ensure_tenant_linked(db, org)
+    return ensure_tenant_linked(db, org)

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -74,6 +74,17 @@ def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: st
     return membership
 
 
+def upsert_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:
+    """get_or_create_membership plus role reconciliation -- unlike get_or_create_membership
+    alone, this also fixes a stale role on an already-existing row, so callers that resolve
+    a membership through more than one code path (existing found / newly created / recovered
+    from a concurrent-insert race) can call this unconditionally and always end up in sync."""
+    membership = get_or_create_membership(db, tenant_id, user_id, role)
+    if membership.role != role:
+        membership = update_membership_role(db, tenant_id, user_id, role)
+    return membership
+
+
 def update_membership_role(db: Session, tenant_id: int, user_id: int, role: str) -> Membership | None:
     membership = (
         db.query(Membership)

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -81,7 +81,11 @@ def upsert_membership(db: Session, tenant_id: int, user_id: int, role: str) -> M
     from a concurrent-insert race) can call this unconditionally and always end up in sync."""
     membership = get_or_create_membership(db, tenant_id, user_id, role)
     if membership.role != role:
-        membership = update_membership_role(db, tenant_id, user_id, role)
+        updated = update_membership_role(db, tenant_id, user_id, role)
+        # A concurrent delete_membership could remove the row between the get-or-create
+        # above and this update -- re-create it rather than returning None despite this
+        # function's Membership (non-Optional) return type.
+        membership = updated if updated is not None else get_or_create_membership(db, tenant_id, user_id, role)
     return membership
 
 

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -7,7 +7,10 @@ pooled connection next. Uses the real engine/pool directly (not the savepoint-pe
 `db` fixture), since the bug is specifically about connection *reuse* across separate
 get_db() calls."""
 
+from unittest.mock import patch
+
 from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from src.core.db import get_db
 
@@ -37,3 +40,24 @@ def test_get_db_resets_tenant_context_before_connection_checkin():
     # favor immediate reuse of the just-returned connection in a single-threaded test).
     seen = {_current_setting_via_new_connection() for _ in range(5)}
     assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"
+
+
+def test_get_db_invalidates_the_connection_if_the_reset_itself_fails():
+    # If RESET/commit fails partway through, closing normally would return a connection
+    # to the pool whose reset status is uncertain -- get_db() must invalidate it instead
+    # of risking a dirty connection reaching an unrelated later request.
+    original_commit = Session.commit
+    calls = {"n": 0}
+
+    def failing_commit(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("simulated failure during tenant-context reset")
+        return original_commit(self)
+
+    gen = get_db()
+    next(gen)
+    with patch.object(Session, "commit", failing_commit), patch.object(Session, "invalidate") as mock_invalidate:
+        gen.close()
+
+    mock_invalidate.assert_called_once()

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -1,0 +1,39 @@
+"""Regression test for get_db()'s tenant-session-context reset on connection checkin
+(issue #190, PR 5a). require_org_role/require_personal_tenant set app.tenant_id/
+app.user_id via plain SET (not SET LOCAL, since a request can commit more than once) --
+SET persists for the life of the physical connection, not just one request's Session, so
+without an explicit reset it would leak into whatever unrelated request reuses the same
+pooled connection next. Uses the real engine/pool directly (not the savepoint-per-test
+`db` fixture), since the bug is specifically about connection *reuse* across separate
+get_db() calls."""
+
+from sqlalchemy import text
+
+from src.core.db import get_db
+
+
+def _current_setting_via_new_connection() -> str | None:
+    gen = get_db()
+    db = next(gen)
+    try:
+        value = db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar()
+    finally:
+        gen.close()
+    return value or None
+
+
+def test_get_db_resets_tenant_context_before_connection_checkin():
+    gen = get_db()
+    db = next(gen)
+    db.execute(text("SET app.tenant_id = 555555"))
+    db.execute(text("SET app.user_id = 777777"))
+    db.commit()
+    assert db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar() == "555555"
+    gen.close()  # triggers get_db()'s finally: block
+
+    # A fresh get_db() call may or may not reuse the exact same physical connection
+    # depending on pool state, so poll a handful of connections -- if the reset didn't
+    # happen, the leaked value would show up on at least one of them (LIFO pools strongly
+    # favor immediate reuse of the just-returned connection in a single-threaded test).
+    seen = {_current_setting_via_new_connection() for _ in range(5)}
+    assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"

--- a/apps/api/tests/test_db_get_db.py
+++ b/apps/api/tests/test_db_get_db.py
@@ -15,14 +15,16 @@ from sqlalchemy.orm import Session
 from src.core.db import get_db
 
 
-def _current_setting_via_new_connection() -> str | None:
+def _session_context_via_new_connection() -> tuple[str | None, str | None]:
     gen = get_db()
     db = next(gen)
     try:
-        value = db.execute(text("SELECT current_setting('app.tenant_id', true)")).scalar()
+        tenant, user = db.execute(
+            text("SELECT current_setting('app.tenant_id', true), current_setting('app.user_id', true)")
+        ).one()
     finally:
         gen.close()
-    return value or None
+    return (tenant or None, user or None)
 
 
 def test_get_db_resets_tenant_context_before_connection_checkin():
@@ -38,8 +40,8 @@ def test_get_db_resets_tenant_context_before_connection_checkin():
     # depending on pool state, so poll a handful of connections -- if the reset didn't
     # happen, the leaked value would show up on at least one of them (LIFO pools strongly
     # favor immediate reuse of the just-returned connection in a single-threaded test).
-    seen = {_current_setting_via_new_connection() for _ in range(5)}
-    assert seen == {None}, f"app.tenant_id leaked into a reused connection: {seen}"
+    seen = {_session_context_via_new_connection() for _ in range(5)}
+    assert seen == {(None, None)}, f"session context leaked into a reused connection: {seen}"
 
 
 def test_get_db_invalidates_the_connection_if_the_reset_itself_fails():

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -203,6 +203,99 @@ def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
         session_a.close()
 
 
+def test_delete_blocks_a_concurrent_get_or_create_until_the_mirror_delete_commits():
+    """Regression test for a code-review finding on #324: delete()'s original two-phase
+    commit (commit the OrgMembership delete, *then* delete the mirror) released its row
+    lock before the mirror was touched. A concurrent get_or_create() could see the row
+    already gone, legitimately re-create a fresh OrgMembership + mirror, and then have
+    delete()'s now-unblocked mirror deletion remove that brand-new mirror out from under
+    it -- membership drift from the opposite direction of the get_or_create/update_role
+    race fixed above. Needs two genuinely separate connections, same reasoning as above."""
+    setup = SessionLocal()
+    org = org_repo.get_or_create(setup, github_login="acme-lock-test-2")
+    user = User(email="mallory@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    setup.add(user)
+    setup.commit()
+    setup.refresh(user)
+    org_id, user_id = org.id, user.id
+    org_membership_repo.get_or_create(setup, org_id=org_id, user_id=user_id, role="member")
+    setup.close()
+
+    reached_lock = threading.Event()
+    release_lock = threading.Event()
+    original_delete_membership = org_membership_repo.tenant_repo.delete_membership
+
+    def paused_delete_membership(db, tenant_id, user_id):
+        reached_lock.set()
+        assert release_lock.wait(timeout=5), "test setup never released the paused delete"
+        original_delete_membership(db, tenant_id=tenant_id, user_id=user_id)
+
+    delete_result: dict[str, bool] = {}
+    recreate_result: dict[str, bool] = {}
+
+    def run_delete(session_a):
+        org_membership_repo.delete(session_a, org_id=org_id, user_id=user_id)
+        delete_result["finished"] = True
+
+    def run_get_or_create():
+        session_b = SessionLocal()
+        try:
+            assert reached_lock.wait(timeout=5), "delete() never reached its locked section"
+            org_membership_repo.get_or_create(session_b, org_id=org_id, user_id=user_id, role="member")
+            recreate_result["finished"] = True
+        finally:
+            session_b.close()
+
+    session_a = SessionLocal()
+    try:
+        with patch.object(org_membership_repo.tenant_repo, "delete_membership", paused_delete_membership):
+            delete_thread = threading.Thread(target=run_delete, args=(session_a,))
+            delete_thread.start()
+            assert reached_lock.wait(timeout=5), "delete() never reached its locked section"
+
+            recreate_thread = threading.Thread(target=run_get_or_create)
+            recreate_thread.start()
+            recreate_thread.join(timeout=0.3)
+            assert not recreate_result, "get_or_create() must block while delete() holds the row lock"
+
+            release_lock.set()
+            delete_thread.join(timeout=5)
+            recreate_thread.join(timeout=5)
+        assert delete_result.get("finished") is True
+        assert recreate_result.get("finished") is True
+
+        # get_or_create() ran after delete()'s commit released the lock, legitimately
+        # re-creating the membership -- its mirror must exist and match, not be missing
+        # (which is what the pre-fix ordering would have left behind).
+        remaining = (
+            session_a.query(OrgMembership)
+            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+            .first()
+        )
+        assert remaining is not None
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        mirror = (
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        assert mirror is not None
+        assert mirror.role == remaining.role
+    finally:
+        session_a.rollback()
+        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is not None:
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+            org_row = session_a.query(Org).filter(Org.id == org_id).first()
+            if org_row is not None:
+                org_row.tenant_id = None
+                session_a.commit()
+            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
+        session_a.query(Org).filter(Org.id == org_id).delete()
+        session_a.query(User).filter(User.id == user_id).delete()
+        session_a.commit()
+        session_a.close()
+
+
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
     org = org_repo.get_or_create(db, github_login="acme")
     admin = _make_user(db, "erin@example.com")

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -67,6 +67,44 @@ def test_delete_removes_the_membership_mirror_too(db):
     assert membership is None
 
 
+def test_get_or_create_repairs_a_missing_mirror_on_an_existing_membership(db):
+    # Regression test for a CodeRabbit finding on #323: get_or_create's early-return path
+    # (OrgMembership already exists) used to skip the dual-write entirely, so a Membership
+    # row deleted or never created out-of-band would never get repaired on subsequent calls
+    # -- exactly the pattern org_provisioning.py's reconcile loop hits on every login.
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "grace@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    assert _membership_row(db, org.id, user.id) is not None
+    # Simulate the mirror having gone missing out-of-band.
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).delete()
+    db.commit()
+    assert _membership_row(db, org.id, user.id) is None
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership is not None
+    assert membership.role == "member"
+
+
+def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "heidi@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+    # Simulate the mirror's role having drifted out-of-band from the OrgMembership's role.
+    tenant = db.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org.id).first()
+    stale = db.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user.id).first()
+    stale.role = "admin"
+    db.commit()
+
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="member")
+
+    membership = _membership_row(db, org.id, user.id)
+    assert membership.role == "member"
+
+
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):
     org = org_repo.get_or_create(db, github_login="acme")
     admin = _make_user(db, "erin@example.com")

--- a/apps/api/tests/test_org_membership_repo.py
+++ b/apps/api/tests/test_org_membership_repo.py
@@ -2,7 +2,10 @@
 every OrgMembership create/update/delete must be mirrored onto the tenants/memberships
 tables, keyed off the org's tenant."""
 
-from src.core.db import Membership, Tenant, User
+import threading
+from unittest.mock import patch
+
+from src.core.db import Membership, Org, OrgMembership, SessionLocal, Tenant, User
 from src.repositories import org_membership_repo, org_repo
 
 
@@ -103,6 +106,101 @@ def test_get_or_create_repairs_a_stale_role_on_an_existing_mirror(db):
 
     membership = _membership_row(db, org.id, user.id)
     assert membership.role == "member"
+
+
+def test_update_role_blocks_a_concurrent_delete_until_the_mirror_sync_commits():
+    """Regression test for a CodeRabbit finding on #324: without row locking, a concurrent
+    delete() could interleave between update_role's membership lookup and its mirror sync,
+    resurrecting the tenant Membership mirror right after revocation. Needs two genuinely
+    separate connections (not the savepoint-per-test `db` fixture, same reasoning as
+    test_db_get_db.py) since the race only exists across real concurrent transactions."""
+    setup = SessionLocal()
+    org = org_repo.get_or_create(setup, github_login="acme-lock-test")
+    user = User(email="ivy@example.com", name=None, password_hash=None, is_workspace_admin=False)
+    setup.add(user)
+    setup.commit()
+    setup.refresh(user)
+    org_id, user_id = org.id, user.id
+    org_membership_repo.get_or_create(setup, org_id=org_id, user_id=user_id, role="member")
+    setup.close()
+    # org/user are bound to `setup`, now closed -- only org_id/user_id (plain ints) are used
+    # from here on, never the detached ORM objects themselves.
+
+    reached_lock = threading.Event()
+    release_lock = threading.Event()
+    original_sync = org_membership_repo._sync_membership_mirror
+
+    def paused_sync(db, org_id, membership):
+        reached_lock.set()
+        assert release_lock.wait(timeout=5), "test setup never released the paused sync"
+        original_sync(db, org_id, membership)
+
+    update_result: dict[str, bool] = {}
+    delete_result: dict[str, bool] = {}
+
+    def run_update_role(session_a):
+        org_membership_repo.update_role(session_a, org_id=org_id, user_id=user_id, role="admin")
+        update_result["finished"] = True
+
+    def run_delete():
+        session_b = SessionLocal()
+        try:
+            assert reached_lock.wait(timeout=5), "update_role never reached its locked section"
+            org_membership_repo.delete(session_b, org_id=org_id, user_id=user_id)
+            delete_result["finished"] = True
+        finally:
+            session_b.close()
+
+    session_a = SessionLocal()
+    try:
+        with patch.object(org_membership_repo, "_sync_membership_mirror", paused_sync):
+            update_thread = threading.Thread(target=run_update_role, args=(session_a,))
+            update_thread.start()
+            assert reached_lock.wait(timeout=5), "update_role never reached its locked section"
+
+            delete_thread = threading.Thread(target=run_delete)
+            delete_thread.start()
+            delete_thread.join(timeout=0.3)
+            assert not delete_result, "delete() must block while update_role holds the row lock"
+
+            release_lock.set()
+            update_thread.join(timeout=5)
+            delete_thread.join(timeout=5)
+        assert update_result.get("finished") is True
+        assert delete_result.get("finished") is True
+
+        # The delete landed after update_role's commit released the lock, so the final
+        # state must reflect the delete -- no resurrected mirror row.
+        remaining = (
+            session_a.query(OrgMembership)
+            .filter(OrgMembership.org_id == org_id, OrgMembership.user_id == user_id)
+            .first()
+        )
+        assert remaining is None
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        mirror = (
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id, Membership.user_id == user_id).first()
+        )
+        assert mirror is None
+    finally:
+        # This test uses real committing connections (not the savepoint-per-test `db`
+        # fixture), so the rows it creates persist unless cleaned up explicitly here.
+        session_a.rollback()
+        session_a.query(OrgMembership).filter(OrgMembership.org_id == org_id).delete()
+        tenant = session_a.query(Tenant).filter(Tenant.kind == "org", Tenant.org_id == org_id).first()
+        if tenant is not None:
+            session_a.query(Membership).filter(Membership.tenant_id == tenant.id).delete()
+            # orgs.tenant_id and tenants.org_id reference each other (composite reciprocal
+            # FK) -- null the org side first so either row can then be deleted freely.
+            org_row = session_a.query(Org).filter(Org.id == org_id).first()
+            if org_row is not None:
+                org_row.tenant_id = None
+                session_a.commit()
+            session_a.query(Tenant).filter(Tenant.id == tenant.id).delete()
+        session_a.query(Org).filter(Org.id == org_id).delete()
+        session_a.query(User).filter(User.id == user_id).delete()
+        session_a.commit()
+        session_a.close()
 
 
 def test_dual_write_uses_the_same_tenant_for_every_membership_in_an_org(db):

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,115 +1,77 @@
-"""Tests for src.core.rbac's org-role dependency."""
+"""Tests for src.core.rbac's tenant-context session-variable wiring (issue #190, PR 5a).
 
+require_org_role's HTTP-level behavior (404/403 on missing org/membership) is already
+covered by router tests (e.g. test_invitations.py) that exercise it un-mocked through a
+real request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
+router tests never assert on directly."""
+
+from fastapi import HTTPException
+from sqlalchemy import text
 import pytest
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi.testclient import TestClient
 
-from src.core.auth import UserOut, require_auth
-from src.core.db import User, get_db
-from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
+from src.core.auth import UserOut
+from src.core.db import User
+from src.core.rbac import require_org_role, require_personal_tenant
 from src.repositories import org_membership_repo, org_repo
 
-_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
 
-
-def _make_user(db, email: str) -> UserOut:
+def _make_user(db, email: str) -> User:
     user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
     db.add(user)
     db.commit()
     db.refresh(user)
-    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+    return user
 
 
-@pytest.fixture()
-def rbac_app(db):
-    app = FastAPI()
-
-    @app.get("/orgs/{org_login}/member-only")
-    def member_route(ctx=Depends(require_org_role(min_role="member"))):
-        return {"org": ctx.org.github_login, "role": ctx.membership.role}
-
-    @app.get("/orgs/{org_login}/admin-only")
-    def admin_route(ctx=Depends(require_org_role(min_role="admin"))):
-        return {"org": ctx.org.github_login, "role": ctx.membership.role}
-
-    app.dependency_overrides[get_db] = lambda: db
-    return app
+def _current_setting(db, name: str) -> str | None:
+    value = db.execute(text("SELECT current_setting(:name, true)"), {"name": name}).scalar()
+    return value or None
 
 
-@pytest.fixture()
-def acme_org(db):
-    admin = _make_user(db, "admin@e.com")
-    member = _make_user(db, "member@e.com")
+def test_require_org_role_sets_tenant_and_user_session_vars(db):
     org = org_repo.get_or_create(db, github_login="acme")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
-    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
-    return org, admin, member
+    user = _make_user(db, "alice@example.com")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    dependency = require_org_role("member")
+    ctx = dependency(org_login="acme", db=db, user=user_out)
+
+    assert ctx.org.id == org.id
+    assert _current_setting(db, "app.tenant_id") == str(org.tenant_id)
+    assert _current_setting(db, "app.user_id") == str(user.id)
 
 
-def _client(app, user):
-    app.dependency_overrides[require_auth] = lambda: user
-    return TestClient(app)
+def test_require_org_role_does_not_set_session_vars_on_403(db):
+    org_repo.get_or_create(db, github_login="acme")
+    user = _make_user(db, "bob@example.com")  # no membership
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-
-def test_member_route_allows_member(rbac_app, acme_org):
-    _, _admin, member = acme_org
-    resp = _client(rbac_app, member).get("/orgs/acme/member-only")
-    assert resp.status_code == 200
-    assert resp.json() == {"org": "acme", "role": "member"}
-
-
-def test_member_route_allows_admin(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/acme/member-only")
-    assert resp.status_code == 200
-
-
-def test_member_route_rejects_outsider(rbac_app, acme_org):
-    resp = _client(rbac_app, _OUTSIDER).get("/orgs/acme/member-only")
-    assert resp.status_code == 403
-
-
-def test_admin_route_rejects_member(rbac_app, acme_org):
-    _, _admin, member = acme_org
-    resp = _client(rbac_app, member).get("/orgs/acme/admin-only")
-    assert resp.status_code == 403
-
-
-def test_admin_route_allows_admin(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/acme/admin-only")
-    assert resp.status_code == 200
-
-
-def test_route_rejects_unknown_org(rbac_app, acme_org):
-    _, admin, _member = acme_org
-    resp = _client(rbac_app, admin).get("/orgs/does-not-exist/member-only")
-    assert resp.status_code == 404
-
-
-def test_route_requires_auth(rbac_app, acme_org):
-    resp = TestClient(rbac_app).get("/orgs/acme/member-only")
-    assert resp.status_code == 401
-
-
-# ── assert_owner_matches_org ────────────────────────────────────────────────────
-
-def test_assert_owner_matches_org_allows_exact_match(db):
-    org = org_repo.get_or_create(db, github_login="acme")
-    assert_owner_matches_org("acme", OrgContext(org=org, membership=None))
-
-
-def test_assert_owner_matches_org_is_case_insensitive(db):
-    # GitHub logins are case-insensitive (Acme and acme are the same account) --
-    # regression test for issue #224 item 1, matching the .lower() comparison already
-    # used in apps/api/src/routers/installations.py for the same class of check.
-    org = org_repo.get_or_create(db, github_login="acme")
-    assert_owner_matches_org("Acme", OrgContext(org=org, membership=None))
-    assert_owner_matches_org("ACME", OrgContext(org=org, membership=None))
-
-
-def test_assert_owner_matches_org_rejects_a_different_org(db):
-    org = org_repo.get_or_create(db, github_login="acme")
+    dependency = require_org_role("member")
     with pytest.raises(HTTPException) as exc_info:
-        assert_owner_matches_org("widgets-inc", OrgContext(org=org, membership=None))
+        dependency(org_login="acme", db=db, user=user_out)
+
     assert exc_info.value.status_code == 403
+    assert _current_setting(db, "app.tenant_id") is None
+
+
+def test_require_personal_tenant_sets_session_vars(db):
+    user = _make_user(db, "carol@example.com")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    ctx = require_personal_tenant(db=db, user=user_out)
+
+    assert ctx.tenant.kind == "personal"
+    assert ctx.tenant.personal_user_id == user.id
+    assert _current_setting(db, "app.tenant_id") == str(ctx.tenant.id)
+    assert _current_setting(db, "app.user_id") == str(user.id)
+
+
+def test_require_personal_tenant_is_idempotent(db):
+    user = _make_user(db, "dave@example.com")
+    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
+
+    first = require_personal_tenant(db=db, user=user_out)
+    second = require_personal_tenant(db=db, user=user_out)
+
+    assert second.tenant.id == first.tenant.id

--- a/apps/api/tests/test_rbac.py
+++ b/apps/api/tests/test_rbac.py
@@ -1,27 +1,126 @@
-"""Tests for src.core.rbac's tenant-context session-variable wiring (issue #190, PR 5a).
+"""Tests for src.core.rbac's org-role dependency."""
 
-require_org_role's HTTP-level behavior (404/403 on missing org/membership) is already
-covered by router tests (e.g. test_invitations.py) that exercise it un-mocked through a
-real request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
-router tests never assert on directly."""
-
-from fastapi import HTTPException
-from sqlalchemy import text
 import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import text
 
-from src.core.auth import UserOut
-from src.core.db import User
-from src.core.rbac import require_org_role, require_personal_tenant
+from src.core.auth import UserOut, require_auth
+from src.core.db import User, get_db
+from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role, require_personal_tenant
 from src.repositories import org_membership_repo, org_repo
 
+_OUTSIDER = UserOut(id=99999, email="outsider@e.com", name=None, is_workspace_admin=False)
 
-def _make_user(db, email: str) -> User:
+
+def _make_user(db, email: str) -> UserOut:
     user = User(email=email, name=None, password_hash=None, is_workspace_admin=False)
     db.add(user)
     db.commit()
     db.refresh(user)
-    return user
+    return UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
+
+@pytest.fixture()
+def rbac_app(db):
+    app = FastAPI()
+
+    @app.get("/orgs/{org_login}/member-only")
+    def member_route(ctx=Depends(require_org_role(min_role="member"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    @app.get("/orgs/{org_login}/admin-only")
+    def admin_route(ctx=Depends(require_org_role(min_role="admin"))):
+        return {"org": ctx.org.github_login, "role": ctx.membership.role}
+
+    app.dependency_overrides[get_db] = lambda: db
+    return app
+
+
+@pytest.fixture()
+def acme_org(db):
+    admin = _make_user(db, "admin@e.com")
+    member = _make_user(db, "member@e.com")
+    org = org_repo.get_or_create(db, github_login="acme")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=admin.id, role="admin")
+    org_membership_repo.get_or_create(db, org_id=org.id, user_id=member.id, role="member")
+    return org, admin, member
+
+
+def _client(app, user):
+    app.dependency_overrides[require_auth] = lambda: user
+    return TestClient(app)
+
+
+def test_member_route_allows_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+    assert resp.json() == {"org": "acme", "role": "member"}
+
+
+def test_member_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/member-only")
+    assert resp.status_code == 200
+
+
+def test_member_route_rejects_outsider(rbac_app, acme_org):
+    resp = _client(rbac_app, _OUTSIDER).get("/orgs/acme/member-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_rejects_member(rbac_app, acme_org):
+    _, _admin, member = acme_org
+    resp = _client(rbac_app, member).get("/orgs/acme/admin-only")
+    assert resp.status_code == 403
+
+
+def test_admin_route_allows_admin(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/acme/admin-only")
+    assert resp.status_code == 200
+
+
+def test_route_rejects_unknown_org(rbac_app, acme_org):
+    _, admin, _member = acme_org
+    resp = _client(rbac_app, admin).get("/orgs/does-not-exist/member-only")
+    assert resp.status_code == 404
+
+
+def test_route_requires_auth(rbac_app, acme_org):
+    resp = TestClient(rbac_app).get("/orgs/acme/member-only")
+    assert resp.status_code == 401
+
+
+# ── assert_owner_matches_org ────────────────────────────────────────────────────
+
+def test_assert_owner_matches_org_allows_exact_match(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    assert_owner_matches_org("acme", OrgContext(org=org, membership=None))
+
+
+def test_assert_owner_matches_org_is_case_insensitive(db):
+    # GitHub logins are case-insensitive (Acme and acme are the same account) --
+    # regression test for issue #224 item 1, matching the .lower() comparison already
+    # used in apps/api/src/routers/installations.py for the same class of check.
+    org = org_repo.get_or_create(db, github_login="acme")
+    assert_owner_matches_org("Acme", OrgContext(org=org, membership=None))
+    assert_owner_matches_org("ACME", OrgContext(org=org, membership=None))
+
+
+def test_assert_owner_matches_org_rejects_a_different_org(db):
+    org = org_repo.get_or_create(db, github_login="acme")
+    with pytest.raises(HTTPException) as exc_info:
+        assert_owner_matches_org("widgets-inc", OrgContext(org=org, membership=None))
+    assert exc_info.value.status_code == 403
+
+
+# ── tenant-context session-variable wiring (issue #190, PR 5a) ─────────────────────
+#
+# require_org_role's HTTP-level behavior is already covered above through a real
+# request. These tests focus on the SET app.tenant_id / app.user_id side effect, which
+# the HTTP-level tests never assert on directly.
 
 def _current_setting(db, name: str) -> str | None:
     value = db.execute(text("SELECT current_setting(:name, true)"), {"name": name}).scalar()
@@ -29,13 +128,12 @@ def _current_setting(db, name: str) -> str | None:
 
 
 def test_require_org_role_sets_tenant_and_user_session_vars(db):
-    org = org_repo.get_or_create(db, github_login="acme")
+    org = org_repo.get_or_create(db, github_login="widgets")
     user = _make_user(db, "alice@example.com")
     org_membership_repo.get_or_create(db, org_id=org.id, user_id=user.id, role="admin")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
     dependency = require_org_role("member")
-    ctx = dependency(org_login="acme", db=db, user=user_out)
+    ctx = dependency(org_login="widgets", db=db, user=user)
 
     assert ctx.org.id == org.id
     assert _current_setting(db, "app.tenant_id") == str(org.tenant_id)
@@ -43,13 +141,12 @@ def test_require_org_role_sets_tenant_and_user_session_vars(db):
 
 
 def test_require_org_role_does_not_set_session_vars_on_403(db):
-    org_repo.get_or_create(db, github_login="acme")
+    org_repo.get_or_create(db, github_login="widgets")
     user = _make_user(db, "bob@example.com")  # no membership
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
     dependency = require_org_role("member")
     with pytest.raises(HTTPException) as exc_info:
-        dependency(org_login="acme", db=db, user=user_out)
+        dependency(org_login="widgets", db=db, user=user)
 
     assert exc_info.value.status_code == 403
     assert _current_setting(db, "app.tenant_id") is None
@@ -57,9 +154,8 @@ def test_require_org_role_does_not_set_session_vars_on_403(db):
 
 def test_require_personal_tenant_sets_session_vars(db):
     user = _make_user(db, "carol@example.com")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-    ctx = require_personal_tenant(db=db, user=user_out)
+    ctx = require_personal_tenant(db=db, user=user)
 
     assert ctx.tenant.kind == "personal"
     assert ctx.tenant.personal_user_id == user.id
@@ -69,9 +165,8 @@ def test_require_personal_tenant_sets_session_vars(db):
 
 def test_require_personal_tenant_is_idempotent(db):
     user = _make_user(db, "dave@example.com")
-    user_out = UserOut(id=user.id, email=user.email, name=user.name, is_workspace_admin=False)
 
-    first = require_personal_tenant(db=db, user=user_out)
-    second = require_personal_tenant(db=db, user=user_out)
+    first = require_personal_tenant(db=db, user=user)
+    second = require_personal_tenant(db=db, user=user)
 
     assert second.tenant.id == first.tenant.id

--- a/apps/api/tests/test_tenant_repo.py
+++ b/apps/api/tests/test_tenant_repo.py
@@ -175,3 +175,49 @@ def test_delete_membership_is_a_noop_when_missing(db):
     user = _make_user(db, "ivan@example.com")
 
     tenant_repo.delete_membership(db, tenant_id=tenant.id, user_id=user.id)  # must not raise
+
+
+# ── upsert_membership ─────────────────────────────────────────────────────────
+
+def test_upsert_membership_creates_when_missing(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "judy@example.com")
+
+    membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    assert membership.role == "member"
+
+
+def test_upsert_membership_fixes_a_stale_role(db):
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "kevin@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert membership.role == "admin"
+
+
+def test_upsert_membership_recreates_a_row_deleted_between_its_two_internal_lookups(db):
+    # Regression test: upsert_membership's internal update_membership_role call can find
+    # nothing if a concurrent delete_membership races in between its get-or-create and its
+    # role-reconciliation step. Must recreate the row rather than returning None despite
+    # the function's non-Optional Membership return type.
+    org_id = _acme_org_id(db)
+    tenant = tenant_repo.get_or_create_org_tenant(db, org_id)
+    user = _make_user(db, "laura@example.com")
+    tenant_repo.get_or_create_membership(db, tenant_id=tenant.id, user_id=user.id, role="member")
+
+    original_update = tenant_repo.update_membership_role
+
+    def racy_update(db, tenant_id, user_id, role):
+        tenant_repo.delete_membership(db, tenant_id=tenant_id, user_id=user_id)
+        return original_update(db, tenant_id=tenant_id, user_id=user_id, role=role)
+
+    with patch.object(tenant_repo, "update_membership_role", racy_update):
+        membership = tenant_repo.upsert_membership(db, tenant_id=tenant.id, user_id=user.id, role="admin")
+
+    assert membership is not None
+    assert membership.role == "admin"


### PR DESCRIPTION
## Summary

Issue #190 (S2 multi-tenancy), PR 5a of 7 (RLS enablement, split in two for risk containment — see design rationale below). Two things:

1. Enforces `NOT NULL` on `invitations.tenant_id` and `github_installations.tenant_id`, now that PR 4's dual-write (already merged) covers every write path.
2. Wires `require_org_role` and a new `require_personal_tenant` dependency to set `app.tenant_id`/`app.user_id` Postgres session variables — scaffolding for PR 5b's RLS policies, no behavior change yet (nothing reads these variables until PR 5b).

## Schema change (per AGENTS.md's migration guardrail)

**Yes** — migration `0029_enforce_tenant_id_not_null`. Re-runs the original backfill `UPDATE` from migrations `0025`/`0026` (idempotent) to catch any row created in the deploy gap between those migrations landing and PR 4's dual-write code actually shipping, then `ALTER COLUMN ... SET NOT NULL`.

**Data-loss/backfill risk, stated explicitly per the guardrail:** if a real gap exists beyond what the backfill can resolve, the `ALTER COLUMN` fails atomically and the whole migration rolls back — verified this directly against real Postgres: seeded a genuine unbackfillable gap (an org with no tenant row, an invitation pointing at it with `tenant_id=NULL`), confirmed `alembic upgrade head` failed with a clean `NotNullViolation` and rolled back to the prior revision with no partial state, then fixed the gap and confirmed a clean upgrade.

**`orgs.tenant_id` is deliberately excluded and stays nullable permanently** — a real structural finding from this PR: creating a brand-new org requires inserting both the `Org` row (needs `tenant_id`) and its reciprocal `Tenant` row (needs `org_id`, via the composite FK from migration `0024`) — each references the other's not-yet-existing id. Postgres `NOT NULL` constraints can't be deferred (only FK/UNIQUE/PK/EXCLUSION constraints can), so there's no way to insert a genuinely new org+tenant pair in one transaction under a hard `NOT NULL`, short of a materially more complex deferred-FK migration. Decided with the repo owner to keep `orgs.tenant_id` nullable and rely on `org_repo.get_or_create`'s existing self-healing dual-write instead — same accepted pattern already used for `scan_results`/`saved_tokens.tenant_id`.

## What changed

- `apps/api/alembic/versions/0029_enforce_tenant_id_not_null.py` (new) — includes the verification-query runbook inline in its docstring (a standalone `docs/` file was considered but this repo's `.gitignore` reserves `docs/` for local Claude planning artifacts, only `docs/self-hosting.md` is actually tracked).
- `apps/api/src/core/db.py` — `Invitation.tenant_id`/`GitHubInstallation.tenant_id` become non-optional `Mapped[int]`; `Org.tenant_id` stays `Mapped[int | None]` with an updated docstring explaining why.
- `apps/api/src/core/rbac.py` — `require_org_role` now sets `app.tenant_id`/`app.user_id` (plain `SET`, not `SET LOCAL` — a request's `Session` lifetime doesn't cleanly map to one transaction) after resolving org+membership, self-healing `org.tenant_id` inline if a legacy row resolved via `get_by_login` never went through `get_or_create`'s dual-write. New `require_personal_tenant` dependency does the same for the caller's own personal tenant. Not yet wired into any `/me/...` route — those that go through `token_resolution.resolve_owner_token` can resolve to either an org or personal tenant depending on the `owner` path param, which is a real design fork deferred to before PR 6, not decided here.
- `apps/api/src/repositories/tenant_repo.py` — new `upsert_membership` (get-or-create plus role reconciliation).
- `apps/api/src/repositories/org_membership_repo.py` — **CodeRabbit finding on PR #323, fixed:** `get_or_create`'s early-return path (membership already exists — the common case, since `org_provisioning.py`'s reconcile loop calls this on every login) and its concurrent-insert-race recovery path both skipped the `Membership` mirror write entirely; `update_role`'s mirror call also silently no-op'd if the mirror row didn't exist yet (`tenant_repo.update_membership_role` returns `None` on a missing row and nothing checked that). All three functions now funnel through a shared `_sync_membership_mirror` helper backed by the new `upsert_membership`, so the mirror self-heals on every call regardless of which path is taken.

**Also evaluated, deliberately not fixed here:** a second CodeRabbit finding on PR #323 about `tenant_repo.ensure_personal_tenant` and its 3 callers (`auth.py` setup/register, `github_auth.py`) not being fully atomic with the user-row commit — a real gap (a failure between the separate commits could leave an orphaned `User` with no personal tenant), but CodeRabbit itself tagged it "Heavy lift," and the existing codebase already has the same multi-commit-within-one-request pattern elsewhere (e.g. `org_repo.get_or_create`'s own two-phase org-insert-then-tenant-link). Fixing it properly would mean restructuring commit boundaries across 3 files for a low-probability edge case, out of scope for this PR.

## Test plan

- [x] New `apps/api/tests/test_rbac.py` — asserts `require_org_role`/`require_personal_tenant` actually set the session variables (and don't on a 403), using `current_setting()`.
- [x] Extended `test_org_membership_repo.py` — two regression tests reproducing the CodeRabbit-flagged gap directly (a missing mirror row and a stale mirror role both get repaired on the next `get_or_create` call).
- [x] Migration verified against real Postgres: downgrade/upgrade cycle, a deliberately-seeded unbackfillable gap causing a clean atomic failure (see above), then a clean upgrade after fixing it.
- [x] `pytest -q` — 629 passed.
- [x] `bun run test` via the pre-push hook — 388 passed (no UI files touched by this PR; one earlier push attempt hit an unrelated pre-existing flaky font-import test under local resource contention, resolved on retry).
- [x] `ruff check` on all touched Python files — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tenant and user context isolation when database connections are reused.
  - Automatically repairs missing or outdated organization membership links.
  - Ensures required tenant associations are populated and consistently maintained.
  - Strengthened authorization handling for organization and personal-tenant access.

- **Data Integrity**
  - Tenant associations for invitations and GitHub installations are now required.

- **Tests**
  - Added coverage for context cleanup, authorization behavior, membership repair, and concurrent membership updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->