### PR TITLE
feat(db): widen membership RLS with self-access and enable FORCE

### DIFF
--- a/apps/api/alembic/versions/0031_membership_self_access_force_rls.py
+++ b/apps/api/alembic/versions/0031_membership_self_access_force_rls.py
@@ -1,0 +1,140 @@
+"""Widen memberships/github_installations RLS with self-access + enable FORCE (issue #190, PR 6c).
+
+*** IMPORTANT CAVEAT, discovered while building this migration ***
+The API's own DB role (DB_USER, e.g. "clevis") is a Postgres SUPERUSER in the default
+docker-compose deployment: docker-compose.yml sets POSTGRES_USER: ${DB_USER}, and the
+official postgres image always makes that role the initdb bootstrap superuser -- there is
+no way to make it non-superuser through that env var alone. Postgres superusers
+unconditionally bypass RLS, ENABLE or FORCE, no exceptions -- so as of this migration, FORCE
+ROW LEVEL SECURITY has NO EFFECT on the actual running system, despite everything in this
+migration and its policies being logically correct (verified against a manually-created
+non-superuser test role, not the app's real connection). This mirrors a gap migration 0020
+already solved for the *worker* (a dedicated clevis_worker non-superuser role with explicit
+GRANTs) -- the API itself never got the equivalent treatment. Giving the API its own
+non-superuser role is separate, dedicated infrastructure work (new role, GRANTs, connection
+string/entrypoint changes) tracked as a follow-up, not folded into this migration. Everything
+here is still worth doing now: it's the correct, safe policy design and the FORCE flag itself
+is inert-but-harmless until that follow-up lands, at which point it starts actually enforcing
+with no further schema change needed.
+
+Migration 0030 enabled RLS (ENABLE, not FORCE) and added tenant_id-equality policies, but
+left FORCE off precisely because a write-path audit (done for this migration) found every
+write into `memberships` in the entire codebase never ran through require_org_role/
+require_personal_tenant -- the only places that set the app.tenant_id session variable
+migration 0030's policies read. Under FORCE, those policies' implicit WITH CHECK (Postgres
+defaults it to the same expression as USING when a policy omits it) would reject every one
+of those writes.
+
+The audit (see PR description) found something useful: every single one of those writes is
+a *self-write* -- the row's user_id (memberships) or owner_user_id (github_installations,
+personal installations only) always equals the currently-authenticated caller:
+  - installations.py's _bootstrap_org_admin_from_installation (org-admin bootstrap)
+  - installations.py's sync_personal_installation (via installation_repo.upsert's internal
+    tenant_repo.ensure_personal_tenant call)
+  - invitations.py's accept_invitation
+  - org_provisioning.py's sync_org_admin_memberships (OAuth-login provisioning, both loops)
+  - rbac.py's own require_personal_tenant had an internal ordering bug: it wrote the
+    membership *before* calling set_tenant_session_context -- even the "guarded" path
+    wasn't guarded for its own write
+  - auth.py's setup/register and github_auth.py's find_or_create_user (pre-login personal
+    tenant/membership creation, same transaction as the new User row)
+
+Rather than add a tenant-resolving call at each of those sites individually (fragile, as
+require_personal_tenant's own bug demonstrates -- easy to miss one as the code evolves),
+the app-code half of this PR sets app.user_id broadly in require_auth itself (the one
+dependency nearly every authenticated route already uses, via the new
+src.core.db.set_session_user), plus a few explicit calls at routes with no request-scoped
+caller identity (pre-login flows, the OAuth callback's multi-org provisioning loop). This
+migration is the matching database-side half: widen the policies with an additional
+self-access clause, so a row is also visible/writable when its own user_id/owner_user_id
+matches app.user_id, regardless of tenant session context.
+
+This is safe: since every real write is confirmed self-scoped, letting a user always read/
+write their OWN membership or personal-installation row can never leak another tenant's or
+another user's data -- the isolation boundary that actually matters (a *mismatched*
+user_id) is still fully enforced by the unchanged tenant_id-equality half of each policy.
+Verified against real Postgres (see PR description): a non-owner test role CAN read/write
+its own row regardless of session tenant context, and CANNOT read/write a *different*
+user's row in a tenant it doesn't belong to.
+
+github_installations' org-scoped rows (org_id set, owner_user_id NULL) have no per-row user
+column, so the self-access clause only helps owner_user_id-scoped (personal) rows. The one
+remaining org-scoped write (installations.py's sync_org_installation, installation_repo.create)
+now calls set_tenant_session_context explicitly instead, once org.tenant_id is resolved (it
+already is, from ensure_tenant_linked -- issue #190 step 6a).
+
+FORCE ROW LEVEL SECURITY is added here for memberships, github_installations, and
+scan_results (already write-safe since PR #327's tenant_id backfill -- both its write paths
+run after a real tenant is resolved via require_org_role/ensure_personal_tenant, no
+self-access clause needed there).
+
+orgs, invitations, audit_logs, and saved_tokens are deliberately NOT forced, and this is an
+architectural exclusion, not a deferral:
+  - orgs (org_repo.get_by_login) and invitations (invitation_repo.get_by_token) are both
+    read to *discover* which tenant something belongs to -- a read that structurally can't
+    be gated behind already knowing that tenant. FORCE would break org lookup and invitation
+    acceptance outright, not just need a session-context fix.
+  - audit_logs (routers/audit.py's list_audit_logs) and saved_tokens (routers/tokens.py's
+    list_tokens/upsert_token/resolve_token/delete_token) are confirmed cross-tenant-by-design
+    admin panels -- gated only by require_workspace_admin, intentionally listing across
+    every org. FORCE would break them outright. BYPASSRLS isn't a fix either: it's an
+    all-or-nothing role attribute that would neuter RLS for every query the app's one DB
+    role makes, not just these two routers'.
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-08-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+_TENANT_FILTER = "tenant_id = NULLIF(current_setting('app.tenant_id', true), '')::int"
+_USER_FILTER = "user_id = NULLIF(current_setting('app.user_id', true), '')::int"
+_OWNER_USER_FILTER = "owner_user_id = NULLIF(current_setting('app.user_id', true), '')::int"
+
+_FORCE_TABLES = ["memberships", "github_installations", "scan_results"]
+
+
+def upgrade() -> None:
+    op.execute(sa.text("DROP POLICY tenant_isolation ON memberships"))
+    op.execute(
+        sa.text(
+            f"CREATE POLICY tenant_isolation ON memberships "
+            f"USING ({_TENANT_FILTER} OR {_USER_FILTER}) "
+            f"WITH CHECK ({_TENANT_FILTER} OR {_USER_FILTER})"
+        )
+    )
+
+    op.execute(sa.text("DROP POLICY tenant_isolation ON github_installations"))
+    op.execute(
+        sa.text(
+            f"CREATE POLICY tenant_isolation ON github_installations "
+            f"USING ({_TENANT_FILTER} OR {_OWNER_USER_FILTER}) "
+            f"WITH CHECK ({_TENANT_FILTER} OR {_OWNER_USER_FILTER})"
+        )
+    )
+
+    for table in _FORCE_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"))
+
+
+def downgrade() -> None:
+    for table in _FORCE_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY"))
+
+    op.execute(sa.text("DROP POLICY tenant_isolation ON github_installations"))
+    op.execute(
+        sa.text(
+            "CREATE POLICY tenant_isolation ON github_installations "
+            f"USING ({_TENANT_FILTER})"
+        )
+    )
+
+    op.execute(sa.text("DROP POLICY tenant_isolation ON memberships"))
+    op.execute(sa.text(f"CREATE POLICY tenant_isolation ON memberships USING ({_TENANT_FILTER})"))

--- a/apps/api/src/core/auth.py
+++ b/apps/api/src/core/auth.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from src.core.config import settings
-from src.core.db import User, get_db
+from src.core.db import User, get_db, set_session_user
 
 _ALGORITHM = "HS256"
 _TOKEN_EXPIRE_DAYS = 30
@@ -119,6 +119,12 @@ def require_auth(
     db_user = db.query(User).filter(User.id == user_id).first()
     if db_user is None or db_user.token_version != payload.get("token_version", 0):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+    # Issue #190 step 6c: every authenticated request gets app.user_id set here, ahead of
+    # require_org_role/require_personal_tenant's more specific app.tenant_id+app.user_id SET
+    # (src.core.rbac). Covers RLS self-access checks (migration 0031) for routes that write
+    # a user's own membership/installation row without ever resolving a single tenant --
+    # see that migration's docstring for why this is safe.
+    set_session_user(db, user_id)
     return UserOut(
         id=user_id,
         email=email,

--- a/apps/api/src/core/db.py
+++ b/apps/api/src/core/db.py
@@ -288,6 +288,20 @@ engine = create_engine(settings.database_url.get_secret_value())
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 
 
+def set_session_user(db: Session, user_id: int) -> None:
+    """Sets app.user_id alone, for write paths that know the acting user but not (yet, or
+    ever) a single tenant -- e.g. require_auth (every authenticated request), OAuth-login
+    provisioning across multiple orgs, and pre-login user-creation flows. Issue #190 step
+    6c: migration 0031's memberships/github_installations policies accept a row whose
+    user_id/owner_user_id matches this alongside the existing tenant_id match, since every
+    write to those tables is confirmed self-scoped (the row's own user, never someone
+    else's). src.core.rbac's _set_tenant_session_context sets both this and app.tenant_id
+    together once a specific tenant is actually known; this is the narrower, more widely
+    applicable half of that. Same plain-SET reasoning as that function -- see its docstring.
+    """
+    db.execute(text(f"SET app.user_id = {int(user_id)}"))
+
+
 def get_db() -> Generator[Session, None, None]:
     db = SessionLocal()
     try:

--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -31,11 +31,12 @@ class PersonalTenantContext:
     tenant: Tenant
 
 
-def _set_tenant_session_context(db: Session, tenant_id: int, user_id: int) -> None:
+def set_tenant_session_context(db: Session, tenant_id: int, user_id: int) -> None:
     # Plain SET (not SET LOCAL): a request's Session lifetime doesn't cleanly map to one
-    # transaction, so a transaction-scoped SET LOCAL could stop applying mid-request. No
-    # RLS policy reads these yet (migration 0030 adds FORCE-free policies as scaffolding
-    # only) -- this just prepares the session variable for when that lands.
+    # transaction, so a transaction-scoped SET LOCAL could stop applying mid-request. Read
+    # by migration 0030's RLS policies (tenant_id match) and migration 0031's widened
+    # self-access clause (user_id match, via src.core.db.set_session_user -- this function's
+    # narrower sibling for write paths that know the acting user but not a single tenant).
     #
     # SET does not accept bind parameters (it's a configuration command, not a regular
     # query) -- Postgres rejects `SET app.tenant_id = $1` with a syntax error. Both values
@@ -69,7 +70,7 @@ def require_org_role(min_role: Literal["member", "admin"]):
         membership = tenant_repo.get_membership(db, org.tenant_id, user.id)
         if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
-        _set_tenant_session_context(db, org.tenant_id, user.id)
+        set_tenant_session_context(db, org.tenant_id, user.id)
         return OrgContext(org=org, membership=membership)
 
     return dependency
@@ -84,7 +85,7 @@ def require_personal_tenant(
     on an `owner` path param (see src.services.token_resolution.resolve_owner_token);
     wiring those is a separate design decision, deferred out of issue #190's PR 5."""
     tenant = tenant_repo.ensure_personal_tenant(db, user.id)
-    _set_tenant_session_context(db, tenant.id, user.id)
+    set_tenant_session_context(db, tenant.id, user.id)
     return PersonalTenantContext(tenant=tenant)
 
 

--- a/apps/api/src/routers/auth.py
+++ b/apps/api/src/routers/auth.py
@@ -38,7 +38,7 @@ from sqlalchemy.orm import Session
 from src.core.app_config import get_config
 from src.core.auth import UserOut, clear_session_cookie, create_access_token, require_auth
 from src.core.config import settings
-from src.core.db import Org, User, get_db
+from src.core.db import Org, User, get_db, set_session_user
 from src.core.rate_limit import check_account_rate_limit, rate_limit
 from src.repositories import invitation_repo, tenant_repo
 from src.services.email import EmailNotConfigured, send_verification_email
@@ -247,6 +247,7 @@ def setup(body: SetupRequest, db: Session = Depends(get_db)):
     except IntegrityError:
         db.rollback()
         raise HTTPException(status_code=409, detail="Setup already complete") from None
+    set_session_user(db, user.id)
     tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)
