### PR TITLE
refactor(api): share org-role resolution between require_org_role and installation sync

### DIFF
--- a/apps/api/src/core/rbac.py
+++ b/apps/api/src/core/rbac.py
@@ -47,6 +47,31 @@ def set_tenant_session_context(db: Session, tenant_id: int, user_id: int) -> Non
     db.execute(text(f"SET app.user_id = {int(user_id)}"))
 
 
+def resolve_org_role(db: Session, org_login: str, user_id: int, min_role: Literal["member", "admin"]) -> OrgContext | None:
+    """Same resolution logic require_org_role's dependency raises on, but returns None
+    instead of raising when org_login doesn't exist or the membership doesn't meet
+    min_role. Shared by require_org_role itself and by installations.py's
+    sync_org_installation, which needs a non-raising check to decide whether to take its
+    known-admin fast path or fall through to first-time GitHub-verified bootstrap --
+    keeping the two checks from silently drifting apart (issue #190 CodeRabbit follow-up)."""
+    org = org_repo.get_by_login(db, org_login)
+    if org is None:
+        return None
+    # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
+    # resolved here via get_by_login (not get_or_create) never gets org_repo's own
+    # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
+    # itself uses, rather than a separate hand-rolled copy of the same logic. Resolved
+    # ahead of the role check (issue #190 step 6a) so the role lookup itself can read
+    # from `memberships` (tenant_id-keyed), the new source of truth for org RBAC, instead
+    # of the legacy `org_memberships` table (org_id-keyed) it used to read.
+    org = org_repo.ensure_tenant_linked(db, org)
+    membership = tenant_repo.get_membership(db, org.tenant_id, user_id)
+    if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
+        return None
+    set_tenant_session_context(db, org.tenant_id, user_id)
+    return OrgContext(org=org, membership=membership)
+
+
 def require_org_role(min_role: Literal["member", "admin"]):
     """Dependency factory: 404 if org_login (path param) doesn't exist, 403 if the
     current user isn't a member of it or is below min_role."""
@@ -56,22 +81,12 @@ def require_org_role(min_role: Literal["member", "admin"]):
         db: Session = Depends(get_db),
         user: UserOut = Depends(require_auth),
     ) -> OrgContext:
-        org = org_repo.get_by_login(db, org_login)
-        if org is None:
+        ctx = resolve_org_role(db, org_login, user.id, min_role)
+        if ctx is not None:
+            return ctx
+        if org_repo.get_by_login(db, org_login) is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
-        # org.tenant_id is nullable (see db.py's Org.tenant_id docstring) -- a legacy row
-        # resolved here via get_by_login (not get_or_create) never gets org_repo's own
-        # self-healing dual-write, so reuse the exact same helper org_repo.get_or_create
-        # itself uses, rather than a separate hand-rolled copy of the same logic. Resolved
-        # ahead of the role check (issue #190 step 6a) so the role lookup itself can read
-        # from `memberships` (tenant_id-keyed), the new source of truth for org RBAC, instead
-        # of the legacy `org_memberships` table (org_id-keyed) it used to read.
-        org = org_repo.ensure_tenant_linked(db, org)
-        membership = tenant_repo.get_membership(db, org.tenant_id, user.id)
-        if membership is None or _ROLE_RANK.get(membership.role, -1) < _ROLE_RANK[min_role]:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
-        set_tenant_session_context(db, org.tenant_id, user.id)
-        return OrgContext(org=org, membership=membership)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Org access required")
 
     return dependency
 

