### PR TITLE
feat(db): cut over RBAC reads from org_memberships to memberships

### DIFF
--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -14,8 +14,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, Tenant, get_db
-from src.repositories import org_membership_repo, org_repo, tenant_repo
+from src.core.db import Membership, Org, Tenant, get_db
+from src.repositories import org_repo, tenant_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -23,7 +23,7 @@ _ROLE_RANK = {"member": 0, "admin": 1}
 @dataclass
 class OrgContext:
     org: Org
-    membership: OrgMembership
+    membership: Membership
 
 
 @dataclass
@@ -58,14 +58,17 @@ def require_org_role(min_role: Literal["member", "admin"]):
         org = org_repo.get_by_login(db, org_login)
         if org is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
-        membership = org_membership_repo.get(db, org.id, user.id)
-        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
         # resolved here via get_by_login (not get_or_create) never gets org_repo's own
         # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
-        # itself uses, rather than a separate hand-rolled copy of the same logic.
+        # itself uses, rather than a separate hand-rolled copy of the same logic. Resolved
+        # ahead of the role check (issue #190 step 6a) so the role lookup itself can read
+        # from `memberships` (tenant_id-keyed), the new source of truth for org RBAC, instead
+        # of the legacy `org_memberships` table (org_id-keyed) it used to read.
         org = org_repo.ensure_tenant_linked(db, org)
+        membership = tenant_repo.get_membership(db, org.tenant_id, user.id)
+        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         _set_tenant_session_context(db, org.tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from src.core.db import Membership, Tenant
+from src.core.db import Membership, Org, Tenant
 
 
 def get_or_create_org_tenant(db: Session, org_id: int) -> Tenant:
@@ -70,6 +70,28 @@ def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Te
             db.add(Membership(tenant_id=tenant.id, user_id=user_id, role="admin"))
             db.flush()
     return tenant
+
+
+def get_membership(db: Session, tenant_id: int, user_id: int) -> Membership | None:
+    """Read-only lookup, keyed on tenant_id -- the memberships-side equivalent of
+    org_membership_repo.get's org_id-keyed lookup on the legacy org_memberships table.
+    Issue #190 step 6a: RBAC callsites now read from here instead of org_memberships;
+    org_membership_repo's write functions are unchanged and keep dual-writing into
+    memberships via _sync_membership_mirror, so this always sees the current state."""
+    return db.query(Membership).filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id).first()
+
+
+def list_org_memberships_for_user(db: Session, user_id: int) -> list[tuple[Org, Membership]]:
+    """All of a user's org-tenant memberships, joined back to each Org row -- the
+    memberships-side equivalent of org_membership_repo.list_for_user, for callers that
+    need to enumerate a user's orgs rather than check one specific org."""
+    return (
+        db.query(Org, Membership)
+        .join(Tenant, Tenant.org_id == Org.id)
+        .join(Membership, Membership.tenant_id == Tenant.id)
+        .filter(Membership.user_id == user_id, Tenant.kind == "org")
+        .all()
+    )
 
 
 def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