@@ -295,6 +296,7 @@ def register(body: RegisterRequest, db: Session = Depends(get_db)):
     # commit=False: land the personal tenant/membership in the same transaction as this
     # user, then commit once -- a failure between two separate commits could otherwise
     # leave a User row with no personal tenant (#323 CodeRabbit finding).
+    set_session_user(db, user.id)
     tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)

--- a/apps/api/src/routers/github_auth.py
+++ b/apps/api/src/routers/github_auth.py
@@ -27,7 +27,7 @@ from sqlalchemy.orm import Session
 
 from src.core.auth import create_access_token, set_session_cookie
 from src.core.config import settings
-from src.core.db import User, get_db
+from src.core.db import User, get_db, set_session_user
 from src.core.rate_limit import rate_limit
 from src.repositories import tenant_repo
 from src.services import github_oauth, org_provisioning
@@ -90,6 +90,7 @@ def find_or_create_user(db: Session, identity: github_oauth.GitHubIdentity) -> U
     # this user, then commit once -- a failure between two separate commits could otherwise
     # leave a User row with no personal tenant (#323 CodeRabbit finding).
     db.flush()
+    set_session_user(db, user.id)
     tenant_repo.ensure_personal_tenant(db, user.id, commit=False)
     db.commit()
     db.refresh(user)

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -28,7 +28,7 @@ from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
 from src.core.db import Membership, Org, User, get_db
