### PR TITLE
test(ci): run the API test suite as clevis_api and prove RLS enforces isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
+      # Superuser URL: used for migrations and every step except "Run Python tests" below,
+      # which overrides DATABASE_URL to the clevis_api role instead (issue #330/#190 --
+      # proves RLS actually enforces tenant isolation under the real non-superuser runtime
+      # role, not just a hand-built throwaway test role).
       DATABASE_URL: postgresql+psycopg://clevis:clevis@localhost:5432/clevis
+      API_DB_PASSWORD: ci-dummy-api-db-password-not-for-production-use-0
       JOB_SECRET_KEY: ${{ secrets.JOB_SECRET_KEY || 'ci-dummy-secret-key-not-for-production-use-00' }}
       AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'ci-dummy-auth-secret-not-for-production-use-000' }}
     steps:
@@ -149,11 +154,35 @@ jobs:
         working-directory: apps/api
         run: python -m alembic check
 
+      # Reuses the exact same script an operator runs by hand for an existing deployment
+      # (docs/self-hosting.md) instead of duplicating its grant SQL here -- keeps CI's
+      # provisioning and the documented manual path from drifting apart. Connects over TCP
+      # to the service container (not a docker exec local-socket connection like the
+      # script's usual home), so auth needs PGPASSWORD/PGHOST/PGPORT explicitly.
+      - name: Provision clevis_api role (issue #330 -- non-superuser runtime role)
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGPASSWORD: clevis
+          POSTGRES_USER: clevis
+          POSTGRES_DB: clevis
+        run: sh docker/provision-api-role-existing-deployment.sh
+
       # Global floor (.coveragerc / --cov-fail-under) is a regression guard measured against
       # the current baseline (~87%), not an aspirational target — it stops overall coverage
       # from silently eroding. New/changed lines are held to a much higher bar by the diff
       # coverage step below.
+      #
+      # DATABASE_URL is overridden here (not at job level) to the clevis_api role
+      # provisioned above -- issue #330/#190: this is what actually exercises the RLS
+      # policies (migrations 0030/0031) against a real non-superuser, non-owner role, the
+      # same posture as production when API_DB_PASSWORD is configured. Every other step
+      # in this job (migrations, drift check, coverage upload) keeps using the job-level
+      # superuser DATABASE_URL, since Alembic needs DDL/GRANT privilege this role
+      # intentionally lacks.
       - name: Run Python tests (with coverage)
+        env:
+          DATABASE_URL: postgresql+psycopg://clevis_api:${{ env.API_DB_PASSWORD }}@localhost:5432/clevis
         run: >
           python -m pytest -q
           --cov=apps/api/src --cov=apps/worker/src --cov=packages/checks/src

--- a/apps/api/tests/test_rls_isolation.py
+++ b/apps/api/tests/test_rls_isolation.py
@@ -45,7 +45,8 @@ def _clevis_api_engine():
             "provision the role (docker/provision-api-role-existing-deployment.sh) "
             "and set API_DB_PASSWORD to exercise this test locally"
         )
-    netloc = f"clevis_api:{quote(password, safe='')}@{url.hostname}:{url.port}"
+    port = f":{url.port}" if url.port is not None else ""
+    netloc = f"clevis_api:{quote(password, safe='')}@{url.hostname}{port}"
     return create_engine(urlunsplit((url.scheme, netloc, url.path, url.query, url.fragment)))
 
 
@@ -57,32 +58,36 @@ def test_rls_blocks_cross_tenant_audit_log_access():
         # context, which correctly fails (RLS makes it invisible) but raises
         # ObjectDeletedError instead of just leaving the already-fetched attributes alone.
         session = Session(bind=conn, expire_on_commit=False)
+        # Initialized up front and only ever deleted in the finally block if non-None, so a
+        # failure partway through setup (e.g. after users commit but before tenants do) still
+        # cleans up whatever was actually committed instead of leaking rows into a local DB.
+        user_a = user_b = tenant_a = tenant_b = log_a = log_b = None
         try:
