### PR TITLE
feat(db): backfill tenant_id on ScanResult writes

### DIFF
--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -14,8 +14,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, Tenant, get_db
-from src.repositories import org_membership_repo, org_repo, tenant_repo
+from src.core.db import Membership, Org, Tenant, get_db
+from src.repositories import org_repo, tenant_repo
 
 _ROLE_RANK = {"member": 0, "admin": 1}
 
@@ -23,7 +23,7 @@ _ROLE_RANK = {"member": 0, "admin": 1}
 @dataclass
 class OrgContext:
     org: Org
-    membership: OrgMembership
+    membership: Membership
 
 
 @dataclass
@@ -58,14 +58,17 @@ def require_org_role(min_role: Literal["member", "admin"]):
         org = org_repo.get_by_login(db, org_login)
         if org is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
-        membership = org_membership_repo.get(db, org.id, user.id)
-        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
         # resolved here via get_by_login (not get_or_create) never gets org_repo's own
         # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
-        # itself uses, rather than a separate hand-rolled copy of the same logic.
+        # itself uses, rather than a separate hand-rolled copy of the same logic. Resolved
+        # ahead of the role check (issue #190 step 6a) so the role lookup itself can read
+        # from `memberships` (tenant_id-keyed), the new source of truth for org RBAC, instead
+        # of the legacy `org_memberships` table (org_id-keyed) it used to read.
         org = org_repo.ensure_tenant_linked(db, org)