-from src.repositories import installation_repo, job_repo, org_membership_repo, org_repo, scan_results_repo
+from src.repositories import installation_repo, job_repo, org_repo, scan_results_repo, tenant_repo
 from src.routers.github import _cached_events
 from src.schemas.analytics import (
     AnalyticsInput,
@@ -86,8 +86,10 @@ def _user_can_read_history(db: Session, user: UserOut, owner: str) -> bool:
     personal scan against that owner before (scanned_by_user_id, for owners with
     no workspace Org/membership at all -- the raw-PAT-paste flow)."""
     org = org_repo.get_by_login(db, owner)
-    if org is not None and org_membership_repo.get(db, org.id, user.id) is not None:
-        return True
+    if org is not None:
+        org = org_repo.ensure_tenant_linked(db, org)
+        if tenant_repo.get_membership(db, org.tenant_id, user.id) is not None:
+            return True
     if installation_repo.get_for_user(db, owner_user_id=user.id, account_login=owner) is not None:
         return True
     return scan_results_repo.exists_for_user(db, owner=owner, user_id=user.id)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -27,9 +27,9 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, User, get_db
+from src.core.db import Membership, Org, User, get_db
 from src.core.rbac import OrgContext, require_org_role
-from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo
+from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo, tenant_repo
 from src.schemas.installation import (
     InstallationLookupOut,
     InstallationOut,
@@ -149,7 +149,9 @@ def sync_org_installation(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="owner must match the org in the URL")
 
     org: Org | None = org_repo.get_by_login(db, org_login)
-    membership: OrgMembership | None = org_membership_repo.get(db, org.id, user.id) if org else None
+    if org is not None:
+        org = org_repo.ensure_tenant_linked(db, org)
+    membership: Membership | None = tenant_repo.get_membership(db, org.tenant_id, user.id) if org else None
     is_known_admin = org is not None and membership is not None and membership.role == "admin"
 
     # Only a caller who ISN'T already a confirmed local admin needs the extra checks below

--- a/apps/api/src/routers/orgs.py
+++ b/apps/api/src/routers/orgs.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, get_db
-from src.repositories import org_membership_repo
+from src.core.db import get_db
+from src.repositories import tenant_repo
 from src.schemas.org import MyOrgMembershipOut
 
 router = APIRouter()
@@ -13,10 +13,7 @@ router = APIRouter()
 
 @router.get("/me/orgs", response_model=list[MyOrgMembershipOut])
 def list_my_orgs(user: UserOut = Depends(require_auth), db: Session = Depends(get_db)):
-    memberships = org_membership_repo.list_for_user(db, user_id=user.id)
-    org_by_id = {org.id: org for org in db.query(Org).filter(Org.id.in_([m.org_id for m in memberships])).all()}
     return [
-        {"org_login": org_by_id[m.org_id].github_login, "role": m.role}
-        for m in memberships
-        if m.org_id in org_by_id
+        {"org_login": org.github_login, "role": membership.role}
+        for org, membership in tenant_repo.list_org_memberships_for_user(db, user_id=user.id)
     ]

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -30,7 +30,7 @@ import httpx
 from sqlalchemy.orm import Session
 
 from src.core.db import User
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import org_membership_repo, org_repo, tenant_repo
 from src.services import github_oauth
 
 logger = logging.getLogger(__name__)
@@ -55,12 +55,11 @@ def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None
         if membership.role != "admin":
             org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
 
-    for membership in org_membership_repo.list_for_user(db, user.id):
-        org = org_repo.get_by_id(db, membership.org_id)
-        if org is None or org.github_org_id is None:
+    for org, membership in tenant_repo.list_org_memberships_for_user(db, user.id):
+        if org.github_org_id is None:
             continue
         gh_role = gh_role_by_org_id.get(org.github_org_id)
         if gh_role is None:
-            org_membership_repo.delete(db, org_id=membership.org_id, user_id=user.id)
+            org_membership_repo.delete(db, org_id=org.id, user_id=user.id)
         elif gh_role == "member" and membership.role != "member":
-            org_membership_repo.update_role(db, org_id=membership.org_id, user_id=user.id, role="member")
+            org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="member")

--- a/apps/api/src/services/token_resolution.py
+++ b/apps/api/src/services/token_resolution.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from src.core.config import settings
 from src.core.db import GitHubInstallation
-from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.repositories import installation_repo, org_repo, tenant_repo
 from src.services import github_app
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,8 @@ def resolve_owner_token(
     """
     org = org_repo.get_by_login_ci(db, owner)
     if org is not None:
-        membership = org_membership_repo.get(db, org.id, user_id)
+        org = org_repo.ensure_tenant_linked(db, org)
+        membership = tenant_repo.get_membership(db, org.tenant_id, user_id)
         if membership is not None:
             if _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
                 raise InsufficientOrgRole(f"'{min_role}' access to '{owner}' is required for this action.")


### PR DESCRIPTION
## Summary

Issue #190, step 6a of the multi-tenancy rollout (7-PR breakdown, see #190's design comment). Every org-scoped role/membership lookup now reads from the newer `memberships` table (`tenant_id`-keyed) instead of the legacy `org_memberships` table (`org_id`-keyed):

- `src/core/rbac.py` — `require_org_role`'s role check
- `src/routers/installations.py` — `sync_org_installation`'s known-admin check
- `src/routers/analytics.py` — `_user_can_read_history`'s org-membership visibility check
- `src/services/token_resolution.py` — org-vs-personal installation token preference
- `src/routers/orgs.py` — `GET /me/orgs` listing
- `src/services/org_provisioning.py` — GitHub-login-time membership reconciliation read

**No schema change, no migration file** — this is a pure app-code read-source swap. Writes are untouched: `org_membership_repo`'s write functions (`get_or_create`, `update_role`, `delete`) still write `org_memberships` primarily and mirror into `memberships` exactly as before (that mirroring was built in the already-merged dual-write PR). Dropping the `org_memberships` write path entirely is out of scope here — that's issue #190's step 7, a separate follow-up issue.

## Why now, and why scoped this way

The RLS scaffolding migration (`0030`, merged in #325) enabled row-level-security policies but deliberately didn't turn on `FORCE ROW LEVEL SECURITY` yet, so nothing here is forced to read from `memberships` — this PR is about making `memberships` the actual source of truth for RBAC *before* flipping that switch, so the cutover and the enforcement change aren't bundled into one risky PR.

The originally-scoped "step 6" (cutover + `FORCE ROW LEVEL SECURITY`) turned out to bundle three separable risks once I researched it: (a) this read cutover, (b) `SavedToken`/`ScanResult` writes that currently omit `tenant_id` entirely and would start failing their RLS `WITH CHECK` the moment `FORCE` is on, and (c) workspace-admin cross-tenant routes (audit logs, token management) that would lose their unfiltered access under `FORCE` unless something (likely a `BYPASSRLS` grant) is added. Splitting this PR out first keeps it behavior-neutral and independently revertable; a follow-up PR will tackle `FORCE` + the write-path backfills + the workspace-admin bypass decision together, since `FORCE` is what makes (b) and (c) matter at all.

## A reordering worth flagging

`require_org_role` used to resolve `org.tenant_id` (via the existing self-healing `ensure_tenant_linked`) *after* the role check, purely to feed the RLS session variable. It now resolves `tenant_id` *before* the role check, since the role lookup itself needs it to query `memberships`. `ensure_tenant_linked` is idempotent and self-healing (unchanged), so this reordering has no behavior change beyond making `tenant_id` available earlier in the function.

## Verification

- Full `pytest -q`: 649 passed — the existing RBAC-heavy test suite (installation sync, GitHub OAuth provisioning, org membership repo, invitations) exercises every callsite touched here and stayed green.
- Beyond the test suite, a direct proof against real Postgres that the cutover is real and not just "tests still pass because the dual-write happens to keep both tables in sync": manually diverged the two tables for a throwaway membership — with only a `memberships` row present (`org_memberships` deleted), the RBAC read still succeeds; with only an `org_memberships` row present (`memberships` deleted), the RBAC read now correctly fails. This proves `org_memberships` is no longer authoritative for reads, not merely that the mirror still matches in the common case. Test data fully cleaned up afterward.

## Not in scope for this PR

- `FORCE ROW LEVEL SECURITY` on any table.
- Backfilling `tenant_id` on `SavedToken` writes (`tokens.py`) and personal-scan `ScanResult` writes (`analytics.py`'s personal-analytics path).
- The workspace-admin cross-tenant access story for `audit.py`/`tokens.py` once `FORCE` is enabled.
- Dropping `org_memberships` writes entirely — separate follow-up issue from #190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization access checks by consistently using tenant-linked memberships.
  * Fixed authorization for analytics history, installations, token resolution, and organization listings.
  * Improved organization synchronization and membership reconciliation reliability.
* **Improvements**
  * Organization membership results are now retrieved more efficiently and consistently.
  * Organizations are automatically linked to their tenant before membership access is evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->