-            user_a = User(email="rls-isolation-a@test.local", name=None, password_hash=None, is_workspace_admin=False)
-            user_b = User(email="rls-isolation-b@test.local", name=None, password_hash=None, is_workspace_admin=False)
-            session.add_all([user_a, user_b])
-            session.commit()
-
-            tenant_a = Tenant(kind="personal", personal_user_id=user_a.id)
-            tenant_b = Tenant(kind="personal", personal_user_id=user_b.id)
-            session.add_all([tenant_a, tenant_b])
-            session.commit()
-
-            # Each insert happens under its own tenant's session context, since Group A's
-            # strict equality policy has no separate WITH CHECK -- it defaults to the
-            # USING clause, so a row is only insertable when it's already visible under
-            # the session's current tenant_id.
-            set_tenant_session_context(session, tenant_a.id, user_a.id)
-            log_a = AuditLog(actor="tester", action="test", target="a", payload="{}", tenant_id=tenant_a.id)
-            session.add(log_a)
-            session.commit()
-
-            set_tenant_session_context(session, tenant_b.id, user_b.id)
-            log_b = AuditLog(actor="tester", action="test", target="b", payload="{}", tenant_id=tenant_b.id)
-            session.add(log_b)
-            session.commit()
-
             try:
+                user_a = User(email="rls-isolation-a@test.local", name=None, password_hash=None, is_workspace_admin=False)
+                user_b = User(email="rls-isolation-b@test.local", name=None, password_hash=None, is_workspace_admin=False)
+                session.add_all([user_a, user_b])
+                session.commit()
+
+                tenant_a = Tenant(kind="personal", personal_user_id=user_a.id)
+                tenant_b = Tenant(kind="personal", personal_user_id=user_b.id)
+                session.add_all([tenant_a, tenant_b])
+                session.commit()
+
+                # Each insert happens under its own tenant's session context, since Group A's
+                # strict equality policy has no separate WITH CHECK -- it defaults to the
+                # USING clause, so a row is only insertable when it's already visible under
+                # the session's current tenant_id.
+                set_tenant_session_context(session, tenant_a.id, user_a.id)
+                log_a = AuditLog(actor="tester", action="test", target="a", payload="{}", tenant_id=tenant_a.id)
+                session.add(log_a)
+                session.commit()
+
+                set_tenant_session_context(session, tenant_b.id, user_b.id)
+                log_b = AuditLog(actor="tester", action="test", target="b", payload="{}", tenant_id=tenant_b.id)
+                session.add(log_b)
+                session.commit()
+
                 # Back in tenant A's context: tenant B's row must be invisible to SELECT,
                 # and untouched by UPDATE/DELETE targeting it directly by id.
                 set_tenant_session_context(session, tenant_a.id, user_a.id)
@@ -105,19 +110,27 @@ def test_rls_blocks_cross_tenant_audit_log_access():
                 assert visible_ids == {log_b.id}
             finally:
                 # Cleanup must happen per-tenant context too -- RLS applies to DELETE just
-                # like SELECT, so a single DELETE can't remove both rows at once.
-                set_tenant_session_context(session, tenant_a.id, user_a.id)
-                session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_a.id})
-                session.commit()
-                set_tenant_session_context(session, tenant_b.id, user_b.id)
-                session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_b.id})
-                session.commit()
+                # like SELECT, so a single DELETE can't remove both rows at once. A prior
+                # exception may leave the session mid-transaction, so roll back first.
+                session.rollback()
+                if log_a is not None:
+                    set_tenant_session_context(session, tenant_a.id, user_a.id)
+                    session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_a.id})
+                    session.commit()
+                if log_b is not None:
+                    set_tenant_session_context(session, tenant_b.id, user_b.id)
+                    session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_b.id})
+                    session.commit()
                 session.execute(text("RESET app.tenant_id"))
                 session.execute(text("RESET app.user_id"))
-                session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_a.id})
-                session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_b.id})
-                session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_a.id})
-                session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_b.id})
+                if tenant_a is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_a.id})
+                if tenant_b is not None:
+                    session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_b.id})
+                if user_a is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_a.id})
+                if user_b is not None:
+                    session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_b.id})
                 session.commit()
         finally:
             session.close()