+        membership = tenant_repo.get_membership(db, org.tenant_id, user.id)
+        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
         _set_tenant_session_context(db, org.tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 

--- a/apps/api/src/repositories/scan_results_repo.py
+++ b/apps/api/src/repositories/scan_results_repo.py
@@ -12,6 +12,7 @@ def insert(
     total_checks: int,
     failed_checks: int,
     checks: list[dict],
+    tenant_id: int | None = None,
     scanned_by_user_id: int | None = None,
 ) -> None:
     db.add(
@@ -21,6 +22,7 @@ def insert(
             total_checks=total_checks,
             failed_checks=failed_checks,
             checks_json=json.dumps(checks),
+            tenant_id=tenant_id,
             scanned_by_user_id=scanned_by_user_id,
         )
     )

--- a/apps/api/src/repositories/tenant_repo.py
+++ b/apps/api/src/repositories/tenant_repo.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from src.core.db import Membership, Tenant
+from src.core.db import Membership, Org, Tenant
 
 
 def get_or_create_org_tenant(db: Session, org_id: int) -> Tenant:
@@ -70,6 +70,28 @@ def ensure_personal_tenant(db: Session, user_id: int, commit: bool = True) -> Te
             db.add(Membership(tenant_id=tenant.id, user_id=user_id, role="admin"))
             db.flush()
     return tenant
+
+
+def get_membership(db: Session, tenant_id: int, user_id: int) -> Membership | None:
+    """Read-only lookup, keyed on tenant_id -- the memberships-side equivalent of
+    org_membership_repo.get's org_id-keyed lookup on the legacy org_memberships table.
+    Issue #190 step 6a: RBAC callsites now read from here instead of org_memberships;
+    org_membership_repo's write functions are unchanged and keep dual-writing into
+    memberships via _sync_membership_mirror, so this always sees the current state."""
+    return db.query(Membership).filter(Membership.tenant_id == tenant_id, Membership.user_id == user_id).first()
+
+
+def list_org_memberships_for_user(db: Session, user_id: int) -> list[tuple[Org, Membership]]:
+    """All of a user's org-tenant memberships, joined back to each Org row -- the
+    memberships-side equivalent of org_membership_repo.list_for_user, for callers that
+    need to enumerate a user's orgs rather than check one specific org."""
+    return (
+        db.query(Org, Membership)
+        .join(Tenant, Tenant.org_id == Org.id)
+        .join(Membership, Membership.tenant_id == Tenant.id)
+        .filter(Membership.user_id == user_id, Tenant.kind == "org")
+        .all()
+    )
 
 
 def get_or_create_membership(db: Session, tenant_id: int, user_id: int, role: str) -> Membership:

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -65,7 +65,7 @@ async def _get_account_type(owner: str, token: str) -> str:
         raise HTTPException(status_code=503, detail="GitHub API unreachable")
 
 
-def _persist_scan(db: Session, result: dict, scanned_by_user_id: int | None = None) -> None:
+def _persist_scan(db: Session, result: dict, tenant_id: int | None, scanned_by_user_id: int | None = None) -> None:
     scan_results_repo.insert(
         db,
         owner=result["owner"],
@@ -73,6 +73,7 @@ def _persist_scan(db: Session, result: dict, scanned_by_user_id: int | None = No
         total_checks=result["total_checks"],
         failed_checks=result["failed_checks"],
         checks=result["checks"],
+        tenant_id=tenant_id,
         scanned_by_user_id=scanned_by_user_id,
     )
 
@@ -110,7 +111,7 @@ async def org_analytics_overview(
     except NoGitHubTokenAvailable as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     result = await _run_overview(payload.owner, token)
-    _persist_scan(db, result)
+    _persist_scan(db, result, tenant_id=ctx.org.tenant_id)
     return result
 
 
@@ -134,7 +135,12 @@ async def personal_analytics_overview(
             detail="Personal GitHub accounts aren't supported for security scanning yet. Connect a GitHub organization instead.",
         )
     result = await _run_overview(payload.owner, token)
-    _persist_scan(db, result, scanned_by_user_id=user.id)
+    # payload.owner here can be any GitHub account the user has a token for (bring-your-own-
+    # token path), not necessarily a Clevis org -- the scan row is associated with the
+    # scanning user's own personal tenant, consistent with the existing scanned_by_user_id-
+    # based access-gating design (see ScanResult.tenant_id/scanned_by_user_id in db.py).
+    personal_tenant = tenant_repo.ensure_personal_tenant(db, user.id)
+    _persist_scan(db, result, tenant_id=personal_tenant.id, scanned_by_user_id=user.id)
     return result
 
 

--- a/apps/api/src/routers/analytics.py
+++ b/apps/api/src/routers/analytics.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from src.core.auth import UserOut, require_auth
 from src.core.db import get_db
 from src.core.rbac import OrgContext, assert_owner_matches_org, require_org_role
-from src.repositories import installation_repo, job_repo, org_membership_repo, org_repo, scan_results_repo
+from src.repositories import installation_repo, job_repo, org_repo, scan_results_repo, tenant_repo
 from src.routers.github import _cached_events
 from src.schemas.analytics import (
     AnalyticsInput,
@@ -86,8 +86,10 @@ def _user_can_read_history(db: Session, user: UserOut, owner: str) -> bool:
     personal scan against that owner before (scanned_by_user_id, for owners with
     no workspace Org/membership at all -- the raw-PAT-paste flow)."""
     org = org_repo.get_by_login(db, owner)
-    if org is not None and org_membership_repo.get(db, org.id, user.id) is not None:
-        return True
+    if org is not None:
+        org = org_repo.ensure_tenant_linked(db, org)
+        if tenant_repo.get_membership(db, org.tenant_id, user.id) is not None:
+            return True
     if installation_repo.get_for_user(db, owner_user_id=user.id, account_login=owner) is not None:
         return True
     return scan_results_repo.exists_for_user(db, owner=owner, user_id=user.id)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -27,9 +27,9 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, OrgMembership, User, get_db
+from src.core.db import Membership, Org, User, get_db
 from src.core.rbac import OrgContext, require_org_role
-from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo
+from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo, tenant_repo
 from src.schemas.installation import (
     InstallationLookupOut,
     InstallationOut,
@@ -149,7 +149,9 @@ def sync_org_installation(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="owner must match the org in the URL")
 
     org: Org | None = org_repo.get_by_login(db, org_login)
-    membership: OrgMembership | None = org_membership_repo.get(db, org.id, user.id) if org else None
+    if org is not None:
+        org = org_repo.ensure_tenant_linked(db, org)
+    membership: Membership | None = tenant_repo.get_membership(db, org.tenant_id, user.id) if org else None
     is_known_admin = org is not None and membership is not None and membership.role == "admin"
 
     # Only a caller who ISN'T already a confirmed local admin needs the extra checks below

--- a/apps/api/src/routers/orgs.py
+++ b/apps/api/src/routers/orgs.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Org, get_db
-from src.repositories import org_membership_repo
+from src.core.db import get_db
+from src.repositories import tenant_repo
 from src.schemas.org import MyOrgMembershipOut
 
 router = APIRouter()
@@ -13,10 +13,7 @@ router = APIRouter()
 
 @router.get("/me/orgs", response_model=list[MyOrgMembershipOut])
 def list_my_orgs(user: UserOut = Depends(require_auth), db: Session = Depends(get_db)):
-    memberships = org_membership_repo.list_for_user(db, user_id=user.id)
-    org_by_id = {org.id: org for org in db.query(Org).filter(Org.id.in_([m.org_id for m in memberships])).all()}
     return [
-        {"org_login": org_by_id[m.org_id].github_login, "role": m.role}
-        for m in memberships
-        if m.org_id in org_by_id
+        {"org_login": org.github_login, "role": membership.role}
+        for org, membership in tenant_repo.list_org_memberships_for_user(db, user_id=user.id)
     ]

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -30,7 +30,7 @@ import httpx
 from sqlalchemy.orm import Session
 
 from src.core.db import User
-from src.repositories import org_membership_repo, org_repo
+from src.repositories import org_membership_repo, org_repo, tenant_repo
 from src.services import github_oauth
 
 logger = logging.getLogger(__name__)
@@ -55,12 +55,11 @@ def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None
         if membership.role != "admin":
             org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="admin")
 
-    for membership in org_membership_repo.list_for_user(db, user.id):
-        org = org_repo.get_by_id(db, membership.org_id)
-        if org is None or org.github_org_id is None:
+    for org, membership in tenant_repo.list_org_memberships_for_user(db, user.id):
+        if org.github_org_id is None:
             continue
         gh_role = gh_role_by_org_id.get(org.github_org_id)
         if gh_role is None:
-            org_membership_repo.delete(db, org_id=membership.org_id, user_id=user.id)
+            org_membership_repo.delete(db, org_id=org.id, user_id=user.id)
         elif gh_role == "member" and membership.role != "member":
-            org_membership_repo.update_role(db, org_id=membership.org_id, user_id=user.id, role="member")
+            org_membership_repo.update_role(db, org_id=org.id, user_id=user.id, role="member")

--- a/apps/api/src/services/token_resolution.py
+++ b/apps/api/src/services/token_resolution.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 
 from src.core.config import settings
 from src.core.db import GitHubInstallation
-from src.repositories import installation_repo, org_membership_repo, org_repo
+from src.repositories import installation_repo, org_repo, tenant_repo
 from src.services import github_app
 
 logger = logging.getLogger(__name__)
@@ -140,7 +140,8 @@ def resolve_owner_token(
     """
     org = org_repo.get_by_login_ci(db, owner)
     if org is not None:
-        membership = org_membership_repo.get(db, org.id, user_id)
+        org = org_repo.ensure_tenant_linked(db, org)
+        membership = tenant_repo.get_membership(db, org.tenant_id, user_id)
         if membership is not None:
             if _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
                 raise InsufficientOrgRole(f"'{min_role}' access to '{owner}' is required for this action.")


### PR DESCRIPTION
## Summary

Issue #190, part of the multi-tenancy rollout. Both scan-persisting paths in `analytics.py` now set `tenant_id` on the `ScanResult` row they insert:

- `org_analytics_overview`: passes `ctx.org.tenant_id` — already resolved by `require_org_role` before the route body runs.
- `personal_analytics_overview`: resolves the scanning user's own personal tenant via the existing `tenant_repo.ensure_personal_tenant` helper. `payload.owner` on this route can be any GitHub account the user has a token for (bring-your-own-token path), not necessarily a Clevis org, so the scan row is associated with the *scanning user's* personal tenant — consistent with the existing `scanned_by_user_id`-based access-gating design already documented on the `ScanResult` model.

**No migration** — the `tenant_id` column already exists (migration `0027`) and is nullable, so this is a pure app-code write-path change.

## Why this PR, and why it's scoped this narrowly

This was originally going to be part of a bigger "6b: enable `FORCE ROW LEVEL SECURITY`" PR, following the read-cutover in #326. Researching that turned up a much bigger problem than expected: migration `0030`'s policies for `memberships`/`github_installations`/`invitations`/`audit_logs` default `WITH CHECK` to the same expression as `USING`, so under `FORCE`, every write to those tables would need `app.tenant_id` already correctly set in the session — and several real write paths don't set it today (installation-bootstrap, invitation-accept, OAuth-login org provisioning). There's also a structural chicken-and-egg problem: `orgs` and `invitations` are both read *to discover* which tenant something belongs to, so they can't be gated behind already knowing that tenant. Separately, `audit_logs` and `saved_tokens` turned out to be genuinely cross-tenant-by-design admin panels (`list_audit_logs`/`list_tokens` intentionally list across every org) — `FORCE` would break them outright, and `BYPASSRLS` isn't a fix since it's an all-or-nothing role attribute that would neuter RLS for every query the app's one DB role makes.

Given that, enabling `FORCE` anywhere needs a dedicated write-path audit-and-fix pass first — separate, appropriately-scoped work, not something to bundle in here. This PR does the one piece that was genuinely safe and self-contained today: `scan_results` has no chicken-and-egg or write-context problem (both write paths already run after a real tenant is resolved), so it closes the write-side gap CodeRabbit originally flagged on the RLS scaffolding PR (#325) for that one table, ahead of whatever PR eventually turns `FORCE` on.

## Verification

- Full `pytest -q`: 649 passed.
- Beyond the test suite: a throwaway test hit both live endpoints (org and personal, GitHub calls mocked) and confirmed the resulting `scan_results` row's `tenant_id` matches `org.tenant_id` / the scanning user's personal tenant id respectively. Deleted afterward — not part of this commit.

## Not in scope for this PR

- `FORCE ROW LEVEL SECURITY` on any table.
- Auditing/fixing tenant-session-context gaps in installation-bootstrap, invitation-accept, and OAuth-login org provisioning.
- Backfilling `tenant_id` on `SavedToken` writes — no longer blocking anything now that `saved_tokens` is expected to stay `ENABLE`-only permanently (cross-tenant-by-design admin panel).
- The final access-control design for `audit_logs`/`saved_tokens` workspace-admin cross-tenant reads.
- Dropping `org_memberships` writes entirely — separate follow-up issue from #190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Improved organization access checks using tenant-based memberships.
  * Updated token and installation authorization to ensure organizations are properly linked.

* **Analytics**
  * Scan history now records the associated tenant for organization and personal scans.
  * Improved history access validation.

* **Organization Management**
  * Improved organization listing and membership synchronization.
  * Membership data is retrieved more consistently across organization features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->