--- a/apps/api/src/routers/installations.py
+++ b/apps/api/src/routers/installations.py
@@ -27,9 +27,9 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from src.core.auth import UserOut, require_auth
-from src.core.db import Membership, Org, User, get_db
-from src.core.rbac import OrgContext, require_org_role, set_tenant_session_context
-from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo, tenant_repo
+from src.core.db import Org, User, get_db
+from src.core.rbac import OrgContext, require_org_role, resolve_org_role, set_tenant_session_context
+from src.repositories import audit_repo, installation_repo, org_membership_repo, org_repo
 from src.schemas.installation import (
     InstallationLookupOut,
     InstallationOut,
@@ -148,11 +148,13 @@ def sync_org_installation(
     if payload.account_login.lower() != org_login.lower():
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="owner must match the org in the URL")
 
-    org: Org | None = org_repo.get_by_login(db, org_login)
-    if org is not None:
-        org = org_repo.ensure_tenant_linked(db, org)
-    membership: Membership | None = tenant_repo.get_membership(db, org.tenant_id, user.id) if org else None
-    is_known_admin = org is not None and membership is not None and membership.role == "admin"
+    # Issue #190 CodeRabbit follow-up: this reuses rbac.resolve_org_role -- the same
+    # non-raising resolution logic require_org_role's dependency itself calls -- so the
+    # known-admin fast-path check here can't silently drift from what require_org_role
+    # considers a valid org admin.
+    ctx: OrgContext | None = resolve_org_role(db, org_login, user.id, "admin")
+    is_known_admin = ctx is not None
+    org: Org | None = ctx.org if ctx is not None else org_repo.get_by_login(db, org_login)
 
     # Only a caller who ISN'T already a confirmed local admin needs the extra checks below
     # (linked GitHub account, installation_id present) -- resolved before any GitHub call


### PR DESCRIPTION
## Summary

CodeRabbit repeatedly flagged (on PRs #326, #327, #328 — same finding each time, since those were stacked branches under review) that `installations.py`'s `sync_org_installation` does an inline admin check instead of using the shared `require_org_role("admin")` dependency.

The endpoint is genuinely dual-purpose: it serves a caller who is already a known local org admin (DB membership check) *and* a first-time org connect where no local membership exists yet (falls back to a live GitHub role check via the App installation token, then bootstraps the `Org`/`OrgMembership` rows). `require_org_role` can't be used directly as a hard `Depends(...)` here because it raises 404/403 instead of allowing a fallthrough to the bootstrap path — that's *why* the inline check existed.

## What changed and why

A true two-endpoint split (CodeRabbit's literal suggestion) was considered and rejected: there's only one UI call site (`apps/ui/app/settings/github-callback/page.tsx`, the GitHub App post-install callback), and it can't know in advance whether the caller is already a known admin — a real split would need either speculative try-then-fallback orchestration in the UI or a new mechanism, plus reworking ~20 existing tests in `apps/api/tests/test_installations.py`, for no behavioral improvement. CodeRabbit's own comment labeled this a "Heavy lift."

Instead, this PR fixes the actual risk (the inline check silently drifting from `require_org_role`'s real logic over time) by extracting the shared, non-raising resolution logic:

- **`apps/api/src/core/rbac.py`**: new `resolve_org_role(db, org_login, user_id, min_role) -> OrgContext | None` — the same org/membership lookup `require_org_role`'s dependency already did, but returning `None` instead of raising. `require_org_role` itself now calls it internally (raises 404 if the org doesn't exist, 403 otherwise — identical status codes to before).
- **`apps/api/src/routers/installations.py`**: `sync_org_installation`'s known-admin fast-path check now calls `resolve_org_role` directly instead of a hand-rolled copy of the same three-step lookup (`get_by_login` → `ensure_tenant_linked` → `get_membership`). Two now-unused imports (`Membership`, `tenant_repo`) were removed as a result.

No endpoint URL/contract change, no UI change, no migration, no test changes needed — behavior for every existing scenario (known-admin fast path, first-time bootstrap, all the error-mapping and advisory-lock tests) is identical. Full `pytest -q` (649 tests) and the full pre-push suite (vitest, next build, pytest) both pass.

## Sensitive files note (per AGENTS.md)

This touches RBAC code (`rbac.py`) but not RBAC *behavior* — same role checks, same status codes, same access decisions for every caller of `require_org_role`. Flagging per AGENTS.md's guidance on auth-code changes even though nothing about who's authorized to do what actually changed.

## Test plan

- [x] `pytest -q` — 649 passed
- [x] Full pre-push hook (vitest, `next build`, pytest) — all green
- [ ] Reviewer: confirm `test_installations.py`'s fast-path/bootstrap/error-mapping scenarios still read correctly against the new `resolve_org_role`-based flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved organization access checks during installation synchronization.
  * Ensured organization membership, role requirements, and tenant context are validated consistently.
  * Preserved clear error handling for missing organizations and insufficient permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->