--- a/apps/api/tests/test_rls_isolation.py
+++ b/apps/api/tests/test_rls_isolation.py
@@ -1,0 +1,124 @@
+"""End-to-end proof that RLS (migrations 0030/0031) actually blocks cross-tenant access
+under the real, non-superuser clevis_api role -- not just against a hand-built throwaway
+test role. This is the concrete claim issue #190's closing comment promised and, before
+this test existed, had only ever been checked by hand (see docs/self-hosting.md and the
+migration 0032/0033 verification notes) rather than as a standing regression test.
+
+Deliberately does NOT use the shared `db` fixture (conftest.py) -- that fixture is bound
+to whatever settings.database_url the rest of the suite runs under, which is the
+bootstrap superuser DB_USER in most local/dev runs (superuser unconditionally bypasses
+RLS, so this test would silently prove nothing if it ran that way). Instead this test
+opens its own connection explicitly as clevis_api: reused as-is when the suite is already
+running under clevis_api (CI's python job, after issue #330's verification wiring), or
+built by swapping credentials onto the same host/port/db when a local run sets
+API_DB_PASSWORD to opt in. Skips (not fails) when neither is true, so a plain local
+`pytest -q` run without API_DB_PASSWORD configured still passes -- that's the documented,
+optional "Recommended" setup per AGENTS.md, not a hard requirement.
+
+audit_logs is used as the RLS-protected table under test: it gets the simple strict
+tenant_isolation equality policy (migration 0030), with none of memberships'/
+github_installations' widened self-access carve-out (migration 0031) that would
+complicate a minimal two-tenant isolation check.
+"""
+
+import os
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from src.core.config import settings
+from src.core.db import AuditLog, Tenant, User
+from src.core.rbac import set_tenant_session_context
+
+
+def _clevis_api_engine():
+    url = urlsplit(settings.database_url.get_secret_value())
+    if url.username == "clevis_api":
+        return create_engine(settings.database_url.get_secret_value())
+
+    password = os.environ.get("API_DB_PASSWORD")
+    if not password:
+        pytest.skip(
+            "neither DATABASE_URL nor API_DB_PASSWORD point at clevis_api -- "
+            "provision the role (docker/provision-api-role-existing-deployment.sh) "
+            "and set API_DB_PASSWORD to exercise this test locally"
+        )
+    netloc = f"clevis_api:{quote(password, safe='')}@{url.hostname}:{url.port}"
+    return create_engine(urlunsplit((url.scheme, netloc, url.path, url.query, url.fragment)))
+
+
+def test_rls_blocks_cross_tenant_audit_log_access():
+    engine = _clevis_api_engine()
+    with engine.connect() as conn:
+        # expire_on_commit=False: default expire-then-refresh-on-next-access behavior would
+        # try to re-SELECT log_a by identity after switching the session to tenant B's
+        # context, which correctly fails (RLS makes it invisible) but raises
+        # ObjectDeletedError instead of just leaving the already-fetched attributes alone.
+        session = Session(bind=conn, expire_on_commit=False)
+        try:
+            user_a = User(email="rls-isolation-a@test.local", name=None, password_hash=None, is_workspace_admin=False)
+            user_b = User(email="rls-isolation-b@test.local", name=None, password_hash=None, is_workspace_admin=False)
+            session.add_all([user_a, user_b])
+            session.commit()
+
+            tenant_a = Tenant(kind="personal", personal_user_id=user_a.id)
+            tenant_b = Tenant(kind="personal", personal_user_id=user_b.id)
+            session.add_all([tenant_a, tenant_b])
+            session.commit()
+
+            # Each insert happens under its own tenant's session context, since Group A's
+            # strict equality policy has no separate WITH CHECK -- it defaults to the
+            # USING clause, so a row is only insertable when it's already visible under
+            # the session's current tenant_id.
+            set_tenant_session_context(session, tenant_a.id, user_a.id)
+            log_a = AuditLog(actor="tester", action="test", target="a", payload="{}", tenant_id=tenant_a.id)
+            session.add(log_a)
+            session.commit()
+
+            set_tenant_session_context(session, tenant_b.id, user_b.id)
+            log_b = AuditLog(actor="tester", action="test", target="b", payload="{}", tenant_id=tenant_b.id)
+            session.add(log_b)
+            session.commit()
+
+            try:
+                # Back in tenant A's context: tenant B's row must be invisible to SELECT,
+                # and untouched by UPDATE/DELETE targeting it directly by id.
+                set_tenant_session_context(session, tenant_a.id, user_a.id)
+                visible_ids = {row[0] for row in session.execute(text("SELECT id FROM audit_logs")).all()}
+                assert visible_ids == {log_a.id}
+
+                update_result = session.execute(
+                    text("UPDATE audit_logs SET action = 'tampered' WHERE id = :id"), {"id": log_b.id}
+                )
+                assert update_result.rowcount == 0
+                session.commit()
+
+                delete_result = session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_b.id})
+                assert delete_result.rowcount == 0
+                session.commit()
+
+                # And the reverse, confirming isolation isn't just a one-directional fluke.
+                set_tenant_session_context(session, tenant_b.id, user_b.id)
+                visible_ids = {row[0] for row in session.execute(text("SELECT id FROM audit_logs")).all()}
+                assert visible_ids == {log_b.id}
+            finally:
+                # Cleanup must happen per-tenant context too -- RLS applies to DELETE just
+                # like SELECT, so a single DELETE can't remove both rows at once.
+                set_tenant_session_context(session, tenant_a.id, user_a.id)
+                session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_a.id})
+                session.commit()
+                set_tenant_session_context(session, tenant_b.id, user_b.id)
+                session.execute(text("DELETE FROM audit_logs WHERE id = :id"), {"id": log_b.id})
+                session.commit()
+                session.execute(text("RESET app.tenant_id"))
+                session.execute(text("RESET app.user_id"))
+                session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_a.id})
+                session.execute(text("DELETE FROM tenants WHERE id = :id"), {"id": tenant_b.id})
+                session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_a.id})
+                session.execute(text("DELETE FROM users WHERE id = :id"), {"id": user_b.id})
+                session.commit()
+        finally:
+            session.close()
+    engine.dispose()