-from src.core.rbac import OrgContext, require_org_role
+from src.core.rbac import OrgContext, require_org_role, set_tenant_session_context
 from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo, tenant_repo
 from src.schemas.installation import (
     InstallationLookupOut,
@@ -173,6 +173,12 @@ def sync_org_installation(
     if not is_known_admin:
         org = _bootstrap_org_admin_from_installation(db, db_user, org_login, payload.installation_id)
 
+    # Issue #190 step 6c: github_installations' org-scoped rows have no per-row user column,
+    # so migration 0031's self-access clause (owner_user_id match) can't cover this write the
+    # way it covers personal installations -- org.tenant_id is already resolved by this point
+    # (ensure_tenant_linked above, or _bootstrap_org_admin_from_installation's own
+    # org_repo.get_or_create), so set the real tenant context explicitly instead.
+    set_tenant_session_context(db, org.tenant_id, user.id)
     row = installation_repo.create(
         db,
         account_login=payload.account_login,

--- a/apps/api/src/services/org_provisioning.py
+++ b/apps/api/src/services/org_provisioning.py
@@ -29,7 +29,7 @@ import httpx
 
 from sqlalchemy.orm import Session
 
-from src.core.db import User
+from src.core.db import User, set_session_user
 from src.repositories import org_membership_repo, org_repo, tenant_repo
 from src.services import github_oauth
 
@@ -37,6 +37,12 @@ logger = logging.getLogger(__name__)
 
 
 def sync_org_admin_memberships(db: Session, user: User, user_token: str) -> None:
+    # Issue #190 step 6c: every membership write below is for `user` (never a different
+    # user), so this alone satisfies migration 0031's self-access RLS check regardless of
+    # which org/tenant each individual write targets. Defensive here rather than relying on
+    # the caller (github_auth.py's OAuth callback) having already set it, since this
+    # function has no other tenant context of its own across its multi-org loops.
+    set_session_user(db, user.id)
     try:
         memberships = github_oauth.list_user_org_memberships(user_token)
     except httpx.HTTPError:


### PR DESCRIPTION
## Summary

Issue #190 step 6c — the last piece of the multi-tenancy RLS rollout (steps 5/6a/6b already merged: #325, #326, #327).

**Schema change included:** yes — migration `0031_membership_self_access_force_rls.py`. Widens the `memberships`/`github_installations` RLS policies (added in migration `0030`) with a self-access clause, and enables `FORCE ROW LEVEL SECURITY` on `memberships`, `github_installations`, and `scan_results`. Full reasoning in the migration's own docstring; summarized below.

## What changed and why

A write-path audit (done while researching this PR) found every write into `memberships` in the entire codebase is a **self-write** — the row's `user_id` always equals the currently-authenticated caller:
- `installations.py`'s `_bootstrap_org_admin_from_installation` and `sync_personal_installation`
- `invitations.py`'s `accept_invitation`
- `org_provisioning.py`'s `sync_org_admin_memberships` (OAuth-login provisioning, both loops)
- `rbac.py`'s own `require_personal_tenant` had an internal ordering bug: it wrote the membership row **before** setting session context at all — even the "guarded" path wasn't guarded for its own write
- `auth.py`'s `setup`/`register` and `github_auth.py`'s `find_or_create_user` (pre-login personal tenant/membership creation)

None of these ran through `require_org_role`/`require_personal_tenant` (the only places the `app.tenant_id` session variable got set), so under `FORCE`, every one of them would have been rejected by migration `0030`'s implicit `WITH CHECK`.

Rather than add a tenant-resolving call at each of those 6+ sites individually (fragile — `require_personal_tenant`'s own bug shows how easy it is to miss one), this PR:
1. Sets `app.user_id` broadly in `require_auth` (`core/auth.py`) via a new `src.core.db.set_session_user` helper — the one dependency nearly every authenticated route already uses.
2. Adds a handful of explicit calls at routes with no request-scoped caller identity (pre-login flows in `auth.py`/`github_auth.py`, `org_provisioning.py`'s OAuth-callback entry point).
3. Migration `0031` widens the `memberships`/`github_installations` policies with a matching self-access clause: a row is also visible/writable when its own `user_id`/`owner_user_id` matches `app.user_id`, regardless of tenant session context.

This is safe: since every real write is confirmed self-scoped, letting a user touch only their **own** row can never leak another tenant's or another user's data — the isolation boundary that actually matters (a *mismatched* user_id) is still fully enforced by the unchanged `tenant_id`-equality half of each policy.

`github_installations`' org-scoped rows have no per-row user column (only `owner_user_id`-scoped personal-installation rows do), so its one remaining write site (`installations.py`'s `sync_org_installation`) sets real tenant context explicitly instead, now that `org.tenant_id` is already resolved by that point (step 6a).

`FORCE` is also enabled on `scan_results` (already write-safe since #327's `tenant_id` backfill). `orgs`, `invitations`, `audit_logs`, and `saved_tokens` are deliberately **excluded from `FORCE`, architecturally, not deferred**: `orgs`/`invitations` are read to *discover* which tenant something belongs to (can't be gated behind already knowing it); `audit_logs`/`saved_tokens` are confirmed cross-tenant-by-design admin panels that `FORCE` would break outright.

## Important caveat, discovered while building this

**The API's own DB role is a Postgres superuser in the default docker-compose deployment.** `docker-compose.yml` sets `POSTGRES_USER: ${DB_USER}`, and the official `postgres` image always makes that role the `initdb` bootstrap superuser — there's no way to make it non-superuser through that env var alone. Postgres superusers unconditionally bypass RLS, `ENABLE` or `FORCE`, no exceptions. So **this migration's policies are logically correct but currently have no effect on the real running system** — confirmed by connecting directly as the app's configured role and checking `pg_roles.rolsuper = true`.

This is the same gap migration `0020` already solved for the *worker* (a dedicated `clevis_worker` non-superuser role with explicit `GRANT`s) — the API itself never got the equivalent treatment. Giving the API its own non-superuser role is separate, dedicated infrastructure work (new role, `GRANT`s, connection string/entrypoint changes), tracked as a follow-up, not folded into this PR. Still worth doing now: it's the correct policy design, and `FORCE` is inert-but-harmless until that follow-up lands, at which point it starts enforcing with no further schema change needed.

## Verification

- Full `pytest -q`: 649 passed. Migration `upgrade`/`downgrade` cycle clean.
- Beyond the test suite (which can't prove anything about RLS given the superuser gap above): created a throwaway **non-superuser, non-BYPASSRLS** test role and directly verified, against real Postgres:
  - A user can insert their own `memberships` row with only `app.user_id` set (no tenant context at all) — self-access works.
  - A user **cannot** update a *different* user's membership row (0 rows affected) even with no tenant context — cross-user isolation holds.
  - An org-scoped `github_installations` insert **fails** without an explicit `app.tenant_id` set, and **succeeds** once it is — proves the one remaining explicit call (`installations.py`) is actually necessary, not just harmless.
  - A personal (`owner_user_id`-scoped) installation insert succeeds via `app.user_id` self-access alone.
  - An attempt to insert a personal-installation row under a *different* user's `owner_user_id` is blocked, even with a valid `app.user_id` set for the attacker.
  - All test data and the probe role fully cleaned up afterward.

## Not in scope for this PR

- Giving the API its own non-superuser DB role — separate follow-up (see caveat above); without it, this PR's `FORCE` has no real-world effect yet.
- The `installations.py` `sync_org_installation` auth-architecture refactor (a separate CodeRabbit finding, splitting bootstrap from the DB-backed admin check) — planned as a follow-up after this PR.
- Dropping `org_memberships` writes entirely — separate follow-up issue from #190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened access controls for memberships, GitHub installations, and scan results.
  * Authenticated actions now consistently apply the acting user and organization context.
  * Improved protection for personal and organization-scoped data during account creation, sign-in, installation setup, and membership synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->