### PR DESCRIPTION
## Summary

- Closes the remaining gap in issue #330: PR1/PR2 (merged) provisioned the `clevis_api` role and cut the API's runtime connection over to it, but nothing ever actually *ran* under that role — CI's `python` job created only the bootstrap superuser and ran migrations, the drift check, and the full pytest suite all as it. RLS's tenant-isolation policies (migrations `0030`/`0031`) were logically correct but had only ever been verified by hand, never as a standing check.
- **CI workflow change** (`.github/workflows/ci.yml`, `python` job): added a step that provisions `clevis_api` against the ephemeral CI Postgres service by reusing `docker/provision-api-role-existing-deployment.sh` verbatim (so CI and the documented manual-provisioning path in `docs/self-hosting.md` can't drift apart), then overrides `DATABASE_URL` for the "Run Python tests" step (and only that step) to connect as `clevis_api` instead of the superuser. Migrations and `alembic check` stay on the superuser URL, since Alembic needs DDL/GRANT privilege this role intentionally lacks.
- **New test** `apps/api/tests/test_rls_isolation.py`: a standing cross-tenant regression test, not just a one-off manual check. Two tenants, two users, real `SELECT`/`UPDATE`/`DELETE` attempts against `audit_logs` from a session explicitly connected as `clevis_api`. Verified locally that it actually catches a regression: temporarily granting `clevis_api` `BYPASSRLS` makes the test fail (wrong tenant's row visible), then reverting makes it pass again. Skips (not fails) on a local run that hasn't opted into `API_DB_PASSWORD`, so the default local dev workflow is unaffected.
- No migration in this PR — local verification (`pytest -q` run end-to-end against `clevis_api`) found no new permission gaps; migrations `0032`/`0033` already granted everything needed.

## Why

Issue #190's closing comment explicitly wants "RLS confirmed to actually enforce something in the real deployment, not just migration-level verification" before closing. That proof didn't exist anywhere — not locally, not in CI — until this PR. This is the last piece blocking closing out #330 and #190.

## Test plan

- [x] Local: full `pytest -q` green connected as `clevis_api` (role provisioned via the existing script against a real local Postgres) — 647 passed, 3 xfailed, including the new isolation test actually exercising RLS.
- [x] Local: full `pytest -q` green connected as the superuser too, with the new test correctly skipping (no `API_DB_PASSWORD` set) — confirms the default local workflow is unaffected.
- [x] Local sanity check: temporarily granted `clevis_api` `BYPASSRLS` and confirmed `test_rls_isolation.py` fails as expected, then reverted — proves the test has real teeth, not a false-positive pass.
- [ ] CI: this PR's own `python` job run is the first real exercise of the new provisioning step + `clevis_api`-connected test run end-to-end in the actual CI environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage verifying that tenant-scoped audit logs cannot be viewed, modified, or deleted across tenant boundaries.
  * Expanded automated test configuration to run isolation checks with a restricted database role.
  * Tests automatically skip when the required isolated test credentials are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->